### PR TITLE
Add long-term memory system with hybrid search

### DIFF
--- a/forge-core/channels/plugin.go
+++ b/forge-core/channels/plugin.go
@@ -46,6 +46,7 @@ type ChannelEvent struct {
 	WorkspaceID string          `json:"workspace_id"`
 	UserID      string          `json:"user_id"`
 	ThreadID    string          `json:"thread_id,omitempty"`
+	MessageID   string          `json:"message_id,omitempty"` // per-message ID for reply targeting
 	Message     string          `json:"message"`
 	Attachments []Attachment    `json:"attachments,omitempty"`
 	Raw         json.RawMessage `json:"raw,omitempty"`

--- a/forge-core/llm/embedder.go
+++ b/forge-core/llm/embedder.go
@@ -1,0 +1,24 @@
+package llm
+
+import "context"
+
+// EmbeddingRequest is a provider-agnostic request to generate embeddings.
+type EmbeddingRequest struct {
+	Texts []string // texts to embed
+	Model string   // optional model override
+}
+
+// EmbeddingResponse is a provider-agnostic embedding response.
+type EmbeddingResponse struct {
+	Embeddings [][]float32
+	Model      string
+	Usage      UsageInfo
+}
+
+// Embedder generates vector embeddings from text.
+type Embedder interface {
+	// Embed produces embeddings for the given texts.
+	Embed(ctx context.Context, req *EmbeddingRequest) (*EmbeddingResponse, error)
+	// Dimensions returns the dimensionality of the embedding vectors.
+	Dimensions() int
+}

--- a/forge-core/llm/providers/embedder_factory.go
+++ b/forge-core/llm/providers/embedder_factory.go
@@ -1,0 +1,28 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// NewEmbedder creates an Embedder for the specified provider.
+// Supported providers: "openai", "gemini", "ollama".
+// Returns an error for "anthropic" (no embedding API).
+func NewEmbedder(provider string, cfg OpenAIEmbedderConfig) (llm.Embedder, error) {
+	switch provider {
+	case "openai":
+		return NewOpenAIEmbedder(cfg), nil
+	case "gemini":
+		if cfg.BaseURL == "" {
+			cfg.BaseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
+		}
+		return NewOpenAIEmbedder(cfg), nil
+	case "ollama":
+		return NewOllamaEmbedder(cfg), nil
+	case "anthropic":
+		return nil, fmt.Errorf("anthropic does not provide an embedding API; configure an alternative embedding provider")
+	default:
+		return nil, fmt.Errorf("unknown embedding provider: %q", provider)
+	}
+}

--- a/forge-core/llm/providers/embedder_factory_test.go
+++ b/forge-core/llm/providers/embedder_factory_test.go
@@ -1,0 +1,61 @@
+package providers
+
+import (
+	"testing"
+)
+
+func TestNewEmbedder(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		wantErr  bool
+	}{
+		{"openai", "openai", false},
+		{"gemini", "gemini", false},
+		{"ollama", "ollama", false},
+		{"anthropic", "anthropic", true},
+		{"unknown", "unknown", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := OpenAIEmbedderConfig{APIKey: "test-key"}
+			emb, err := NewEmbedder(tt.provider, cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for provider %q", tt.provider)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if emb == nil {
+				t.Fatal("expected non-nil embedder")
+			}
+			if emb.Dimensions() <= 0 {
+				t.Errorf("expected positive dimensions, got %d", emb.Dimensions())
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbedderDefaults(t *testing.T) {
+	emb := NewOpenAIEmbedder(OpenAIEmbedderConfig{})
+	if emb.Dimensions() != defaultEmbeddingDims {
+		t.Errorf("expected %d dims, got %d", defaultEmbeddingDims, emb.Dimensions())
+	}
+	if emb.model != defaultEmbeddingModel {
+		t.Errorf("expected model %q, got %q", defaultEmbeddingModel, emb.model)
+	}
+}
+
+func TestOllamaEmbedderDefaults(t *testing.T) {
+	emb := NewOllamaEmbedder(OpenAIEmbedderConfig{})
+	if emb.Dimensions() != ollamaDefaultEmbeddingDims {
+		t.Errorf("expected %d dims, got %d", ollamaDefaultEmbeddingDims, emb.Dimensions())
+	}
+	if emb.model != ollamaDefaultEmbeddingModel {
+		t.Errorf("expected model %q, got %q", ollamaDefaultEmbeddingModel, emb.model)
+	}
+}

--- a/forge-core/llm/providers/ollama_embedder.go
+++ b/forge-core/llm/providers/ollama_embedder.go
@@ -1,0 +1,31 @@
+package providers
+
+// OllamaEmbedder wraps OpenAIEmbedder with Ollama-specific defaults.
+// Ollama provides an OpenAI-compatible /v1/embeddings endpoint.
+type OllamaEmbedder struct {
+	*OpenAIEmbedder
+}
+
+const (
+	ollamaDefaultEmbeddingModel = "nomic-embed-text"
+	ollamaDefaultEmbeddingDims  = 768
+)
+
+// NewOllamaEmbedder creates an embedder that talks to a local Ollama server.
+func NewOllamaEmbedder(cfg OpenAIEmbedderConfig) *OllamaEmbedder {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "http://localhost:11434/v1"
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = "ollama" // Ollama requires a non-empty key
+	}
+	if cfg.Model == "" {
+		cfg.Model = ollamaDefaultEmbeddingModel
+	}
+	if cfg.Dims <= 0 {
+		cfg.Dims = ollamaDefaultEmbeddingDims
+	}
+	return &OllamaEmbedder{
+		OpenAIEmbedder: NewOpenAIEmbedder(cfg),
+	}
+}

--- a/forge-core/llm/providers/openai_embedder.go
+++ b/forge-core/llm/providers/openai_embedder.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+const (
+	defaultEmbeddingModel = "text-embedding-3-small"
+	defaultEmbeddingDims  = 1536
+	embeddingTimeout      = 30 * time.Second
+)
+
+// OpenAIEmbedder implements llm.Embedder using the OpenAI Embeddings API.
+type OpenAIEmbedder struct {
+	apiKey  string
+	baseURL string
+	model   string
+	dims    int
+	client  *http.Client
+}
+
+// OpenAIEmbedderConfig configures the OpenAI embedder.
+type OpenAIEmbedderConfig struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+	Dims    int
+}
+
+// NewOpenAIEmbedder creates an OpenAI embedder.
+func NewOpenAIEmbedder(cfg OpenAIEmbedderConfig) *OpenAIEmbedder {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	model := cfg.Model
+	if model == "" {
+		model = defaultEmbeddingModel
+	}
+	dims := cfg.Dims
+	if dims <= 0 {
+		dims = defaultEmbeddingDims
+	}
+	return &OpenAIEmbedder{
+		apiKey:  cfg.APIKey,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		dims:    dims,
+		client:  &http.Client{Timeout: embeddingTimeout},
+	}
+}
+
+func (e *OpenAIEmbedder) Dimensions() int { return e.dims }
+
+// Embed produces embeddings for the given texts using POST /v1/embeddings.
+func (e *OpenAIEmbedder) Embed(ctx context.Context, req *llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+	if len(req.Texts) == 0 {
+		return &llm.EmbeddingResponse{Model: e.model}, nil
+	}
+
+	model := req.Model
+	if model == "" {
+		model = e.model
+	}
+
+	body := embeddingRequest{
+		Model: model,
+		Input: req.Texts,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling embedding request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/embeddings", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if e.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
+	}
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("embedding request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("embedding error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var embResp embeddingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embResp); err != nil {
+		return nil, fmt.Errorf("decoding embedding response: %w", err)
+	}
+
+	embeddings := make([][]float32, len(embResp.Data))
+	for i, d := range embResp.Data {
+		embeddings[i] = d.Embedding
+	}
+
+	return &llm.EmbeddingResponse{
+		Embeddings: embeddings,
+		Model:      embResp.Model,
+		Usage: llm.UsageInfo{
+			PromptTokens: embResp.Usage.PromptTokens,
+			TotalTokens:  embResp.Usage.TotalTokens,
+		},
+	}, nil
+}
+
+// embeddingRequest is the OpenAI embeddings API request format.
+type embeddingRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// embeddingResponse is the OpenAI embeddings API response format.
+type embeddingResponse struct {
+	Data  []embeddingData `json:"data"`
+	Model string          `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+type embeddingData struct {
+	Embedding []float32 `json:"embedding"`
+	Index     int       `json:"index"`
+}

--- a/forge-core/memory/chunker.go
+++ b/forge-core/memory/chunker.go
@@ -1,0 +1,180 @@
+package memory
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Default chunking parameters (~400 tokens at ~4 chars/token).
+const (
+	DefaultChunkChars   = 1600
+	DefaultOverlapChars = 320
+)
+
+// Chunk is a segment of a memory file for indexing and search.
+type Chunk struct {
+	ID        string    `json:"id"`
+	Source    string    `json:"source"` // relative file path
+	Content   string    `json:"content"`
+	LineStart int       `json:"line_start"`
+	LineEnd   int       `json:"line_end"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ChunkText splits text from a source file into overlapping chunks.
+// chunkSize and overlap are in characters. Use 0 for defaults.
+func ChunkText(text, source string, chunkSize, overlap int) []Chunk {
+	if chunkSize <= 0 {
+		chunkSize = DefaultChunkChars
+	}
+	if overlap <= 0 {
+		overlap = DefaultOverlapChars
+	}
+	if overlap >= chunkSize {
+		overlap = chunkSize / 5
+	}
+
+	lines := strings.Split(text, "\n")
+	paragraphs := splitParagraphs(lines)
+
+	var chunks []Chunk
+	var buf strings.Builder
+	bufStartLine := 0
+	bufEndLine := 0
+
+	for _, p := range paragraphs {
+		// If adding this paragraph exceeds chunk size, emit current buffer.
+		if buf.Len() > 0 && buf.Len()+len(p.text) > chunkSize {
+			chunks = append(chunks, makeChunk(buf.String(), source, bufStartLine, bufEndLine))
+
+			// Start next chunk with overlap from the end of current buffer.
+			overlapText := overlapSuffix(buf.String(), overlap)
+			buf.Reset()
+			buf.WriteString(overlapText)
+			bufStartLine = p.lineStart
+		}
+
+		if buf.Len() == 0 {
+			bufStartLine = p.lineStart
+		}
+		if buf.Len() > 0 {
+			buf.WriteString("\n\n")
+		}
+		buf.WriteString(p.text)
+		bufEndLine = p.lineEnd
+
+		// Handle oversized paragraphs: split on sentence boundaries.
+		if buf.Len() > chunkSize {
+			sentences := splitSentences(buf.String())
+			buf.Reset()
+			for _, sent := range sentences {
+				if buf.Len() > 0 && buf.Len()+len(sent) > chunkSize {
+					chunks = append(chunks, makeChunk(buf.String(), source, bufStartLine, bufEndLine))
+					overlapText := overlapSuffix(buf.String(), overlap)
+					buf.Reset()
+					buf.WriteString(overlapText)
+				}
+				if buf.Len() > 0 {
+					buf.WriteString(" ")
+				}
+				buf.WriteString(sent)
+			}
+		}
+	}
+
+	// Emit remaining buffer.
+	if buf.Len() > 0 {
+		chunks = append(chunks, makeChunk(buf.String(), source, bufStartLine, bufEndLine))
+	}
+
+	return chunks
+}
+
+type paragraph struct {
+	text      string
+	lineStart int
+	lineEnd   int
+}
+
+// splitParagraphs groups lines separated by blank lines into paragraphs.
+func splitParagraphs(lines []string) []paragraph {
+	var paragraphs []paragraph
+	var current strings.Builder
+	startLine := 0
+	inParagraph := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if inParagraph {
+				paragraphs = append(paragraphs, paragraph{
+					text:      current.String(),
+					lineStart: startLine,
+					lineEnd:   i - 1,
+				})
+				current.Reset()
+				inParagraph = false
+			}
+			continue
+		}
+
+		if !inParagraph {
+			startLine = i
+			inParagraph = true
+		} else {
+			current.WriteString("\n")
+		}
+		current.WriteString(line)
+	}
+
+	if inParagraph {
+		paragraphs = append(paragraphs, paragraph{
+			text:      current.String(),
+			lineStart: startLine,
+			lineEnd:   len(lines) - 1,
+		})
+	}
+
+	return paragraphs
+}
+
+// splitSentences splits text on sentence-ending punctuation.
+func splitSentences(text string) []string {
+	var sentences []string
+	var current strings.Builder
+
+	for i, r := range text {
+		current.WriteRune(r)
+		if (r == '.' || r == '!' || r == '?') && i+1 < len(text) && text[i+1] == ' ' {
+			sentences = append(sentences, strings.TrimSpace(current.String()))
+			current.Reset()
+		}
+	}
+	if current.Len() > 0 {
+		sentences = append(sentences, strings.TrimSpace(current.String()))
+	}
+	return sentences
+}
+
+// overlapSuffix returns the last `n` characters of s.
+func overlapSuffix(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+
+// makeChunk creates a Chunk with a deterministic ID based on source, position, and content.
+func makeChunk(content, source string, lineStart, lineEnd int) Chunk {
+	h := sha256.Sum256(fmt.Appendf(nil, "%s:%d:%d:%s", source, lineStart, lineEnd, content))
+	return Chunk{
+		ID:        fmt.Sprintf("%x", h[:8]),
+		Source:    source,
+		Content:   content,
+		LineStart: lineStart,
+		LineEnd:   lineEnd,
+		CreatedAt: time.Now().UTC(),
+	}
+}

--- a/forge-core/memory/chunker_test.go
+++ b/forge-core/memory/chunker_test.go
@@ -1,0 +1,104 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChunkText_Basic(t *testing.T) {
+	text := "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+	chunks := ChunkText(text, "test.md", 100, 20)
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+
+	// All chunks should have the correct source.
+	for _, c := range chunks {
+		if c.Source != "test.md" {
+			t.Errorf("chunk source = %q, want %q", c.Source, "test.md")
+		}
+		if c.ID == "" {
+			t.Error("chunk ID should not be empty")
+		}
+	}
+}
+
+func TestChunkText_SingleParagraph(t *testing.T) {
+	text := "This is a single paragraph with no breaks."
+	chunks := ChunkText(text, "test.md", 1000, 100)
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != text {
+		t.Errorf("chunk content = %q, want %q", chunks[0].Content, text)
+	}
+}
+
+func TestChunkText_LargeText(t *testing.T) {
+	// Create a large text that should be split into multiple chunks.
+	var sb strings.Builder
+	for i := range 100 {
+		sb.WriteString("This is a test sentence that forms a paragraph. ")
+		if i%5 == 4 {
+			sb.WriteString("\n\n")
+		}
+	}
+
+	chunks := ChunkText(sb.String(), "test.md", 200, 40)
+
+	if len(chunks) < 2 {
+		t.Errorf("expected multiple chunks for large text, got %d", len(chunks))
+	}
+
+	// Chunks should have unique IDs.
+	ids := make(map[string]bool)
+	for _, c := range chunks {
+		if ids[c.ID] {
+			t.Errorf("duplicate chunk ID: %s", c.ID)
+		}
+		ids[c.ID] = true
+	}
+}
+
+func TestChunkText_EmptyText(t *testing.T) {
+	chunks := ChunkText("", "test.md", 0, 0)
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty text, got %d", len(chunks))
+	}
+}
+
+func TestChunkText_Defaults(t *testing.T) {
+	text := "Test paragraph."
+	chunks := ChunkText(text, "test.md", 0, 0)
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+}
+
+func TestSplitParagraphs(t *testing.T) {
+	lines := strings.Split("First line\nstill first\n\nSecond paragraph\n\n\nThird", "\n")
+	paras := splitParagraphs(lines)
+
+	if len(paras) != 3 {
+		t.Fatalf("expected 3 paragraphs, got %d", len(paras))
+	}
+
+	if paras[0].lineStart != 0 {
+		t.Errorf("first paragraph lineStart = %d, want 0", paras[0].lineStart)
+	}
+	if !strings.Contains(paras[0].text, "First line") {
+		t.Errorf("first paragraph should contain 'First line'")
+	}
+}
+
+func TestOverlapSuffix(t *testing.T) {
+	if got := overlapSuffix("hello world", 5); got != "world" {
+		t.Errorf("overlapSuffix = %q, want %q", got, "world")
+	}
+	if got := overlapSuffix("hi", 10); got != "hi" {
+		t.Errorf("overlapSuffix short = %q, want %q", got, "hi")
+	}
+}

--- a/forge-core/memory/filestore.go
+++ b/forge-core/memory/filestore.go
@@ -1,0 +1,125 @@
+// Package memory provides long-term agent memory with file-based storage,
+// vector search, and hybrid retrieval.
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// FileStore manages the on-disk memory directory (.forge/memory).
+type FileStore struct {
+	dir string
+}
+
+// NewFileStore creates a FileStore rooted at dir, creating it if needed.
+func NewFileStore(dir string) (*FileStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating memory dir: %w", err)
+	}
+	return &FileStore{dir: dir}, nil
+}
+
+// Dir returns the root directory of the file store.
+func (fs *FileStore) Dir() string { return fs.dir }
+
+// ReadFile reads a file relative to the memory directory.
+// Returns an error if the path escapes the memory directory.
+func (fs *FileStore) ReadFile(relPath string) (string, error) {
+	absPath, err := fs.safePath(relPath)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// AppendDaily appends an entry to today's daily log (YYYY-MM-DD.md).
+func (fs *FileStore) AppendDaily(entry string) error {
+	filename := time.Now().UTC().Format("2006-01-02") + ".md"
+	path := filepath.Join(fs.dir, filename)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening daily log: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Add timestamp prefix and trailing newline.
+	ts := time.Now().UTC().Format("15:04:05")
+	_, err = fmt.Fprintf(f, "\n## %s\n%s\n", ts, entry)
+	return err
+}
+
+// ListFiles returns all .md files in the memory directory (relative paths).
+func (fs *FileStore) ListFiles() ([]string, error) {
+	entries, err := os.ReadDir(fs.dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".md") {
+			files = append(files, e.Name())
+		}
+	}
+	return files, nil
+}
+
+// EnsureMemoryMD creates a template MEMORY.md if one doesn't exist.
+func (fs *FileStore) EnsureMemoryMD() error {
+	path := filepath.Join(fs.dir, "MEMORY.md")
+	if _, err := os.Stat(path); err == nil {
+		return nil // already exists
+	}
+
+	template := `# Agent Memory
+
+This file contains curated long-term facts and knowledge.
+Entries here are evergreen — they do not decay over time.
+
+## Key Facts
+
+<!-- Add important facts, user preferences, and project context here -->
+`
+	return os.WriteFile(path, []byte(template), 0o644)
+}
+
+// safePath resolves a relative path and validates it stays within the memory dir.
+func (fs *FileStore) safePath(relPath string) (string, error) {
+	// Clean the path to prevent traversal
+	cleaned := filepath.Clean(relPath)
+	if filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("absolute paths not allowed: %s", relPath)
+	}
+	if strings.HasPrefix(cleaned, "..") {
+		return "", fmt.Errorf("path traversal not allowed: %s", relPath)
+	}
+
+	absPath := filepath.Join(fs.dir, cleaned)
+
+	// Double-check the resolved path is within our dir
+	absDir, err := filepath.Abs(fs.dir)
+	if err != nil {
+		return "", err
+	}
+	absResolved, err := filepath.Abs(absPath)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(absResolved, absDir+string(filepath.Separator)) && absResolved != absDir {
+		return "", fmt.Errorf("path escapes memory directory: %s", relPath)
+	}
+
+	return absPath, nil
+}

--- a/forge-core/memory/filestore_test.go
+++ b/forge-core/memory/filestore_test.go
@@ -1,0 +1,151 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewFileStore(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	fs, err := NewFileStore(memDir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	// Directory should be created.
+	if _, err := os.Stat(memDir); err != nil {
+		t.Fatalf("memory dir not created: %v", err)
+	}
+	if fs.Dir() != memDir {
+		t.Errorf("Dir() = %q, want %q", fs.Dir(), memDir)
+	}
+}
+
+func TestFileStore_ReadFile(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	// Write a test file.
+	content := "hello world"
+	if err := os.WriteFile(filepath.Join(dir, "test.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.ReadFile("test.md")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got != content {
+		t.Errorf("ReadFile = %q, want %q", got, content)
+	}
+}
+
+func TestFileStore_ReadFile_TraversalPrevention(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	cases := []string{
+		"../etc/passwd",
+		"/etc/passwd",
+		"../../secret",
+	}
+
+	for _, path := range cases {
+		_, err := fs.ReadFile(path)
+		if err == nil {
+			t.Errorf("expected error for path %q", path)
+		}
+	}
+}
+
+func TestFileStore_AppendDaily(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	if err := fs.AppendDaily("test observation"); err != nil {
+		t.Fatalf("AppendDaily: %v", err)
+	}
+
+	// Check that a daily log was created.
+	files, err := fs.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("expected at least one file after AppendDaily")
+	}
+
+	// Read the file and check content.
+	content, err := fs.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(content, "test observation") {
+		t.Errorf("daily log should contain observation, got: %s", content)
+	}
+}
+
+func TestFileStore_EnsureMemoryMD(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	if err := fs.EnsureMemoryMD(); err != nil {
+		t.Fatalf("EnsureMemoryMD: %v", err)
+	}
+
+	content, err := fs.ReadFile("MEMORY.md")
+	if err != nil {
+		t.Fatalf("ReadFile MEMORY.md: %v", err)
+	}
+	if !strings.Contains(content, "Agent Memory") {
+		t.Error("MEMORY.md should contain template content")
+	}
+
+	// Second call should be a no-op.
+	if err := fs.EnsureMemoryMD(); err != nil {
+		t.Fatalf("EnsureMemoryMD (idempotent): %v", err)
+	}
+}
+
+func TestFileStore_ListFiles(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	// Create test files.
+	for _, name := range []string{"MEMORY.md", "2026-01-01.md", "2026-01-02.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Non-.md file should be excluded.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := fs.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(files) != 3 {
+		t.Errorf("expected 3 files, got %d: %v", len(files), files)
+	}
+}

--- a/forge-core/memory/manager.go
+++ b/forge-core/memory/manager.go
@@ -1,0 +1,213 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// Logger is the logging interface used by the memory package.
+type Logger interface {
+	Info(msg string, fields map[string]any)
+	Warn(msg string, fields map[string]any)
+	Error(msg string, fields map[string]any)
+	Debug(msg string, fields map[string]any)
+}
+
+// ManagerConfig configures a Manager.
+type ManagerConfig struct {
+	MemoryDir    string       // root directory for memory files
+	Embedder     llm.Embedder // nil = keyword-only mode
+	Logger       Logger
+	SearchConfig SearchConfig
+}
+
+// Manager orchestrates long-term memory: file storage, indexing, and search.
+type Manager struct {
+	fileStore *FileStore
+	vecStore  VectorStore
+	searcher  *HybridSearcher
+	embedder  llm.Embedder
+	logger    Logger
+}
+
+// NewManager creates a new memory Manager.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if cfg.MemoryDir == "" {
+		return nil, fmt.Errorf("memory dir is required")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = &nopLogger{}
+	}
+
+	fileStore, err := NewFileStore(cfg.MemoryDir)
+	if err != nil {
+		return nil, fmt.Errorf("creating file store: %w", err)
+	}
+
+	// Ensure MEMORY.md exists.
+	if err := fileStore.EnsureMemoryMD(); err != nil {
+		logger.Warn("failed to create MEMORY.md template", map[string]any{"error": err.Error()})
+	}
+
+	indexDir := filepath.Join(cfg.MemoryDir, "index")
+	vecStore, err := NewFileVectorStore(indexDir)
+	if err != nil {
+		return nil, fmt.Errorf("creating vector store: %w", err)
+	}
+
+	searchCfg := cfg.SearchConfig
+	if searchCfg.TopK == 0 {
+		searchCfg = DefaultSearchConfig()
+	}
+
+	searcher := NewHybridSearcher(vecStore, cfg.Embedder, searchCfg)
+
+	return &Manager{
+		fileStore: fileStore,
+		vecStore:  vecStore,
+		searcher:  searcher,
+		embedder:  cfg.Embedder,
+		logger:    logger,
+	}, nil
+}
+
+// Search queries long-term memory with hybrid search.
+func (m *Manager) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	return m.searcher.Search(ctx, query)
+}
+
+// GetFile retrieves a memory file by relative path.
+func (m *Manager) GetFile(path string) (string, error) {
+	return m.fileStore.ReadFile(path)
+}
+
+// AppendDailyLog appends an observation to today's daily log and indexes it.
+func (m *Manager) AppendDailyLog(ctx context.Context, observation string) error {
+	if err := m.fileStore.AppendDaily(observation); err != nil {
+		return err
+	}
+
+	// Re-index today's daily log after appending.
+	// Use best-effort: log errors but don't fail the append.
+	if err := m.indexDailyLog(ctx); err != nil {
+		m.logger.Warn("failed to re-index daily log after append", map[string]any{"error": err.Error()})
+	}
+
+	return nil
+}
+
+// IndexAll indexes all memory files (MEMORY.md + daily logs).
+func (m *Manager) IndexAll(ctx context.Context) error {
+	files, err := m.fileStore.ListFiles()
+	if err != nil {
+		return fmt.Errorf("listing memory files: %w", err)
+	}
+
+	m.logger.Info("indexing memory files", map[string]any{"count": len(files)})
+
+	for _, f := range files {
+		if err := m.IndexFile(ctx, f); err != nil {
+			m.logger.Warn("failed to index file", map[string]any{
+				"file":  f,
+				"error": err.Error(),
+			})
+		}
+	}
+	return nil
+}
+
+// IndexFile indexes a single memory file by relative path.
+func (m *Manager) IndexFile(ctx context.Context, path string) error {
+	content, err := m.fileStore.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// Remove old chunks for this file.
+	if err := m.vecStore.DeleteBySource(ctx, path); err != nil {
+		return fmt.Errorf("deleting old chunks for %s: %w", path, err)
+	}
+
+	// Chunk the content.
+	chunks := ChunkText(content, path, 0, 0)
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	// Generate embeddings if embedder available.
+	indexed := make([]IndexedChunk, len(chunks))
+	if m.embedder != nil {
+		texts := make([]string, len(chunks))
+		for i, c := range chunks {
+			texts[i] = c.Content
+		}
+
+		resp, err := m.embedder.Embed(ctx, &llm.EmbeddingRequest{Texts: texts})
+		if err != nil {
+			m.logger.Warn("embedding failed, indexing without vectors", map[string]any{
+				"file":  path,
+				"error": err.Error(),
+			})
+			for i, c := range chunks {
+				indexed[i] = IndexedChunk{Chunk: c}
+			}
+		} else {
+			for i, c := range chunks {
+				ic := IndexedChunk{Chunk: c}
+				if i < len(resp.Embeddings) {
+					ic.Vector = resp.Embeddings[i]
+				}
+				indexed[i] = ic
+			}
+		}
+	} else {
+		for i, c := range chunks {
+			indexed[i] = IndexedChunk{Chunk: c}
+		}
+	}
+
+	if err := m.vecStore.Index(ctx, indexed); err != nil {
+		return fmt.Errorf("indexing chunks for %s: %w", path, err)
+	}
+
+	m.logger.Debug("indexed file", map[string]any{
+		"file":   path,
+		"chunks": len(indexed),
+	})
+
+	return nil
+}
+
+// indexDailyLog re-indexes today's daily log file.
+func (m *Manager) indexDailyLog(ctx context.Context) error {
+	files, err := m.fileStore.ListFiles()
+	if err != nil {
+		return err
+	}
+
+	// Find the most recent daily log (last .md that isn't MEMORY.md).
+	for i := len(files) - 1; i >= 0; i-- {
+		if files[i] != "MEMORY.md" {
+			return m.IndexFile(ctx, files[i])
+		}
+	}
+	return nil
+}
+
+// Close flushes the vector store to disk.
+func (m *Manager) Close() error {
+	return m.vecStore.Close()
+}
+
+// nopLogger is a no-op Logger.
+type nopLogger struct{}
+
+func (n *nopLogger) Info(_ string, _ map[string]any)  {}
+func (n *nopLogger) Warn(_ string, _ map[string]any)  {}
+func (n *nopLogger) Error(_ string, _ map[string]any) {}
+func (n *nopLogger) Debug(_ string, _ map[string]any) {}

--- a/forge-core/memory/manager_test.go
+++ b/forge-core/memory/manager_test.go
@@ -1,0 +1,178 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManager_NewManager(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	mgr, err := NewManager(ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	// MEMORY.md should be created.
+	if _, err := os.Stat(filepath.Join(memDir, "MEMORY.md")); err != nil {
+		t.Error("MEMORY.md should be created on init")
+	}
+}
+
+func TestManager_EmptyDir(t *testing.T) {
+	_, err := NewManager(ManagerConfig{})
+	if err == nil {
+		t.Error("expected error for empty memory dir")
+	}
+}
+
+func TestManager_GetFile(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	mgr, err := NewManager(ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	content, err := mgr.GetFile("MEMORY.md")
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !strings.Contains(content, "Agent Memory") {
+		t.Error("MEMORY.md should contain template content")
+	}
+}
+
+func TestManager_AppendDailyLog(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	mgr, err := NewManager(ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	if err := mgr.AppendDailyLog(ctx, "test observation"); err != nil {
+		t.Fatalf("AppendDailyLog: %v", err)
+	}
+
+	// The daily log should exist and be searchable (keyword mode since no embedder).
+	results, err := mgr.Search(ctx, "test observation")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	// Should find the observation in results.
+	found := false
+	for _, r := range results {
+		if strings.Contains(r.Chunk.Content, "test observation") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find daily log observation in search results")
+	}
+}
+
+func TestManager_IndexAll(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	// Create some test files.
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("# Memory\nUser prefers Go."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memDir, "2026-02-25.md"), []byte("## 10:00\nDiscussed architecture."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := NewManager(ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	if err := mgr.IndexAll(ctx); err != nil {
+		t.Fatalf("IndexAll: %v", err)
+	}
+
+	// Search should find indexed content.
+	results, err := mgr.Search(ctx, "Go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected search results after IndexAll")
+	}
+}
+
+func TestManager_SearchWithMockEmbedder(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("The user prefers TypeScript over JavaScript."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	emb := &mockEmbedder{dims: 4}
+	mgr, err := NewManager(ManagerConfig{
+		MemoryDir: memDir,
+		Embedder:  emb,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	if err := mgr.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := mgr.Search(ctx, "TypeScript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected search results with embedder")
+	}
+}
+
+func TestManager_GracefulDegradation(t *testing.T) {
+	// Verify no crash when memory dir doesn't have any files.
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	mgr, err := NewManager(ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+
+	// Search on empty index should return nil, not error.
+	results, err := mgr.Search(ctx, "anything")
+	if err != nil {
+		t.Fatalf("Search on empty: %v", err)
+	}
+	// Results may be nil or empty — both are fine.
+	_ = results
+}

--- a/forge-core/memory/search.go
+++ b/forge-core/memory/search.go
@@ -1,0 +1,226 @@
+package memory
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// SearchConfig configures the hybrid search engine.
+type SearchConfig struct {
+	VectorWeight  float64       // weight for vector similarity (default: 0.7)
+	KeywordWeight float64       // weight for keyword overlap (default: 0.3)
+	DecayHalfLife time.Duration // temporal decay half-life (default: 7 days)
+	DecayEnabled  bool          // whether to apply temporal decay (default: true)
+	TopK          int           // max results to return (default: 10)
+}
+
+// DefaultSearchConfig returns a SearchConfig with sensible defaults.
+func DefaultSearchConfig() SearchConfig {
+	return SearchConfig{
+		VectorWeight:  0.7,
+		KeywordWeight: 0.3,
+		DecayHalfLife: 7 * 24 * time.Hour,
+		DecayEnabled:  true,
+		TopK:          10,
+	}
+}
+
+// HybridSearcher combines vector similarity, keyword overlap, and temporal
+// decay for memory retrieval.
+type HybridSearcher struct {
+	store    VectorStore
+	embedder llm.Embedder // nil = keyword-only mode
+	config   SearchConfig
+}
+
+// NewHybridSearcher creates a new hybrid searcher.
+func NewHybridSearcher(store VectorStore, embedder llm.Embedder, config SearchConfig) *HybridSearcher {
+	if config.TopK <= 0 {
+		config.TopK = 10
+	}
+	if config.VectorWeight <= 0 {
+		config.VectorWeight = 0.7
+	}
+	if config.KeywordWeight <= 0 {
+		config.KeywordWeight = 0.3
+	}
+	if config.DecayHalfLife <= 0 {
+		config.DecayHalfLife = 7 * 24 * time.Hour
+	}
+	return &HybridSearcher{
+		store:    store,
+		embedder: embedder,
+		config:   config,
+	}
+}
+
+// Search performs hybrid search: vector + keyword + temporal decay.
+// If no embedder is available, falls back to keyword-only search over all chunks.
+func (h *HybridSearcher) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	candidateK := h.config.TopK * 3 // fetch more candidates for re-ranking
+
+	var candidates []SearchResult
+
+	if h.embedder != nil {
+		// Vector search path
+		resp, err := h.embedder.Embed(ctx, &llm.EmbeddingRequest{Texts: []string{query}})
+		if err != nil {
+			// Fall back to keyword-only on embedding failure.
+			return h.keywordOnlySearch(ctx, query)
+		}
+		if len(resp.Embeddings) == 0 {
+			return h.keywordOnlySearch(ctx, query)
+		}
+
+		candidates, err = h.store.Search(ctx, resp.Embeddings[0], candidateK)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// No embedder — keyword-only mode. Fetch all chunks.
+		candidates, _ = h.store.Search(ctx, nil, 0)
+		if len(candidates) == 0 {
+			return nil, nil
+		}
+	}
+
+	// Re-rank with keyword scoring and temporal decay.
+	queryTerms := tokenize(query)
+	now := time.Now().UTC()
+
+	type scoredResult struct {
+		result     SearchResult
+		finalScore float64
+	}
+
+	scored := make([]scoredResult, 0, len(candidates))
+	for _, c := range candidates {
+		vectorScore := c.Score
+		keywordScore := keywordOverlap(queryTerms, c.Chunk.Content)
+
+		// Temporal decay: MEMORY.md is evergreen (decay = 1.0).
+		decay := 1.0
+		if h.config.DecayEnabled && c.Chunk.Source != "MEMORY.md" {
+			age := now.Sub(c.Chunk.CreatedAt)
+			decay = math.Exp(-math.Ln2 / h.config.DecayHalfLife.Seconds() * age.Seconds())
+		}
+
+		var finalScore float64
+		if h.embedder != nil {
+			finalScore = (h.config.VectorWeight*vectorScore + h.config.KeywordWeight*keywordScore) * decay
+		} else {
+			finalScore = keywordScore * decay
+		}
+
+		// Skip zero-score results (irrelevant in keyword-only mode).
+		if finalScore == 0 {
+			continue
+		}
+
+		scored = append(scored, scoredResult{
+			result:     SearchResult{Chunk: c.Chunk, Score: finalScore},
+			finalScore: finalScore,
+		})
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].finalScore > scored[j].finalScore
+	})
+
+	topK := min(h.config.TopK, len(scored))
+
+	results := make([]SearchResult, topK)
+	for i := range topK {
+		results[i] = scored[i].result
+	}
+	return results, nil
+}
+
+// keywordOnlySearch loads all chunks and ranks by keyword overlap + decay.
+func (h *HybridSearcher) keywordOnlySearch(ctx context.Context, query string) ([]SearchResult, error) {
+	// Use a nil vector with k=0 to get all chunks (store should return everything).
+	all, err := h.store.Search(ctx, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	queryTerms := tokenize(query)
+	now := time.Now().UTC()
+
+	type scoredResult struct {
+		result     SearchResult
+		finalScore float64
+	}
+
+	scored := make([]scoredResult, 0, len(all))
+	for _, c := range all {
+		kw := keywordOverlap(queryTerms, c.Chunk.Content)
+		if kw == 0 {
+			continue
+		}
+
+		decay := 1.0
+		if h.config.DecayEnabled && c.Chunk.Source != "MEMORY.md" {
+			age := now.Sub(c.Chunk.CreatedAt)
+			decay = math.Exp(-math.Ln2 / h.config.DecayHalfLife.Seconds() * age.Seconds())
+		}
+
+		finalScore := kw * decay
+		scored = append(scored, scoredResult{
+			result:     SearchResult{Chunk: c.Chunk, Score: finalScore},
+			finalScore: finalScore,
+		})
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].finalScore > scored[j].finalScore
+	})
+
+	topK := min(h.config.TopK, len(scored))
+
+	results := make([]SearchResult, topK)
+	for i := range topK {
+		results[i] = scored[i].result
+	}
+	return results, nil
+}
+
+// tokenize splits text into lowercase terms for keyword matching.
+func tokenize(text string) []string {
+	words := strings.Fields(strings.ToLower(text))
+	// Deduplicate
+	seen := make(map[string]struct{}, len(words))
+	unique := make([]string, 0, len(words))
+	for _, w := range words {
+		// Strip common punctuation
+		w = strings.Trim(w, ".,;:!?\"'()[]{}—-")
+		if w == "" {
+			continue
+		}
+		if _, ok := seen[w]; !ok {
+			seen[w] = struct{}{}
+			unique = append(unique, w)
+		}
+	}
+	return unique
+}
+
+// keywordOverlap computes the fraction of query terms found in the content.
+func keywordOverlap(queryTerms []string, content string) float64 {
+	if len(queryTerms) == 0 {
+		return 0
+	}
+	lower := strings.ToLower(content)
+	matched := 0
+	for _, term := range queryTerms {
+		if strings.Contains(lower, term) {
+			matched++
+		}
+	}
+	return float64(matched) / float64(len(queryTerms))
+}

--- a/forge-core/memory/search_test.go
+++ b/forge-core/memory/search_test.go
@@ -1,0 +1,200 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// mockEmbedder produces deterministic embeddings for testing.
+type mockEmbedder struct {
+	dims int
+}
+
+func (m *mockEmbedder) Dimensions() int { return m.dims }
+func (m *mockEmbedder) Embed(_ context.Context, req *llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+	embeddings := make([][]float32, len(req.Texts))
+	for i, text := range req.Texts {
+		// Simple hash-based embedding for deterministic tests.
+		vec := make([]float32, m.dims)
+		for j, c := range text {
+			vec[j%m.dims] += float32(c) / 1000.0
+		}
+		_ = i
+		embeddings[i] = vec
+	}
+	return &llm.EmbeddingResponse{Embeddings: embeddings, Model: "mock"}, nil
+}
+
+func TestHybridSearcher_VectorAndKeyword(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	emb := &mockEmbedder{dims: 4}
+
+	// Index some chunks.
+	now := time.Now().UTC()
+	chunks := []IndexedChunk{
+		{
+			Chunk:  Chunk{ID: "1", Source: "MEMORY.md", Content: "user prefers dark mode theme", CreatedAt: now},
+			Vector: []float32{0.5, 0.3, 0.1, 0.0},
+		},
+		{
+			Chunk:  Chunk{ID: "2", Source: "2026-02-20.md", Content: "discussed API rate limiting", CreatedAt: now.Add(-5 * 24 * time.Hour)},
+			Vector: []float32{0.1, 0.5, 0.3, 0.0},
+		},
+		{
+			Chunk:  Chunk{ID: "3", Source: "2026-02-24.md", Content: "user wants dark mode for the dashboard", CreatedAt: now.Add(-1 * 24 * time.Hour)},
+			Vector: []float32{0.4, 0.3, 0.2, 0.0},
+		},
+	}
+	if err := store.Index(ctx, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewHybridSearcher(store, emb, SearchConfig{
+		VectorWeight:  0.7,
+		KeywordWeight: 0.3,
+		DecayHalfLife: 7 * 24 * time.Hour,
+		DecayEnabled:  true,
+		TopK:          10,
+	})
+
+	results, err := searcher.Search(ctx, "dark mode")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("expected search results")
+	}
+
+	// Both chunks mentioning "dark mode" should be near the top.
+	foundDarkMode := false
+	for _, r := range results {
+		if r.Chunk.ID == "1" || r.Chunk.ID == "3" {
+			foundDarkMode = true
+			break
+		}
+	}
+	if !foundDarkMode {
+		t.Error("expected dark mode chunks in results")
+	}
+}
+
+func TestHybridSearcher_KeywordOnly(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	chunks := []IndexedChunk{
+		{Chunk: Chunk{ID: "1", Source: "MEMORY.md", Content: "user prefers dark mode", CreatedAt: now}},
+		{Chunk: Chunk{ID: "2", Source: "daily.md", Content: "unrelated content here", CreatedAt: now}},
+	}
+	if err := store.Index(ctx, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	// No embedder — keyword-only mode.
+	searcher := NewHybridSearcher(store, nil, DefaultSearchConfig())
+
+	results, err := searcher.Search(ctx, "dark mode")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Chunk.ID != "1" {
+		t.Errorf("expected chunk 1, got %s", results[0].Chunk.ID)
+	}
+}
+
+func TestHybridSearcher_TemporalDecay(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Two chunks with same content but different ages.
+	chunks := []IndexedChunk{
+		{Chunk: Chunk{ID: "old", Source: "2026-01-01.md", Content: "important fact about config", CreatedAt: now.Add(-30 * 24 * time.Hour)}},
+		{Chunk: Chunk{ID: "new", Source: "2026-02-24.md", Content: "important fact about config", CreatedAt: now.Add(-1 * 24 * time.Hour)}},
+		{Chunk: Chunk{ID: "evergreen", Source: "MEMORY.md", Content: "important fact about config", CreatedAt: now.Add(-30 * 24 * time.Hour)}},
+	}
+	if err := store.Index(ctx, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewHybridSearcher(store, nil, SearchConfig{
+		VectorWeight:  0.7,
+		KeywordWeight: 0.3,
+		DecayHalfLife: 7 * 24 * time.Hour,
+		DecayEnabled:  true,
+		TopK:          10,
+	})
+
+	results, err := searcher.Search(ctx, "important config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) < 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// MEMORY.md (evergreen, no decay) and recent chunk should rank higher than old chunk.
+	if results[len(results)-1].Chunk.ID != "old" {
+		t.Errorf("expected oldest chunk to rank last, got %s", results[len(results)-1].Chunk.ID)
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	tokens := tokenize("Hello, World! Hello")
+	if len(tokens) != 2 {
+		t.Errorf("expected 2 unique tokens, got %d: %v", len(tokens), tokens)
+	}
+}
+
+func TestKeywordOverlap(t *testing.T) {
+	terms := []string{"hello", "world"}
+
+	overlap := keywordOverlap(terms, "Hello World!")
+	if overlap != 1.0 {
+		t.Errorf("expected 1.0 overlap, got %f", overlap)
+	}
+
+	overlap = keywordOverlap(terms, "Hello there")
+	if overlap != 0.5 {
+		t.Errorf("expected 0.5 overlap, got %f", overlap)
+	}
+
+	overlap = keywordOverlap(terms, "nothing here")
+	if overlap != 0.0 {
+		t.Errorf("expected 0.0 overlap, got %f", overlap)
+	}
+
+	overlap = keywordOverlap(nil, "anything")
+	if overlap != 0.0 {
+		t.Errorf("expected 0.0 for nil terms, got %f", overlap)
+	}
+}

--- a/forge-core/memory/vectorstore.go
+++ b/forge-core/memory/vectorstore.go
@@ -1,0 +1,209 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// VectorStore is the pluggable interface for vector storage backends.
+// FileVectorStore is the initial implementation; swap to Qdrant/Pinecone later.
+type VectorStore interface {
+	// Index adds or updates chunks with their embedding vectors.
+	Index(ctx context.Context, chunks []IndexedChunk) error
+	// Search returns the top-k most similar chunks to the query vector.
+	Search(ctx context.Context, queryVector []float32, k int) ([]SearchResult, error)
+	// DeleteBySource removes all chunks from a given source file.
+	DeleteBySource(ctx context.Context, sourceFile string) error
+	// Count returns the total number of indexed chunks.
+	Count() int
+	// Close flushes any pending writes and releases resources.
+	Close() error
+}
+
+// IndexedChunk is a Chunk with its embedding vector.
+type IndexedChunk struct {
+	Chunk  Chunk     `json:"chunk"`
+	Vector []float32 `json:"vector"`
+}
+
+// SearchResult is a chunk with its similarity score.
+type SearchResult struct {
+	Chunk Chunk   `json:"chunk"`
+	Score float64 `json:"score"`
+}
+
+// FileVectorStore is a JSON file-backed VectorStore.
+// All data is loaded into memory; suitable for corpora under ~10K chunks.
+type FileVectorStore struct {
+	mu     sync.RWMutex
+	dir    string // index directory (e.g. .forge/memory/index)
+	chunks map[string]IndexedChunk
+	dirty  bool
+}
+
+// NewFileVectorStore opens or creates a file-based vector store in dir.
+func NewFileVectorStore(dir string) (*FileVectorStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating index dir: %w", err)
+	}
+
+	store := &FileVectorStore{
+		dir:    dir,
+		chunks: make(map[string]IndexedChunk),
+	}
+
+	if err := store.load(); err != nil {
+		// Corrupted index — start fresh.
+		store.chunks = make(map[string]IndexedChunk)
+	}
+
+	return store, nil
+}
+
+// Index adds or updates indexed chunks. Thread-safe.
+func (s *FileVectorStore) Index(_ context.Context, chunks []IndexedChunk) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, c := range chunks {
+		s.chunks[c.Chunk.ID] = c
+	}
+	s.dirty = true
+	return nil
+}
+
+// Search performs a linear scan with cosine similarity. Thread-safe.
+func (s *FileVectorStore) Search(_ context.Context, queryVector []float32, k int) ([]SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if k <= 0 {
+		k = 10
+	}
+
+	// Compute similarities and maintain a top-k list.
+	results := make([]SearchResult, 0, k)
+	for _, ic := range s.chunks {
+		score := cosineSimilarity(queryVector, ic.Vector)
+		if len(results) < k {
+			results = append(results, SearchResult{Chunk: ic.Chunk, Score: score})
+			// Bubble up (insertion sort for small k).
+			for i := len(results) - 1; i > 0 && results[i].Score > results[i-1].Score; i-- {
+				results[i], results[i-1] = results[i-1], results[i]
+			}
+		} else if score > results[k-1].Score {
+			results[k-1] = SearchResult{Chunk: ic.Chunk, Score: score}
+			for i := k - 1; i > 0 && results[i].Score > results[i-1].Score; i-- {
+				results[i], results[i-1] = results[i-1], results[i]
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// DeleteBySource removes all chunks from a given source file.
+func (s *FileVectorStore) DeleteBySource(_ context.Context, sourceFile string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, ic := range s.chunks {
+		if ic.Chunk.Source == sourceFile {
+			delete(s.chunks, id)
+			s.dirty = true
+		}
+	}
+	return nil
+}
+
+// Count returns the number of indexed chunks.
+func (s *FileVectorStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.chunks)
+}
+
+// Close flushes dirty data to disk.
+func (s *FileVectorStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.dirty {
+		return nil
+	}
+	return s.flush()
+}
+
+// load reads chunks from the JSON index file.
+func (s *FileVectorStore) load() error {
+	path := filepath.Join(s.dir, "index.json")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var chunks []IndexedChunk
+	if err := json.Unmarshal(data, &chunks); err != nil {
+		return fmt.Errorf("decoding index: %w", err)
+	}
+
+	for _, c := range chunks {
+		s.chunks[c.Chunk.ID] = c
+	}
+	return nil
+}
+
+// flush writes all chunks to the JSON index file atomically.
+func (s *FileVectorStore) flush() error {
+	chunks := make([]IndexedChunk, 0, len(s.chunks))
+	for _, c := range s.chunks {
+		chunks = append(chunks, c)
+	}
+
+	data, err := json.Marshal(chunks)
+	if err != nil {
+		return fmt.Errorf("encoding index: %w", err)
+	}
+
+	path := filepath.Join(s.dir, "index.json")
+	tmpPath := path + ".tmp"
+
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing index: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming index: %w", err)
+	}
+
+	s.dirty = false
+	return nil
+}
+
+// cosineSimilarity computes the cosine similarity between two vectors.
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0
+	}
+	return dot / denom
+}

--- a/forge-core/memory/vectorstore_test.go
+++ b/forge-core/memory/vectorstore_test.go
@@ -1,0 +1,152 @@
+package memory
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestFileVectorStore_IndexAndSearch(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileVectorStore: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Index some chunks with vectors.
+	chunks := []IndexedChunk{
+		{
+			Chunk:  Chunk{ID: "1", Source: "test.md", Content: "hello world", CreatedAt: time.Now()},
+			Vector: []float32{1, 0, 0},
+		},
+		{
+			Chunk:  Chunk{ID: "2", Source: "test.md", Content: "goodbye world", CreatedAt: time.Now()},
+			Vector: []float32{0, 1, 0},
+		},
+		{
+			Chunk:  Chunk{ID: "3", Source: "other.md", Content: "other content", CreatedAt: time.Now()},
+			Vector: []float32{0, 0, 1},
+		},
+	}
+
+	if err := store.Index(ctx, chunks); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	if store.Count() != 3 {
+		t.Errorf("Count = %d, want 3", store.Count())
+	}
+
+	// Search with a vector close to chunk 1.
+	results, err := store.Search(ctx, []float32{0.9, 0.1, 0}, 2)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Chunk.ID != "1" {
+		t.Errorf("top result should be chunk 1, got %s", results[0].Chunk.ID)
+	}
+}
+
+func TestFileVectorStore_DeleteBySource(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileVectorStore: %v", err)
+	}
+
+	ctx := context.Background()
+
+	chunks := []IndexedChunk{
+		{Chunk: Chunk{ID: "1", Source: "a.md"}, Vector: []float32{1, 0}},
+		{Chunk: Chunk{ID: "2", Source: "a.md"}, Vector: []float32{0, 1}},
+		{Chunk: Chunk{ID: "3", Source: "b.md"}, Vector: []float32{1, 1}},
+	}
+	if err := store.Index(ctx, chunks); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteBySource(ctx, "a.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	if store.Count() != 1 {
+		t.Errorf("Count after delete = %d, want 1", store.Count())
+	}
+}
+
+func TestFileVectorStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Create store and index.
+	store1, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunks := []IndexedChunk{
+		{Chunk: Chunk{ID: "1", Source: "test.md", Content: "persist me"}, Vector: []float32{1, 0}},
+	}
+	if err := store1.Index(ctx, chunks); err != nil {
+		t.Fatal(err)
+	}
+	if err := store1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen and verify data persisted.
+	store2, err := NewFileVectorStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store2.Close() //nolint:errcheck
+
+	if store2.Count() != 1 {
+		t.Errorf("Count after reopen = %d, want 1", store2.Count())
+	}
+
+	results, err := store2.Search(ctx, []float32{1, 0}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Chunk.Content != "persist me" {
+		t.Errorf("expected persisted chunk, got %v", results)
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	// Same vector → similarity = 1.0
+	sim := cosineSimilarity([]float32{1, 0, 0}, []float32{1, 0, 0})
+	if math.Abs(sim-1.0) > 1e-6 {
+		t.Errorf("same vector similarity = %f, want 1.0", sim)
+	}
+
+	// Orthogonal vectors → similarity = 0.0
+	sim = cosineSimilarity([]float32{1, 0, 0}, []float32{0, 1, 0})
+	if math.Abs(sim) > 1e-6 {
+		t.Errorf("orthogonal similarity = %f, want 0.0", sim)
+	}
+
+	// Opposite vectors → similarity = -1.0
+	sim = cosineSimilarity([]float32{1, 0}, []float32{-1, 0})
+	if math.Abs(sim-(-1.0)) > 1e-6 {
+		t.Errorf("opposite similarity = %f, want -1.0", sim)
+	}
+
+	// Different lengths → 0.0
+	sim = cosineSimilarity([]float32{1}, []float32{1, 0})
+	if sim != 0 {
+		t.Errorf("mismatched lengths = %f, want 0.0", sim)
+	}
+
+	// Empty → 0.0
+	sim = cosineSimilarity(nil, nil)
+	if sim != 0 {
+		t.Errorf("empty = %f, want 0.0", sim)
+	}
+}

--- a/forge-core/runtime/memory.go
+++ b/forge-core/runtime/memory.go
@@ -1,26 +1,79 @@
 package runtime
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/initializ/forge/forge-core/llm"
 )
 
+// ModelContextWindows maps model name prefixes to context window sizes (in tokens).
+var ModelContextWindows = map[string]int{
+	"gpt-4o":        128_000,
+	"gpt-4":         128_000,
+	"gpt-5":         128_000,
+	"gpt-3.5":       16_000,
+	"claude-opus":   200_000,
+	"claude-sonnet": 200_000,
+	"claude-haiku":  200_000,
+	"gemini-2.5":    1_000_000,
+	"gemini-2.0":    1_000_000,
+	"llama3.1":      128_000,
+	"llama3":        8_000,
+	"mistral":       32_000,
+	"codellama":     16_000,
+	"deepseek":      64_000,
+	"qwen":          32_000,
+}
+
+const (
+	defaultContextTokens = 128_000
+	charsPerToken        = 4
+	safetyMargin         = 0.85 // use 85% of context window
+)
+
+// ContextBudgetForModel returns the character budget for a given model name.
+// Uses prefix matching against known models, falls back to defaultContextTokens.
+// Prefixes are checked longest-first to avoid e.g. "llama3" matching before "llama3.1".
+func ContextBudgetForModel(model string) int {
+	model = strings.ToLower(model)
+	bestPrefix := ""
+	bestTokens := 0
+	for prefix, tokens := range ModelContextWindows {
+		if strings.HasPrefix(model, prefix) && len(prefix) > len(bestPrefix) {
+			bestPrefix = prefix
+			bestTokens = tokens
+		}
+	}
+	if bestPrefix != "" {
+		return int(float64(bestTokens) * float64(charsPerToken) * safetyMargin)
+	}
+	return defaultContextTokens * charsPerToken // 512K chars
+}
+
 // Memory manages per-task conversation history with token budget tracking.
 type Memory struct {
-	mu           sync.Mutex
-	systemPrompt string
-	messages     []llm.ChatMessage
-	maxChars     int // approximate token budget: 1 token ~ 4 chars
+	mu              sync.Mutex
+	systemPrompt    string
+	messages        []llm.ChatMessage
+	existingSummary string // compacted summary from prior context
+	maxChars        int    // approximate token budget: 1 token ~ 4 chars
 }
 
 // NewMemory creates a Memory with the given system prompt and character budget.
-// If maxChars is 0, a default of 200000 (~50K tokens) is used. The budget must
-// comfortably exceed the per-message truncation cap so that a single tool result
-// plus its surrounding messages fit without triggering aggressive trimming.
-func NewMemory(systemPrompt string, maxChars int) *Memory {
+// If maxChars is 0, the budget is computed from the model name using
+// ContextBudgetForModel. If both maxChars and model are zero/empty, a default
+// of 512K chars (~128K tokens) is used. The budget must comfortably exceed the
+// per-message truncation cap so that a single tool result plus its surrounding
+// messages fit without triggering aggressive trimming.
+func NewMemory(systemPrompt string, maxChars int, model string) *Memory {
 	if maxChars == 0 {
-		maxChars = 200_000
+		if model != "" {
+			maxChars = ContextBudgetForModel(model)
+		} else {
+			maxChars = defaultContextTokens * charsPerToken
+		}
 	}
 	return &Memory{
 		systemPrompt: systemPrompt,
@@ -44,19 +97,33 @@ func (m *Memory) Append(msg llm.ChatMessage) {
 }
 
 // Messages returns the full message list with the system prompt prepended.
+// If an existing summary is present (from compaction), it is appended to the
+// system prompt so the LLM has prior context.
 func (m *Memory) Messages() []llm.ChatMessage {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	msgs := make([]llm.ChatMessage, 0, len(m.messages)+1)
-	if m.systemPrompt != "" {
+	if m.systemPrompt != "" || m.existingSummary != "" {
+		content := m.systemPrompt
+		if m.existingSummary != "" {
+			content += "\n\n## Conversation Summary (prior context)\n" + m.existingSummary
+		}
 		msgs = append(msgs, llm.ChatMessage{
 			Role:    llm.RoleSystem,
-			Content: m.systemPrompt,
+			Content: content,
 		})
 	}
 	msgs = append(msgs, m.messages...)
 	return msgs
+}
+
+// LoadFromStore restores memory state from a persisted SessionData.
+func (m *Memory) LoadFromStore(data *SessionData) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = data.Messages
+	m.existingSummary = data.Summary
 }
 
 // Reset clears the conversation history (keeps the system prompt).
@@ -67,6 +134,9 @@ func (m *Memory) Reset() {
 }
 
 // trim removes oldest messages when the total character count exceeds budget.
+// It first prunes old tool results into compact placeholders (preserving signal),
+// then drops oldest message groups if still over budget.
+//
 // Messages are removed in structural groups to maintain valid sequences:
 //   - An assistant message with tool_calls is always removed together with its
 //     subsequent tool-result messages (they form one atomic group).
@@ -76,6 +146,12 @@ func (m *Memory) Reset() {
 // Trimming stops if removing the next group would leave zero messages,
 // preserving at least the last complete group even if it exceeds the budget.
 func (m *Memory) trim() {
+	// Phase 1: Replace old tool results with placeholders (preserve signal).
+	if m.totalChars() > m.maxChars {
+		m.pruneToolResults()
+	}
+
+	// Phase 2: Drop oldest message groups (existing logic).
 	for m.totalChars() > m.maxChars && len(m.messages) > 1 {
 		// Determine the size of the first message group.
 		end := 1
@@ -98,10 +174,45 @@ func (m *Memory) trim() {
 	}
 }
 
+// pruneToolResults replaces tool result content in older messages with
+// compact placeholders, preserving the fact that a tool was called while
+// reclaiming most of the space. Only prunes the oldest 50% of tool results
+// that exceed 200 chars.
+func (m *Memory) pruneToolResults() {
+	// Find all tool result indices with substantial content.
+	var toolIndices []int
+	for i, msg := range m.messages {
+		if msg.Role == llm.RoleTool && len(msg.Content) > 200 {
+			toolIndices = append(toolIndices, i)
+		}
+	}
+
+	// Prune oldest 50% of large tool results.
+	pruneCount := len(toolIndices) / 2
+	for j := 0; j < pruneCount; j++ {
+		idx := toolIndices[j]
+		name := m.messages[idx].Name
+		origLen := len(m.messages[idx].Content)
+		m.messages[idx].Content = fmt.Sprintf("[Tool result from %s — %d chars, pruned for context space]", name, origLen)
+	}
+}
+
+// toolResultWeightMultiplier weights tool results at 2x in char counting
+// because tool results contain structured data that tokenizes less efficiently.
+const toolResultWeightMultiplier = 2
+
 func (m *Memory) totalChars() int {
 	total := len(m.systemPrompt)
+	if m.existingSummary != "" {
+		total += len(m.existingSummary)
+	}
 	for _, msg := range m.messages {
-		total += len(msg.Content) + len(msg.Role)
+		if msg.Role == llm.RoleTool {
+			// Tool results tokenize less efficiently — weight at 2x.
+			total += (len(msg.Content) + len(msg.Role)) * toolResultWeightMultiplier
+		} else {
+			total += len(msg.Content) + len(msg.Role)
+		}
 		for _, tc := range msg.ToolCalls {
 			total += len(tc.Function.Name) + len(tc.Function.Arguments)
 		}

--- a/forge-core/runtime/memory_compactor.go
+++ b/forge-core/runtime/memory_compactor.go
@@ -1,0 +1,338 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// Default compaction settings.
+const (
+	defaultCharBudget   = 200_000
+	defaultTriggerRatio = 0.6
+	summaryMaxTokens    = 1024
+	summaryTimeout      = 30 * time.Second
+	maxExtractiveChars  = 2000
+)
+
+// MemoryFlusher is the interface for flushing observations to long-term memory.
+// Implemented by memory.Manager.
+type MemoryFlusher interface {
+	AppendDailyLog(ctx context.Context, observation string) error
+}
+
+// CompactorConfig configures a Compactor.
+type CompactorConfig struct {
+	// Client is the LLM client for abstractive summarization. If nil,
+	// only extractive (bullet-point) summarization is used.
+	Client llm.Client
+	// Store persists sessions to disk after compaction. If nil, compaction
+	// still reduces in-memory messages but nothing is flushed.
+	Store *MemoryStore
+	// Logger for compaction events.
+	Logger Logger
+	// CharBudget is the total character budget. Compaction triggers when
+	// totalChars exceeds CharBudget * TriggerRatio. Default: 200,000.
+	CharBudget int
+	// TriggerRatio is the fraction of CharBudget at which compaction fires.
+	// Default: 0.6.
+	TriggerRatio float64
+	// MemoryFlusher flushes key observations to long-term memory before
+	// compaction discards old messages. Optional.
+	MemoryFlusher MemoryFlusher
+}
+
+// Compactor manages memory compaction by summarizing old messages and
+// optionally flushing to disk.
+//
+// Each Memory instance is single-threaded per task execution (the agent loop
+// is sequential), so holding mem.mu during the LLM summarization call is
+// acceptable — no concurrent access occurs.
+type Compactor struct {
+	client        llm.Client
+	store         *MemoryStore
+	logger        Logger
+	charBudget    int
+	triggerRatio  float64
+	memoryFlusher MemoryFlusher
+}
+
+// NewCompactor creates a Compactor from the given config.
+func NewCompactor(cfg CompactorConfig) *Compactor {
+	budget := cfg.CharBudget
+	if budget <= 0 {
+		budget = defaultCharBudget
+	}
+	ratio := cfg.TriggerRatio
+	if ratio <= 0 || ratio >= 1 {
+		ratio = defaultTriggerRatio
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = &nopLogger{}
+	}
+	return &Compactor{
+		client:        cfg.Client,
+		store:         cfg.Store,
+		logger:        logger,
+		charBudget:    budget,
+		triggerRatio:  ratio,
+		memoryFlusher: cfg.MemoryFlusher,
+	}
+}
+
+// SetMemoryFlusher sets the long-term memory flusher. This allows wiring the
+// flusher after construction (e.g., when the memory manager depends on the
+// same embedder resolution that happens after the compactor is created).
+func (c *Compactor) SetMemoryFlusher(f MemoryFlusher) {
+	c.memoryFlusher = f
+}
+
+// MaybeCompact checks whether the memory exceeds the trigger threshold and,
+// if so, compacts the oldest 50% of messages into a summary. Returns true
+// if compaction occurred.
+//
+// The method holds mem.mu for its entire duration including any LLM call.
+// This is safe because each Memory is used by a single sequential agent loop.
+func (c *Compactor) MaybeCompact(taskID string, mem *Memory) (bool, error) {
+	mem.mu.Lock()
+	defer mem.mu.Unlock()
+
+	total := mem.totalChars()
+	threshold := int(float64(c.charBudget) * c.triggerRatio)
+
+	if total <= threshold {
+		return false, nil
+	}
+
+	c.logger.Info("compaction triggered", map[string]any{
+		"task_id":   taskID,
+		"total":     total,
+		"threshold": threshold,
+		"messages":  len(mem.messages),
+	})
+
+	// Take oldest 50% of messages, respecting group boundaries.
+	target := len(mem.messages) / 2
+	splitIdx := c.findGroupBoundary(mem.messages, target)
+	if splitIdx <= 0 || splitIdx >= len(mem.messages) {
+		return false, nil
+	}
+
+	oldMessages := mem.messages[:splitIdx]
+
+	// Flush key observations to long-term memory before discarding.
+	c.flushToLongTermMemory(oldMessages)
+
+	// Summarize the old messages.
+	summary, err := c.summarize(oldMessages, mem.existingSummary)
+	if err != nil {
+		return false, fmt.Errorf("summarization failed: %w", err)
+	}
+
+	// Replace old messages with the summary.
+	mem.messages = mem.messages[splitIdx:]
+	mem.existingSummary = summary
+
+	c.logger.Info("compaction complete", map[string]any{
+		"task_id":       taskID,
+		"removed":       splitIdx,
+		"remaining":     len(mem.messages),
+		"summary_chars": len(summary),
+	})
+
+	// Flush to disk if store is available.
+	c.flushToDisk(taskID, mem)
+
+	return true, nil
+}
+
+// summarize produces a summary of the given messages, incorporating any
+// existing summary. Tries LLM first, falls back to extractive.
+func (c *Compactor) summarize(messages []llm.ChatMessage, existingSummary string) (string, error) {
+	if c.client != nil {
+		summary, err := c.llmSummarize(messages, existingSummary)
+		if err != nil {
+			c.logger.Warn("LLM summarization failed, falling back to extractive", map[string]any{
+				"error": err.Error(),
+			})
+			return c.extractiveSummarize(messages, existingSummary), nil
+		}
+		return summary, nil
+	}
+	return c.extractiveSummarize(messages, existingSummary), nil
+}
+
+// llmSummarize uses the LLM client to produce an abstractive summary.
+func (c *Compactor) llmSummarize(messages []llm.ChatMessage, existingSummary string) (string, error) {
+	// Build the prompt for summarization.
+	var sb strings.Builder
+	sb.WriteString("Summarize the following conversation concisely. ")
+	sb.WriteString("Preserve key facts, decisions, tool results, and action items. ")
+	sb.WriteString("Output only the summary, no preamble.\n\n")
+
+	if existingSummary != "" {
+		sb.WriteString("## Existing Summary (incorporate and update)\n")
+		sb.WriteString(existingSummary)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("## Conversation to summarize\n")
+	for _, msg := range messages {
+		fmt.Fprintf(&sb, "[%s]: %s\n", msg.Role, truncateForPrompt(msg.Content, 500))
+		for _, tc := range msg.ToolCalls {
+			fmt.Fprintf(&sb, "  -> tool_call: %s(%s)\n", tc.Function.Name, truncateForPrompt(tc.Function.Arguments, 200))
+		}
+	}
+
+	temp := 0.3
+	ctx, cancel := context.WithTimeout(context.Background(), summaryTimeout)
+	defer cancel()
+
+	resp, err := c.client.Chat(ctx, &llm.ChatRequest{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: sb.String()},
+		},
+		Temperature: &temp,
+		MaxTokens:   summaryMaxTokens,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Message.Content, nil
+}
+
+// extractiveSummarize builds a bullet-point summary without an LLM.
+func (c *Compactor) extractiveSummarize(messages []llm.ChatMessage, existingSummary string) string {
+	var sb strings.Builder
+
+	if existingSummary != "" {
+		sb.WriteString(existingSummary)
+		sb.WriteString("\n\n")
+	}
+
+	for _, msg := range messages {
+		if msg.Content == "" && len(msg.ToolCalls) == 0 {
+			continue
+		}
+		content := msg.Content
+		if len(content) > maxExtractiveChars {
+			content = content[:maxExtractiveChars] + "..."
+		}
+		if content != "" {
+			fmt.Fprintf(&sb, "- [%s] %s\n", msg.Role, content)
+		}
+		for _, tc := range msg.ToolCalls {
+			fmt.Fprintf(&sb, "- [tool_call] %s\n", tc.Function.Name)
+		}
+	}
+
+	return sb.String()
+}
+
+// findGroupBoundary finds the nearest valid split point at or after target
+// that respects tool-call group boundaries. An assistant message with
+// tool_calls must not be separated from its subsequent tool-result messages.
+func (c *Compactor) findGroupBoundary(messages []llm.ChatMessage, target int) int {
+	if target >= len(messages) {
+		return len(messages)
+	}
+
+	idx := target
+	for idx < len(messages) {
+		// If we're at a tool result, advance past it — splitting here
+		// would orphan it from its assistant message.
+		if messages[idx].Role == llm.RoleTool {
+			idx++
+			continue
+		}
+		return idx
+	}
+	return idx
+}
+
+// flushToDisk persists the current memory state to the store.
+// Errors are logged but not returned — persistence is best-effort.
+func (c *Compactor) flushToDisk(taskID string, mem *Memory) {
+	if c.store == nil {
+		return
+	}
+
+	data := &SessionData{
+		TaskID:   taskID,
+		Messages: mem.messages,
+		Summary:  mem.existingSummary,
+	}
+
+	if err := c.store.Save(data); err != nil {
+		c.logger.Warn("failed to flush session to disk", map[string]any{
+			"task_id": taskID,
+			"error":   err.Error(),
+		})
+	}
+}
+
+// flushToLongTermMemory extracts key observations from messages being
+// compacted and appends them to the long-term daily log.
+func (c *Compactor) flushToLongTermMemory(messages []llm.ChatMessage) {
+	if c.memoryFlusher == nil {
+		return
+	}
+
+	var observations strings.Builder
+	for _, msg := range messages {
+		switch msg.Role {
+		case llm.RoleTool:
+			// Tool results contain factual observations worth preserving.
+			content := msg.Content
+			if len(content) > maxExtractiveChars {
+				content = content[:maxExtractiveChars] + "..."
+			}
+			if content != "" {
+				fmt.Fprintf(&observations, "- [tool:%s] %s\n", msg.Name, content)
+			}
+		case llm.RoleAssistant:
+			// Capture key decisions from assistant responses.
+			if msg.Content != "" && len(msg.ToolCalls) == 0 {
+				content := msg.Content
+				if len(content) > maxExtractiveChars {
+					content = content[:maxExtractiveChars] + "..."
+				}
+				fmt.Fprintf(&observations, "- [decision] %s\n", content)
+			}
+		}
+	}
+
+	if observations.Len() == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := c.memoryFlusher.AppendDailyLog(ctx, observations.String()); err != nil {
+		c.logger.Warn("failed to flush observations to long-term memory", map[string]any{
+			"error": err.Error(),
+		})
+	}
+}
+
+// truncateForPrompt truncates a string to maxLen for use in prompts.
+func truncateForPrompt(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// nopLogger is a no-op Logger used when no logger is provided.
+type nopLogger struct{}
+
+func (n *nopLogger) Info(_ string, _ map[string]any)  {}
+func (n *nopLogger) Warn(_ string, _ map[string]any)  {}
+func (n *nopLogger) Error(_ string, _ map[string]any) {}
+func (n *nopLogger) Debug(_ string, _ map[string]any) {}

--- a/forge-core/runtime/memory_compactor_test.go
+++ b/forge-core/runtime/memory_compactor_test.go
@@ -1,0 +1,401 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+func TestCompactorBelowThreshold(t *testing.T) {
+	c := NewCompactor(CompactorConfig{
+		CharBudget:   200_000,
+		TriggerRatio: 0.6,
+	})
+
+	mem := NewMemory("system", 0, "")
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: "short message"})
+
+	compacted, err := c.MaybeCompact("task-1", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if compacted {
+		t.Error("should not compact when below threshold")
+	}
+}
+
+func TestCompactorAboveThreshold(t *testing.T) {
+	// Use a very small budget so compaction triggers easily
+	c := NewCompactor(CompactorConfig{
+		CharBudget:   200,
+		TriggerRatio: 0.6,
+	})
+
+	mem := NewMemory("", 0, "") // no system prompt to keep char count predictable
+	// Add enough messages to exceed 120 chars (200 * 0.6)
+	for i := 0; i < 10; i++ {
+		mem.Append(llm.ChatMessage{
+			Role:    llm.RoleUser,
+			Content: fmt.Sprintf("message number %d with some content", i),
+		})
+	}
+
+	msgsBefore := len(mem.Messages())
+
+	compacted, err := c.MaybeCompact("task-2", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if !compacted {
+		t.Error("should compact when above threshold")
+	}
+
+	msgsAfter := len(mem.Messages())
+	if msgsAfter >= msgsBefore {
+		t.Errorf("message count should decrease after compaction: before=%d, after=%d", msgsBefore, msgsAfter)
+	}
+
+	// Verify summary is set
+	msgs := mem.Messages()
+	if len(msgs) > 0 && msgs[0].Role == llm.RoleSystem {
+		if !strings.Contains(msgs[0].Content, "Conversation Summary") {
+			t.Error("system message should contain summary after compaction")
+		}
+	}
+}
+
+func TestCompactorGroupBoundary(t *testing.T) {
+	c := NewCompactor(CompactorConfig{
+		CharBudget:   300,
+		TriggerRatio: 0.5,
+	})
+
+	mem := NewMemory("", 0, "")
+	// Create a sequence: user, assistant+tool_calls, tool, user, assistant
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: strings.Repeat("a", 50)})
+	mem.Append(llm.ChatMessage{
+		Role:    llm.RoleAssistant,
+		Content: "",
+		ToolCalls: []llm.ToolCall{
+			{ID: "call_1", Type: "function", Function: llm.FunctionCall{Name: "test", Arguments: "{}"}},
+		},
+	})
+	mem.Append(llm.ChatMessage{
+		Role:       llm.RoleTool,
+		Content:    strings.Repeat("b", 50),
+		ToolCallID: "call_1",
+		Name:       "test",
+	})
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: strings.Repeat("c", 50)})
+	mem.Append(llm.ChatMessage{Role: llm.RoleAssistant, Content: strings.Repeat("d", 50)})
+
+	compacted, err := c.MaybeCompact("task-3", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if !compacted {
+		t.Error("should compact")
+	}
+
+	// After compaction, remaining messages should not start with a tool result
+	mem.mu.Lock()
+	if len(mem.messages) > 0 && mem.messages[0].Role == llm.RoleTool {
+		t.Error("compaction should not orphan tool results")
+	}
+	mem.mu.Unlock()
+}
+
+func TestCompactorExtractiveSummarize(t *testing.T) {
+	c := NewCompactor(CompactorConfig{}) // no LLM client
+
+	messages := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "What is 2+2?"},
+		{Role: llm.RoleAssistant, Content: "2+2 equals 4."},
+	}
+
+	summary := c.extractiveSummarize(messages, "")
+	if summary == "" {
+		t.Fatal("extractive summary should not be empty")
+	}
+	if !strings.Contains(summary, "[user]") {
+		t.Error("summary should contain role markers")
+	}
+	if !strings.Contains(summary, "What is 2+2?") {
+		t.Error("summary should contain message content")
+	}
+}
+
+func TestCompactorExtractiveSummarizeWithExisting(t *testing.T) {
+	c := NewCompactor(CompactorConfig{})
+
+	messages := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "new question"},
+	}
+
+	summary := c.extractiveSummarize(messages, "previous summary here")
+	if !strings.Contains(summary, "previous summary here") {
+		t.Error("should incorporate existing summary")
+	}
+	if !strings.Contains(summary, "new question") {
+		t.Error("should include new messages")
+	}
+}
+
+func TestCompactorLLMSummarize(t *testing.T) {
+	client := &mockLLMClient{
+		chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			return &llm.ChatResponse{
+				Message: llm.ChatMessage{
+					Role:    llm.RoleAssistant,
+					Content: "Summary: user asked about math, agent answered 4.",
+				},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+
+	c := NewCompactor(CompactorConfig{
+		Client: client,
+	})
+
+	messages := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "What is 2+2?"},
+		{Role: llm.RoleAssistant, Content: "2+2 equals 4."},
+	}
+
+	summary, err := c.llmSummarize(messages, "")
+	if err != nil {
+		t.Fatalf("llmSummarize: %v", err)
+	}
+	if !strings.Contains(summary, "Summary") {
+		t.Errorf("unexpected summary: %q", summary)
+	}
+}
+
+func TestCompactorLLMFailureFallback(t *testing.T) {
+	client := &mockLLMClient{
+		chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			return nil, fmt.Errorf("API error")
+		},
+	}
+
+	c := NewCompactor(CompactorConfig{
+		Client: client,
+	})
+
+	messages := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "What is 2+2?"},
+		{Role: llm.RoleAssistant, Content: "4"},
+	}
+
+	summary, err := c.summarize(messages, "")
+	if err != nil {
+		t.Fatalf("summarize should not error on LLM failure: %v", err)
+	}
+	if summary == "" {
+		t.Error("should fall back to extractive summary")
+	}
+	// Should be extractive format
+	if !strings.Contains(summary, "[user]") {
+		t.Error("fallback summary should use extractive format")
+	}
+}
+
+func TestCompactorFlushToDisk(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	c := NewCompactor(CompactorConfig{
+		Store:        store,
+		CharBudget:   200,
+		TriggerRatio: 0.5,
+	})
+
+	mem := NewMemory("", 0, "")
+	for i := 0; i < 10; i++ {
+		mem.Append(llm.ChatMessage{
+			Role:    llm.RoleUser,
+			Content: fmt.Sprintf("message %d with enough content to trigger compaction", i),
+		})
+	}
+
+	compacted, err := c.MaybeCompact("flush-test", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected compaction to trigger")
+	}
+
+	// Verify session was persisted
+	loaded, err := store.Load("flush-test")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("session should be persisted after compaction")
+	}
+	if loaded.Summary == "" {
+		t.Error("persisted session should have a summary")
+	}
+}
+
+func TestCompactorNoStore(t *testing.T) {
+	// Compaction without a store should still work (summary in memory only).
+	c := NewCompactor(CompactorConfig{
+		CharBudget:   200,
+		TriggerRatio: 0.5,
+	})
+
+	mem := NewMemory("", 0, "")
+	for i := 0; i < 10; i++ {
+		mem.Append(llm.ChatMessage{
+			Role:    llm.RoleUser,
+			Content: fmt.Sprintf("message %d with enough content to trigger compaction", i),
+		})
+	}
+
+	compacted, err := c.MaybeCompact("no-store", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if !compacted {
+		t.Error("compaction should work without a store")
+	}
+
+	// Summary should be in memory
+	mem.mu.Lock()
+	hasSummary := mem.existingSummary != ""
+	mem.mu.Unlock()
+	if !hasSummary {
+		t.Error("in-memory summary should be set even without a store")
+	}
+}
+
+func TestCompactorMemoryFlusher(t *testing.T) {
+	// Mock flusher that captures observations.
+	flusher := &mockMemoryFlusher{}
+
+	c := NewCompactor(CompactorConfig{
+		CharBudget:    200,
+		TriggerRatio:  0.5,
+		MemoryFlusher: flusher,
+	})
+
+	mem := NewMemory("", 0, "")
+	// Add messages with tool results that should be captured.
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: "Search for Go docs"})
+	mem.Append(llm.ChatMessage{
+		Role:    llm.RoleAssistant,
+		Content: "",
+		ToolCalls: []llm.ToolCall{
+			{ID: "call_1", Type: "function", Function: llm.FunctionCall{Name: "search", Arguments: "{}"}},
+		},
+	})
+	mem.Append(llm.ChatMessage{
+		Role:       llm.RoleTool,
+		Content:    "Found Go documentation at golang.org",
+		ToolCallID: "call_1",
+		Name:       "search",
+	})
+	mem.Append(llm.ChatMessage{Role: llm.RoleAssistant, Content: "I found the Go docs for you."})
+	// More padding to trigger compaction.
+	for i := range 5 {
+		mem.Append(llm.ChatMessage{
+			Role:    llm.RoleUser,
+			Content: fmt.Sprintf("padding message %d with enough content", i),
+		})
+	}
+
+	compacted, err := c.MaybeCompact("flusher-test", mem)
+	if err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected compaction")
+	}
+
+	// Flusher should have received observations.
+	if flusher.observation == "" {
+		t.Error("memory flusher should receive observations during compaction")
+	}
+	if !strings.Contains(flusher.observation, "search") {
+		t.Errorf("observations should include tool results, got: %s", flusher.observation)
+	}
+}
+
+func TestCompactorSetMemoryFlusher(t *testing.T) {
+	c := NewCompactor(CompactorConfig{})
+
+	if c.memoryFlusher != nil {
+		t.Error("flusher should be nil initially")
+	}
+
+	flusher := &mockMemoryFlusher{}
+	c.SetMemoryFlusher(flusher)
+
+	if c.memoryFlusher == nil {
+		t.Error("flusher should be set after SetMemoryFlusher")
+	}
+}
+
+type mockMemoryFlusher struct {
+	observation string
+}
+
+func (m *mockMemoryFlusher) AppendDailyLog(_ context.Context, observation string) error {
+	m.observation = observation
+	return nil
+}
+
+func TestFindGroupBoundary(t *testing.T) {
+	c := NewCompactor(CompactorConfig{})
+
+	messages := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "q1"},
+		{Role: llm.RoleAssistant, Content: "", ToolCalls: []llm.ToolCall{{ID: "c1"}}},
+		{Role: llm.RoleTool, Content: "result1", ToolCallID: "c1"},
+		{Role: llm.RoleUser, Content: "q2"},
+		{Role: llm.RoleAssistant, Content: "answer"},
+	}
+
+	// Target index 2 (tool result) should advance to 3 (next user msg)
+	idx := c.findGroupBoundary(messages, 2)
+	if idx != 3 {
+		t.Errorf("expected boundary at 3, got %d", idx)
+	}
+
+	// Target index 3 (user msg) should stay at 3
+	idx = c.findGroupBoundary(messages, 3)
+	if idx != 3 {
+		t.Errorf("expected boundary at 3, got %d", idx)
+	}
+
+	// Target index 0 should stay at 0 (user msg)
+	idx = c.findGroupBoundary(messages, 0)
+	if idx != 0 {
+		t.Errorf("expected boundary at 0, got %d", idx)
+	}
+}
+
+func TestTruncateForPrompt(t *testing.T) {
+	short := "hello"
+	if got := truncateForPrompt(short, 10); got != short {
+		t.Errorf("short string should not be truncated: got %q", got)
+	}
+
+	long := strings.Repeat("x", 100)
+	got := truncateForPrompt(long, 10)
+	if len(got) != 13 { // 10 + len("...")
+		t.Errorf("expected length 13, got %d", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Error("truncated string should end with ...")
+	}
+}

--- a/forge-core/runtime/memory_store.go
+++ b/forge-core/runtime/memory_store.go
@@ -1,0 +1,202 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// SessionData holds the persisted state for a single task's conversation.
+type SessionData struct {
+	TaskID    string            `json:"task_id"`
+	Messages  []llm.ChatMessage `json:"messages"`
+	Summary   string            `json:"summary,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
+}
+
+// MemoryStore provides file-backed session persistence.
+// Each session is stored as a JSON file in the configured directory.
+type MemoryStore struct {
+	dir string
+	mu  sync.RWMutex
+}
+
+// sanitizeRe matches characters unsafe for filenames.
+var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9_\-.]`)
+
+// NewMemoryStore creates a MemoryStore backed by the given directory.
+// The directory is created if it does not exist.
+func NewMemoryStore(dir string) (*MemoryStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating sessions dir: %w", err)
+	}
+	return &MemoryStore{dir: dir}, nil
+}
+
+// Save persists a SessionData to disk using atomic write (temp+fsync+rename).
+// On the first write for a task, CreatedAt is set to now. On subsequent writes,
+// the original CreatedAt is preserved from the existing file.
+func (s *MemoryStore) Save(data *SessionData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fname := s.filename(data.TaskID)
+
+	// Preserve CreatedAt from existing file if present.
+	if data.CreatedAt.IsZero() {
+		existing, _ := s.loadLocked(data.TaskID)
+		if existing != nil && !existing.CreatedAt.IsZero() {
+			data.CreatedAt = existing.CreatedAt
+		} else {
+			data.CreatedAt = time.Now().UTC()
+		}
+	}
+	data.UpdatedAt = time.Now().UTC()
+
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling session data: %w", err)
+	}
+
+	// Atomic write: write to temp file, fsync, rename.
+	tmpFile := fname + ".tmp"
+	f, err := os.Create(tmpFile)
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+
+	if _, err := f.Write(raw); err != nil {
+		f.Close()          //nolint:errcheck
+		os.Remove(tmpFile) //nolint:errcheck
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()          //nolint:errcheck
+		os.Remove(tmpFile) //nolint:errcheck
+		return fmt.Errorf("syncing temp file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(tmpFile) //nolint:errcheck
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile, fname); err != nil {
+		os.Remove(tmpFile) //nolint:errcheck
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	return nil
+}
+
+// Load reads a SessionData from disk. Returns (nil, nil) if the session file
+// does not exist.
+func (s *MemoryStore) Load(taskID string) (*SessionData, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.loadLocked(taskID)
+}
+
+// loadLocked reads a session file without acquiring locks (caller must hold lock).
+func (s *MemoryStore) loadLocked(taskID string) (*SessionData, error) {
+	fname := s.filename(taskID)
+	raw, err := os.ReadFile(fname)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading session file: %w", err)
+	}
+
+	var data SessionData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("unmarshaling session data: %w", err)
+	}
+	return &data, nil
+}
+
+// List returns all session task IDs stored on disk.
+func (s *MemoryStore) List() ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	matches, err := filepath.Glob(filepath.Join(s.dir, "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		base := filepath.Base(m)
+		id := strings.TrimSuffix(base, ".json")
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// Delete removes a session file from disk.
+func (s *MemoryStore) Delete(taskID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fname := s.filename(taskID)
+	if err := os.Remove(fname); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("deleting session file: %w", err)
+	}
+	return nil
+}
+
+// Cleanup removes sessions older than maxAge based on their UpdatedAt timestamp.
+// Returns the number of sessions deleted.
+func (s *MemoryStore) Cleanup(maxAge time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	matches, err := filepath.Glob(filepath.Join(s.dir, "*.json"))
+	if err != nil {
+		return 0, fmt.Errorf("listing sessions for cleanup: %w", err)
+	}
+
+	cutoff := time.Now().UTC().Add(-maxAge)
+	deleted := 0
+
+	for _, m := range matches {
+		raw, err := os.ReadFile(m)
+		if err != nil {
+			continue
+		}
+
+		var data SessionData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			continue
+		}
+
+		if !data.UpdatedAt.IsZero() && data.UpdatedAt.Before(cutoff) {
+			if err := os.Remove(m); err == nil {
+				deleted++
+			}
+		}
+	}
+
+	return deleted, nil
+}
+
+// filename returns the file path for a given task ID.
+func (s *MemoryStore) filename(taskID string) string {
+	safe := sanitizeTaskID(taskID)
+	return filepath.Join(s.dir, safe+".json")
+}
+
+// sanitizeTaskID replaces characters unsafe for filenames.
+func sanitizeTaskID(id string) string {
+	return sanitizeRe.ReplaceAllString(id, "_")
+}

--- a/forge-core/runtime/memory_store_test.go
+++ b/forge-core/runtime/memory_store_test.go
@@ -1,0 +1,317 @@
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+func TestMemoryStoreSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	data := &SessionData{
+		TaskID: "task-1",
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "hello"},
+			{Role: llm.RoleAssistant, Content: "hi there"},
+		},
+		Summary: "greeting exchange",
+	}
+
+	if err := store.Save(data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load("task-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil for existing session")
+	}
+
+	if loaded.TaskID != "task-1" {
+		t.Errorf("expected task ID 'task-1', got %q", loaded.TaskID)
+	}
+	if len(loaded.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(loaded.Messages))
+	}
+	if loaded.Summary != "greeting exchange" {
+		t.Errorf("expected summary 'greeting exchange', got %q", loaded.Summary)
+	}
+	if loaded.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+	if loaded.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should be set")
+	}
+}
+
+func TestMemoryStoreLoadNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	loaded, err := store.Load("nonexistent")
+	if err != nil {
+		t.Fatalf("Load should not error for missing session: %v", err)
+	}
+	if loaded != nil {
+		t.Error("Load should return nil for missing session")
+	}
+}
+
+func TestMemoryStoreList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	// Save two sessions
+	for _, id := range []string{"task-a", "task-b"} {
+		if err := store.Save(&SessionData{
+			TaskID:   id,
+			Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "hi"}},
+		}); err != nil {
+			t.Fatalf("Save(%s): %v", id, err)
+		}
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("expected 2 session IDs, got %d", len(ids))
+	}
+
+	// Check both IDs are present
+	found := map[string]bool{}
+	for _, id := range ids {
+		found[id] = true
+	}
+	if !found["task-a"] || !found["task-b"] {
+		t.Errorf("expected task-a and task-b, got %v", ids)
+	}
+}
+
+func TestMemoryStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	if err := store.Save(&SessionData{
+		TaskID:   "task-del",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "bye"}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := store.Delete("task-del"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	loaded, err := store.Load("task-del")
+	if err != nil {
+		t.Fatalf("Load after delete: %v", err)
+	}
+	if loaded != nil {
+		t.Error("session should be deleted")
+	}
+}
+
+func TestMemoryStoreCleanup(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	// Write an old session file directly (Save always sets UpdatedAt to now).
+	oldData := &SessionData{
+		TaskID:    "old-task",
+		Messages:  []llm.ChatMessage{{Role: llm.RoleUser, Content: "old"}},
+		CreatedAt: time.Now().UTC().Add(-10 * 24 * time.Hour),
+		UpdatedAt: time.Now().UTC().Add(-10 * 24 * time.Hour),
+	}
+	raw, _ := json.Marshal(oldData)
+	if err := os.WriteFile(filepath.Join(dir, "old-task.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile old: %v", err)
+	}
+
+	// Save a recent session
+	recent := &SessionData{
+		TaskID:   "recent-task",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "new"}},
+	}
+	if err := store.Save(recent); err != nil {
+		t.Fatalf("Save recent: %v", err)
+	}
+
+	// Cleanup with 7-day TTL
+	deleted, err := store.Cleanup(7 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+
+	// Old should be gone, recent should remain
+	oldLoaded, _ := store.Load("old-task")
+	if oldLoaded != nil {
+		t.Error("old session should be cleaned up")
+	}
+
+	recentLoaded, _ := store.Load("recent-task")
+	if recentLoaded == nil {
+		t.Error("recent session should not be cleaned up")
+	}
+}
+
+func TestMemoryStoreAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	if err := store.Save(&SessionData{
+		TaskID:   "atomic-test",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "test"}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify no .tmp file remains
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.tmp"))
+	if len(matches) > 0 {
+		t.Errorf("temp file should be cleaned up, found: %v", matches)
+	}
+
+	// Verify the final file exists
+	matches, _ = filepath.Glob(filepath.Join(dir, "*.json"))
+	if len(matches) != 1 {
+		t.Errorf("expected 1 json file, got %d", len(matches))
+	}
+}
+
+func TestMemoryStoreConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			data := &SessionData{
+				TaskID:   "concurrent-task",
+				Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "msg"}},
+			}
+			_ = store.Save(data)
+			_, _ = store.Load("concurrent-task")
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify the file is valid after concurrent writes
+	loaded, err := store.Load("concurrent-task")
+	if err != nil {
+		t.Fatalf("Load after concurrent writes: %v", err)
+	}
+	if loaded == nil {
+		t.Error("session should exist after concurrent writes")
+	}
+}
+
+func TestMemoryStoreSanitizeTaskID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	// Task ID with special characters
+	data := &SessionData{
+		TaskID:   "task/with:special chars!",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "test"}},
+	}
+	if err := store.Save(data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load("task/with:special chars!")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Error("should be able to load session with special chars in ID")
+	}
+
+	// Verify no special characters in filename
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == ".tmp" {
+			continue
+		}
+		name := e.Name()
+		for _, c := range name {
+			if c == '/' || c == ':' || c == '!' || c == ' ' {
+				t.Errorf("filename contains unsafe character %q: %s", string(c), name)
+			}
+		}
+	}
+}
+
+func TestMemoryStorePreservesCreatedAt(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewMemoryStore(dir)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	// First save
+	if err := store.Save(&SessionData{
+		TaskID:   "created-at-test",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "first"}},
+	}); err != nil {
+		t.Fatalf("Save 1: %v", err)
+	}
+
+	first, _ := store.Load("created-at-test")
+	originalCreatedAt := first.CreatedAt
+
+	// Second save — CreatedAt should be preserved
+	if err := store.Save(&SessionData{
+		TaskID:   "created-at-test",
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: "second"}},
+	}); err != nil {
+		t.Fatalf("Save 2: %v", err)
+	}
+
+	second, _ := store.Load("created-at-test")
+	if !second.CreatedAt.Equal(originalCreatedAt) {
+		t.Errorf("CreatedAt changed: was %v, now %v", originalCreatedAt, second.CreatedAt)
+	}
+	if second.Messages[0].Content != "second" {
+		t.Error("Messages should be updated")
+	}
+}

--- a/forge-core/runtime/memory_test.go
+++ b/forge-core/runtime/memory_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestAppendTruncatesOversizedMessage(t *testing.T) {
-	mem := NewMemory("system prompt", 0)
+	mem := NewMemory("system prompt", 0, "")
 
 	largeContent := strings.Repeat("a", 60_000)
 	mem.Append(llm.ChatMessage{
@@ -39,7 +40,7 @@ func TestAppendTruncatesOversizedMessage(t *testing.T) {
 }
 
 func TestAppendDoesNotTruncateSmallMessage(t *testing.T) {
-	mem := NewMemory("system prompt", 0)
+	mem := NewMemory("system prompt", 0, "")
 
 	content := "hello world"
 	mem.Append(llm.ChatMessage{
@@ -58,7 +59,7 @@ func TestAppendDoesNotTruncateSmallMessage(t *testing.T) {
 }
 
 func TestAppendMessageAtExactLimit(t *testing.T) {
-	mem := NewMemory("", 0)
+	mem := NewMemory("", 0, "")
 
 	content := strings.Repeat("b", maxMessageChars)
 	mem.Append(llm.ChatMessage{
@@ -74,7 +75,7 @@ func TestAppendMessageAtExactLimit(t *testing.T) {
 
 func TestTrimRemovesOldMessages(t *testing.T) {
 	// Use a small budget to force trimming
-	mem := NewMemory("", 100)
+	mem := NewMemory("", 100, "")
 
 	// Add messages that exceed the budget
 	for i := 0; i < 10; i++ {
@@ -99,7 +100,7 @@ func TestTrimRemovesOldMessages(t *testing.T) {
 
 func TestTrimAlwaysKeepsLastMessage(t *testing.T) {
 	// Budget smaller than a single message
-	mem := NewMemory("", 10)
+	mem := NewMemory("", 10, "")
 
 	mem.Append(llm.ChatMessage{
 		Role:    llm.RoleUser,
@@ -117,7 +118,7 @@ func TestTrimNeverOrphansToolResults(t *testing.T) {
 	// Use a small budget that will force trimming when the tool result is added.
 	// The sequence is: [user, assistant+tool_calls, tool_result]
 	// Trimming must not leave tool_result at the front without its assistant.
-	mem := NewMemory("", 200)
+	mem := NewMemory("", 200, "")
 
 	mem.Append(llm.ChatMessage{
 		Role:    llm.RoleUser,
@@ -147,7 +148,7 @@ func TestTrimNeverOrphansToolResults(t *testing.T) {
 func TestTrimKeepsAssistantToolPairWhenBudgetAllows(t *testing.T) {
 	// Budget large enough to hold assistant+tool_result but not user+assistant+tool
 	// This verifies we trim the user but keep the assistant→tool pair intact.
-	mem := NewMemory("", 500)
+	mem := NewMemory("", 500, "")
 
 	mem.Append(llm.ChatMessage{
 		Role:    llm.RoleUser,
@@ -185,8 +186,81 @@ func TestTrimKeepsAssistantToolPairWhenBudgetAllows(t *testing.T) {
 	}
 }
 
+func TestMemoryLoadFromStore(t *testing.T) {
+	mem := NewMemory("system prompt", 0, "")
+
+	data := &SessionData{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "restored message"},
+			{Role: llm.RoleAssistant, Content: "restored reply"},
+		},
+		Summary: "prior context summary",
+	}
+
+	mem.LoadFromStore(data)
+
+	msgs := mem.Messages()
+	// Should have: system + 2 restored messages
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	if msgs[1].Content != "restored message" {
+		t.Errorf("expected restored message, got %q", msgs[1].Content)
+	}
+	if msgs[2].Content != "restored reply" {
+		t.Errorf("expected restored reply, got %q", msgs[2].Content)
+	}
+}
+
+func TestMemorySummaryInjectedInMessages(t *testing.T) {
+	mem := NewMemory("You are a helpful agent.", 0, "")
+
+	// Set summary via LoadFromStore
+	data := &SessionData{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "new message"},
+		},
+		Summary: "User asked about weather. Agent provided forecast.",
+	}
+	mem.LoadFromStore(data)
+
+	msgs := mem.Messages()
+	if len(msgs) < 1 {
+		t.Fatal("expected at least system message")
+	}
+
+	system := msgs[0]
+	if system.Role != llm.RoleSystem {
+		t.Fatalf("expected system role, got %s", system.Role)
+	}
+	if !strings.Contains(system.Content, "You are a helpful agent.") {
+		t.Error("system prompt should be preserved")
+	}
+	if !strings.Contains(system.Content, "Conversation Summary (prior context)") {
+		t.Error("summary header should be in system prompt")
+	}
+	if !strings.Contains(system.Content, "User asked about weather") {
+		t.Error("summary content should be in system prompt")
+	}
+}
+
+func TestMemoryEmptySummaryNotInjected(t *testing.T) {
+	mem := NewMemory("base prompt", 0, "")
+
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: "hello"})
+
+	msgs := mem.Messages()
+	system := msgs[0]
+	if strings.Contains(system.Content, "Conversation Summary") {
+		t.Error("empty summary should not inject summary header")
+	}
+	if system.Content != "base prompt" {
+		t.Errorf("expected 'base prompt', got %q", system.Content)
+	}
+}
+
 func TestMemoryReset(t *testing.T) {
-	mem := NewMemory("system", 0)
+	mem := NewMemory("system", 0, "")
 
 	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: "hi"})
 	mem.Append(llm.ChatMessage{Role: llm.RoleAssistant, Content: "hello"})
@@ -200,5 +274,175 @@ func TestMemoryReset(t *testing.T) {
 	}
 	if msgs[0].Role != llm.RoleSystem {
 		t.Errorf("expected system message, got role %s", msgs[0].Role)
+	}
+}
+
+func TestContextBudgetForModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected int
+	}{
+		{"llama3", int(float64(8_000) * 4 * 0.85)},               // 27,200
+		{"llama3.1", int(float64(128_000) * 4 * 0.85)},           // 435,200
+		{"llama3.1:8b", int(float64(128_000) * 4 * 0.85)},        // prefix match
+		{"gpt-4o", int(float64(128_000) * 4 * 0.85)},             // 435,200
+		{"gpt-4o-mini", int(float64(128_000) * 4 * 0.85)},        // prefix match
+		{"claude-sonnet-4", int(float64(200_000) * 4 * 0.85)},    // 680,000
+		{"gemini-2.5-flash", int(float64(1_000_000) * 4 * 0.85)}, // 3,400,000
+		{"unknown-model", defaultContextTokens * charsPerToken},  // fallback
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := ContextBudgetForModel(tt.model)
+			if got != tt.expected {
+				t.Errorf("ContextBudgetForModel(%q) = %d, want %d", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContextBudgetLlama3VsLlama31(t *testing.T) {
+	// Ensure llama3.1 doesn't match as llama3 (longest prefix wins).
+	budget3 := ContextBudgetForModel("llama3")
+	budget31 := ContextBudgetForModel("llama3.1")
+	if budget3 == budget31 {
+		t.Errorf("llama3 and llama3.1 should have different budgets: %d vs %d", budget3, budget31)
+	}
+	if budget3 >= budget31 {
+		t.Errorf("llama3 budget (%d) should be smaller than llama3.1 (%d)", budget3, budget31)
+	}
+}
+
+func TestNewMemoryModelAware(t *testing.T) {
+	// With model name and zero maxChars, budget should come from model lookup.
+	mem := NewMemory("prompt", 0, "llama3")
+	expected := ContextBudgetForModel("llama3")
+	if mem.maxChars != expected {
+		t.Errorf("expected maxChars=%d for llama3, got %d", expected, mem.maxChars)
+	}
+
+	// Explicit maxChars should override model-based budget.
+	mem2 := NewMemory("prompt", 1000, "llama3")
+	if mem2.maxChars != 1000 {
+		t.Errorf("expected maxChars=1000 with explicit override, got %d", mem2.maxChars)
+	}
+
+	// No model and zero maxChars should use default.
+	mem3 := NewMemory("prompt", 0, "")
+	if mem3.maxChars != defaultContextTokens*charsPerToken {
+		t.Errorf("expected default maxChars=%d, got %d", defaultContextTokens*charsPerToken, mem3.maxChars)
+	}
+}
+
+func TestWeightedTotalChars(t *testing.T) {
+	mem := NewMemory("", 0, "")
+
+	// Add a regular user message
+	mem.Append(llm.ChatMessage{
+		Role:    llm.RoleUser,
+		Content: "hello",
+	})
+
+	mem.mu.Lock()
+	charsWithUser := mem.totalChars()
+	mem.mu.Unlock()
+
+	// Now add a tool result with the same content length
+	mem.Append(llm.ChatMessage{
+		Role:    llm.RoleTool,
+		Content: "hello",
+		Name:    "test_tool",
+	})
+
+	mem.mu.Lock()
+	charsWithTool := mem.totalChars()
+	mem.mu.Unlock()
+
+	// The tool message should contribute more than the user message
+	// because of the 2x weight multiplier.
+	toolContribution := charsWithTool - charsWithUser
+	// Tool content "hello" (5) + role "tool" (4) = 9, weighted 2x = 18
+	expectedToolContribution := (len("hello") + len(llm.RoleTool)) * toolResultWeightMultiplier
+	if toolContribution != expectedToolContribution {
+		t.Errorf("tool result contribution = %d, want %d (2x weighted)", toolContribution, expectedToolContribution)
+	}
+}
+
+func TestPruneToolResults(t *testing.T) {
+	// Use a large budget so trim() doesn't drop messages, only prune is tested.
+	mem := NewMemory("", 100_000, "")
+
+	// Add several tool results — some large, some small.
+	for i := 0; i < 6; i++ {
+		mem.mu.Lock()
+		mem.messages = append(mem.messages, llm.ChatMessage{
+			Role:    llm.RoleTool,
+			Content: strings.Repeat("x", 500),
+			Name:    fmt.Sprintf("tool_%d", i),
+		})
+		mem.mu.Unlock()
+	}
+	// Add a small tool result that should not be pruned (< 200 chars).
+	mem.mu.Lock()
+	mem.messages = append(mem.messages, llm.ChatMessage{
+		Role:    llm.RoleTool,
+		Content: "small",
+		Name:    "tiny_tool",
+	})
+	mem.mu.Unlock()
+
+	mem.mu.Lock()
+	mem.pruneToolResults()
+
+	// 6 large tool results → oldest 3 should be pruned.
+	prunedCount := 0
+	for _, msg := range mem.messages {
+		if msg.Role == llm.RoleTool && strings.Contains(msg.Content, "pruned for context space") {
+			prunedCount++
+		}
+	}
+	mem.mu.Unlock()
+
+	if prunedCount != 3 {
+		t.Errorf("expected 3 pruned tool results, got %d", prunedCount)
+	}
+}
+
+func TestPruneBeforeDropInTrim(t *testing.T) {
+	// Budget tight enough that pruning alone reclaims enough space.
+	// We verify that after trim, pruned placeholders exist (phase 1 ran)
+	// but messages were not dropped (phase 2 was not needed).
+	mem := NewMemory("", 5000, "")
+
+	// Add user message + 4 large tool results.
+	mem.mu.Lock()
+	mem.messages = append(mem.messages, llm.ChatMessage{
+		Role: llm.RoleUser, Content: "query",
+	})
+	for i := 0; i < 4; i++ {
+		mem.messages = append(mem.messages, llm.ChatMessage{
+			Role:    llm.RoleTool,
+			Content: strings.Repeat("d", 1000),
+			Name:    fmt.Sprintf("tool_%d", i),
+		})
+	}
+	mem.mu.Unlock()
+
+	// Trigger trim via Append (adds another small message).
+	mem.Append(llm.ChatMessage{Role: llm.RoleUser, Content: "follow-up"})
+
+	mem.mu.Lock()
+	hasPruned := false
+	for _, msg := range mem.messages {
+		if strings.Contains(msg.Content, "pruned for context space") {
+			hasPruned = true
+			break
+		}
+	}
+	mem.mu.Unlock()
+
+	if !hasPruned {
+		t.Error("expected pruning to have replaced some tool results with placeholders")
 	}
 }

--- a/forge-core/tools/builtins/memory_get.go
+++ b/forge-core/tools/builtins/memory_get.go
@@ -1,0 +1,59 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/initializ/forge/forge-core/memory"
+	"github.com/initializ/forge/forge-core/tools"
+)
+
+type memoryGetTool struct {
+	mgr *memory.Manager
+}
+
+// NewMemoryGetTool creates a memory_get tool backed by a Manager.
+// This tool is registered conditionally (not via All()) since it needs
+// a Manager instance.
+func NewMemoryGetTool(mgr *memory.Manager) tools.Tool {
+	return &memoryGetTool{mgr: mgr}
+}
+
+type memoryGetInput struct {
+	Path string `json:"path"`
+}
+
+func (t *memoryGetTool) Name() string { return "memory_get" }
+func (t *memoryGetTool) Description() string {
+	return "Read a specific memory file (e.g. MEMORY.md for curated facts, or a daily log like 2026-02-25.md)"
+}
+func (t *memoryGetTool) Category() tools.Category { return tools.CategoryBuiltin }
+
+func (t *memoryGetTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path": {"type": "string", "description": "Relative path to the memory file (e.g. MEMORY.md, 2026-02-25.md)"}
+		},
+		"required": ["path"]
+	}`)
+}
+
+func (t *memoryGetTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var input memoryGetInput
+	if err := json.Unmarshal(args, &input); err != nil {
+		return "", fmt.Errorf("parsing input: %w", err)
+	}
+
+	if input.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	content, err := t.mgr.GetFile(input.Path)
+	if err != nil {
+		return "", fmt.Errorf("reading memory file: %w", err)
+	}
+
+	return content, nil
+}

--- a/forge-core/tools/builtins/memory_get_test.go
+++ b/forge-core/tools/builtins/memory_get_test.go
@@ -1,0 +1,62 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/memory"
+)
+
+func TestMemoryGetTool(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	// Create sample content.
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "# My Memory\nImportant facts here."
+	if err := os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := memory.NewManager(memory.ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	tool := NewMemoryGetTool(mgr)
+
+	if tool.Name() != "memory_get" {
+		t.Errorf("Name = %q, want memory_get", tool.Name())
+	}
+
+	// Test reading file.
+	args, _ := json.Marshal(map[string]string{"path": "MEMORY.md"})
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(result, "Important facts here") {
+		t.Errorf("expected content, got: %s", result)
+	}
+
+	// Test empty path.
+	args, _ = json.Marshal(map[string]string{"path": ""})
+	_, err = tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Error("expected error for empty path")
+	}
+
+	// Test non-existent file.
+	args, _ = json.Marshal(map[string]string{"path": "nonexistent.md"})
+	_, err = tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}

--- a/forge-core/tools/builtins/memory_search.go
+++ b/forge-core/tools/builtins/memory_search.go
@@ -1,0 +1,92 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/initializ/forge/forge-core/memory"
+	"github.com/initializ/forge/forge-core/tools"
+)
+
+type memorySearchTool struct {
+	mgr *memory.Manager
+}
+
+// NewMemorySearchTool creates a memory_search tool backed by a Manager.
+// This tool is registered conditionally (not via All()) since it needs
+// a Manager instance.
+func NewMemorySearchTool(mgr *memory.Manager) tools.Tool {
+	return &memorySearchTool{mgr: mgr}
+}
+
+type memorySearchInput struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results,omitempty"`
+}
+
+type memorySearchOutput struct {
+	Text      string  `json:"text"`
+	Source    string  `json:"source"`
+	LineStart int     `json:"line_start"`
+	LineEnd   int     `json:"line_end"`
+	Score     float64 `json:"score"`
+}
+
+func (t *memorySearchTool) Name() string { return "memory_search" }
+func (t *memorySearchTool) Description() string {
+	return "Search long-term agent memory for relevant context from past interactions and curated facts"
+}
+func (t *memorySearchTool) Category() tools.Category { return tools.CategoryBuiltin }
+
+func (t *memorySearchTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"query": {"type": "string", "description": "Search query describing the information to find"},
+			"max_results": {"type": "integer", "description": "Maximum number of results to return (default: 5)", "default": 5}
+		},
+		"required": ["query"]
+	}`)
+}
+
+func (t *memorySearchTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var input memorySearchInput
+	if err := json.Unmarshal(args, &input); err != nil {
+		return "", fmt.Errorf("parsing input: %w", err)
+	}
+
+	if input.Query == "" {
+		return "", fmt.Errorf("query is required")
+	}
+	if input.MaxResults <= 0 {
+		input.MaxResults = 5
+	}
+
+	results, err := t.mgr.Search(ctx, input.Query)
+	if err != nil {
+		return "", fmt.Errorf("memory search: %w", err)
+	}
+
+	// Limit results
+	if len(results) > input.MaxResults {
+		results = results[:input.MaxResults]
+	}
+
+	output := make([]memorySearchOutput, len(results))
+	for i, r := range results {
+		output[i] = memorySearchOutput{
+			Text:      r.Chunk.Content,
+			Source:    r.Chunk.Source,
+			LineStart: r.Chunk.LineStart,
+			LineEnd:   r.Chunk.LineEnd,
+			Score:     r.Score,
+		}
+	}
+
+	data, err := json.Marshal(output)
+	if err != nil {
+		return "", fmt.Errorf("marshalling results: %w", err)
+	}
+	return string(data), nil
+}

--- a/forge-core/tools/builtins/memory_search_test.go
+++ b/forge-core/tools/builtins/memory_search_test.go
@@ -1,0 +1,60 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/memory"
+)
+
+func TestMemorySearchTool(t *testing.T) {
+	dir := t.TempDir()
+	memDir := filepath.Join(dir, "memory")
+
+	// Create sample content.
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("User prefers Go over Python."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := memory.NewManager(memory.ManagerConfig{MemoryDir: memDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	if err := mgr.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewMemorySearchTool(mgr)
+
+	if tool.Name() != "memory_search" {
+		t.Errorf("Name = %q, want memory_search", tool.Name())
+	}
+
+	// Test search.
+	args, _ := json.Marshal(map[string]any{"query": "Go Python"})
+	result, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(result, "Go over Python") {
+		t.Errorf("expected result to contain memory content, got: %s", result)
+	}
+
+	// Test empty query.
+	args, _ = json.Marshal(map[string]any{"query": ""})
+	_, err = tool.Execute(ctx, args)
+	if err == nil {
+		t.Error("expected error for empty query")
+	}
+}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -9,16 +9,34 @@ import (
 
 // ForgeConfig represents the top-level forge.yaml configuration.
 type ForgeConfig struct {
-	AgentID    string    `yaml:"agent_id"`
-	Version    string    `yaml:"version"`
-	Framework  string    `yaml:"framework"`
-	Entrypoint string    `yaml:"entrypoint"`
-	Model      ModelRef  `yaml:"model,omitempty"`
-	Tools      []ToolRef `yaml:"tools,omitempty"`
-	Channels   []string  `yaml:"channels,omitempty"`
-	Registry   string    `yaml:"registry,omitempty"`
-	Egress     EgressRef `yaml:"egress,omitempty"`
-	Skills     SkillsRef `yaml:"skills,omitempty"`
+	AgentID    string       `yaml:"agent_id"`
+	Version    string       `yaml:"version"`
+	Framework  string       `yaml:"framework"`
+	Entrypoint string       `yaml:"entrypoint"`
+	Model      ModelRef     `yaml:"model,omitempty"`
+	Tools      []ToolRef    `yaml:"tools,omitempty"`
+	Channels   []string     `yaml:"channels,omitempty"`
+	Registry   string       `yaml:"registry,omitempty"`
+	Egress     EgressRef    `yaml:"egress,omitempty"`
+	Skills     SkillsRef    `yaml:"skills,omitempty"`
+	Memory     MemoryConfig `yaml:"memory,omitempty"`
+}
+
+// MemoryConfig configures agent memory persistence and compaction.
+type MemoryConfig struct {
+	Persistence  *bool   `yaml:"persistence,omitempty"` // default: true
+	SessionsDir  string  `yaml:"sessions_dir,omitempty"`
+	TriggerRatio float64 `yaml:"trigger_ratio,omitempty"`
+	CharBudget   int     `yaml:"char_budget,omitempty"`
+
+	// Long-term memory (persistent cross-session knowledge).
+	LongTerm          *bool   `yaml:"long_term,omitempty"`            // default: false
+	MemoryDir         string  `yaml:"memory_dir,omitempty"`           // default: .forge/memory
+	EmbeddingProvider string  `yaml:"embedding_provider,omitempty"`   // auto-detect from LLM
+	EmbeddingModel    string  `yaml:"embedding_model,omitempty"`      // provider default
+	VectorWeight      float64 `yaml:"vector_weight,omitempty"`        // default: 0.7
+	KeywordWeight     float64 `yaml:"keyword_weight,omitempty"`       // default: 0.3
+	DecayHalfLifeDays int     `yaml:"decay_half_life_days,omitempty"` // default: 7
 }
 
 // EgressRef configures egress security controls.

--- a/forge-plugins/channels/slack/slack_test.go
+++ b/forge-plugins/channels/slack/slack_test.go
@@ -100,9 +100,13 @@ func TestNormalizeEvent_NoThread(t *testing.T) {
 		t.Fatalf("NormalizeEvent() error: %v", err)
 	}
 
-	// Should fall back to ts when thread_ts is empty
-	if event.ThreadID != "1234567890.123456" {
-		t.Errorf("ThreadID = %q, want 1234567890.123456", event.ThreadID)
+	// ThreadID should be empty for non-threaded messages.
+	if event.ThreadID != "" {
+		t.Errorf("ThreadID = %q, want empty (no thread_ts)", event.ThreadID)
+	}
+	// MessageID should hold the message timestamp for reply targeting.
+	if event.MessageID != "1234567890.123456" {
+		t.Errorf("MessageID = %q, want 1234567890.123456", event.MessageID)
 	}
 }
 

--- a/forge-plugins/channels/telegram/telegram_test.go
+++ b/forge-plugins/channels/telegram/telegram_test.go
@@ -40,8 +40,11 @@ func TestNormalizeEvent(t *testing.T) {
 	if event.UserID != "12345" {
 		t.Errorf("UserID = %q, want 12345", event.UserID)
 	}
-	if event.ThreadID != "42" {
-		t.Errorf("ThreadID = %q, want 42", event.ThreadID)
+	if event.ThreadID != "" {
+		t.Errorf("ThreadID = %q, want empty (no reply_to_message)", event.ThreadID)
+	}
+	if event.MessageID != "42" {
+		t.Errorf("MessageID = %q, want 42", event.MessageID)
 	}
 	if event.Message != "hello bot" {
 		t.Errorf("Message = %q, want 'hello bot'", event.Message)
@@ -93,7 +96,7 @@ func TestSendResponse(t *testing.T) {
 
 	event := &channels.ChannelEvent{
 		WorkspaceID: "67890",
-		ThreadID:    "42",
+		MessageID:   "42",
 	}
 
 	msg := &a2a.Message{
@@ -129,7 +132,7 @@ func TestSendResponse_MarkdownConversion(t *testing.T) {
 
 	event := &channels.ChannelEvent{
 		WorkspaceID: "67890",
-		ThreadID:    "42",
+		MessageID:   "42",
 	}
 
 	msg := &a2a.Message{


### PR DESCRIPTION
## Summary

- **Embedder interface + providers**: `Embedder` abstraction with OpenAI (`text-embedding-3-small`), Gemini, and Ollama (`nomic-embed-text`) implementations, plus factory with auto-detection and Anthropic fallback handling
- **Long-term memory package** (`forge-core/memory/`): file-based storage (daily logs + curated `MEMORY.md`), text chunker with paragraph/sentence-aware overlap, `FileVectorStore` with pluggable `VectorStore` interface, and hybrid search engine combining vector cosine similarity, keyword overlap, and temporal decay (7-day half-life, `MEMORY.md` evergreen)
- **Memory tools**: `memory_search` and `memory_get` builtin tools enabling agents to query their own long-term memory
- **Compactor integration**: `MemoryFlusher` hook captures tool results and decisions before compaction discards old messages, writing them to the daily observation log
- **Runner wiring**: embedder auto-resolution from LLM provider config, `memory.Manager` lifecycle, conditional tool registration, and background indexing at startup
- **Graceful degradation**: no embedder → keyword-only search, no memory dir → skip without crash, corrupted index → rebuild from source files

Enable via `memory.long_term: true` in `forge.yaml` or `FORGE_MEMORY_LONG_TERM=true` env var.

## Test plan

- [x] Embedder factory tests (provider routing, defaults)
- [x] FileStore tests (read/write, path traversal prevention, daily logs, MEMORY.md template)
- [x] Chunker tests (paragraph splitting, overlap, empty/large text, unique IDs)
- [x] VectorStore tests (index, search, delete, persistence round-trip, cosine similarity)
- [x] Hybrid search tests (vector+keyword, keyword-only, temporal decay, tokenization)
- [x] Manager tests (full pipeline, mock embedder, graceful degradation on empty index)
- [x] Memory tools tests (memory_search, memory_get with valid/invalid inputs)
- [x] Compactor MemoryFlusher tests (observation capture, SetMemoryFlusher wiring)
- [x] All existing tests pass across forge-core, forge-cli, forge-plugins
- [x] Zero golangci-lint issues across all modules