### PR TITLE
Add runtime egress enforcement and audit logging

### DIFF
--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+)
+
+// Audit event type constants.
+const (
+	AuditSessionStart  = "session_start"
+	AuditSessionEnd    = "session_end"
+	AuditToolExec      = "tool_exec"
+	AuditEgressAllowed = "egress_allowed"
+	AuditEgressBlocked = "egress_blocked"
+	AuditLLMCall       = "llm_call"
+	AuditGuardrail     = "guardrail_check"
+)
+
+// AuditEvent is a single structured audit record emitted as NDJSON.
+type AuditEvent struct {
+	Timestamp     string         `json:"ts"`
+	Event         string         `json:"event"`
+	CorrelationID string         `json:"correlation_id,omitempty"`
+	TaskID        string         `json:"task_id,omitempty"`
+	Fields        map[string]any `json:"fields,omitempty"`
+}
+
+// AuditLogger writes structured NDJSON audit events to an io.Writer.
+type AuditLogger struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewAuditLogger creates a new AuditLogger writing to w.
+func NewAuditLogger(w io.Writer) *AuditLogger {
+	return &AuditLogger{w: w}
+}
+
+// Emit writes an audit event as a single NDJSON line. If Timestamp is empty
+// it is set to the current time in RFC3339 format.
+func (a *AuditLogger) Emit(event AuditEvent) {
+	if event.Timestamp == "" {
+		event.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	a.mu.Lock()
+	a.w.Write(data) //nolint:errcheck
+	a.mu.Unlock()
+}
+
+// Context key types for correlation and task IDs.
+type correlationIDKey struct{}
+type taskIDKey struct{}
+
+// WithCorrelationID stores a correlation ID in the context.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey{}, id)
+}
+
+// CorrelationIDFromContext retrieves the correlation ID from the context.
+// Returns "" if not set.
+func CorrelationIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(correlationIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// WithTaskID stores a task ID in the context.
+func WithTaskID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, taskIDKey{}, id)
+}
+
+// TaskIDFromContext retrieves the task ID from the context.
+// Returns "" if not set.
+func TaskIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(taskIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// GenerateID produces a 16-character hex random ID using crypto/rand.
+func GenerateID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: return a fixed string (should never happen in practice)
+		return "0000000000000000"
+	}
+	return hex.EncodeToString(b)
+}

--- a/forge-core/runtime/audit_integration_test.go
+++ b/forge-core/runtime/audit_integration_test.go
@@ -1,0 +1,127 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAuditLoggerEventSequence(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewAuditLogger(&buf)
+
+	corrID := GenerateID()
+	taskID := "task-integration-1"
+
+	// Simulate a session lifecycle
+	logger.Emit(AuditEvent{
+		Event:         AuditSessionStart,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+	})
+
+	logger.Emit(AuditEvent{
+		Event:         AuditToolExec,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+		Fields:        map[string]any{"tool": "http_request", "phase": "start"},
+	})
+
+	logger.Emit(AuditEvent{
+		Event:         AuditEgressAllowed,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+		Fields:        map[string]any{"domain": "api.openai.com"},
+	})
+
+	logger.Emit(AuditEvent{
+		Event:         AuditToolExec,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+		Fields:        map[string]any{"tool": "http_request", "phase": "end"},
+	})
+
+	logger.Emit(AuditEvent{
+		Event:         AuditLLMCall,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+		Fields:        map[string]any{"tokens": 150},
+	})
+
+	logger.Emit(AuditEvent{
+		Event:         AuditSessionEnd,
+		CorrelationID: corrID,
+		TaskID:        taskID,
+		Fields:        map[string]any{"state": "completed"},
+	})
+
+	// Parse all events
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 events, got %d", len(lines))
+	}
+
+	expectedEvents := []string{
+		AuditSessionStart,
+		AuditToolExec,
+		AuditEgressAllowed,
+		AuditToolExec,
+		AuditLLMCall,
+		AuditSessionEnd,
+	}
+
+	for i, line := range lines {
+		var event AuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("line %d: invalid JSON: %v", i, err)
+		}
+		if event.Event != expectedEvents[i] {
+			t.Errorf("line %d: event = %q, want %q", i, event.Event, expectedEvents[i])
+		}
+		if event.CorrelationID != corrID {
+			t.Errorf("line %d: correlation_id = %q, want %q", i, event.CorrelationID, corrID)
+		}
+		if event.TaskID != taskID {
+			t.Errorf("line %d: task_id = %q, want %q", i, event.TaskID, taskID)
+		}
+		if event.Timestamp == "" {
+			t.Errorf("line %d: timestamp should be auto-set", i)
+		}
+	}
+}
+
+func TestAuditContextIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	corrID := GenerateID()
+	taskID := "task-ctx-1"
+
+	ctx = WithCorrelationID(ctx, corrID)
+	ctx = WithTaskID(ctx, taskID)
+
+	// Verify round-trip
+	if got := CorrelationIDFromContext(ctx); got != corrID {
+		t.Errorf("CorrelationIDFromContext = %q, want %q", got, corrID)
+	}
+	if got := TaskIDFromContext(ctx); got != taskID {
+		t.Errorf("TaskIDFromContext = %q, want %q", got, taskID)
+	}
+
+	// Emit event using context values
+	var buf bytes.Buffer
+	logger := NewAuditLogger(&buf)
+	logger.Emit(AuditEvent{
+		Event:         AuditToolExec,
+		CorrelationID: CorrelationIDFromContext(ctx),
+		TaskID:        TaskIDFromContext(ctx),
+		Fields:        map[string]any{"tool": "web_search"},
+	})
+
+	var event AuditEvent
+	json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &event) //nolint:errcheck
+	if event.CorrelationID != corrID {
+		t.Errorf("emitted event correlation_id = %q, want %q", event.CorrelationID, corrID)
+	}
+}

--- a/forge-core/runtime/audit_test.go
+++ b/forge-core/runtime/audit_test.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestAuditLoggerEmit(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewAuditLogger(&buf)
+
+	logger.Emit(AuditEvent{
+		Event:         AuditToolExec,
+		CorrelationID: "abc123",
+		TaskID:        "task-1",
+		Fields:        map[string]any{"tool": "http_request"},
+	})
+
+	line := strings.TrimSpace(buf.String())
+	var event AuditEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		t.Fatalf("invalid JSON: %v\nline: %s", err, line)
+	}
+
+	if event.Event != AuditToolExec {
+		t.Errorf("event = %q, want %q", event.Event, AuditToolExec)
+	}
+	if event.CorrelationID != "abc123" {
+		t.Errorf("correlation_id = %q, want %q", event.CorrelationID, "abc123")
+	}
+	if event.TaskID != "task-1" {
+		t.Errorf("task_id = %q, want %q", event.TaskID, "task-1")
+	}
+	if event.Timestamp == "" {
+		t.Error("timestamp should be auto-set")
+	}
+	if event.Fields["tool"] != "http_request" {
+		t.Errorf("fields.tool = %v, want %q", event.Fields["tool"], "http_request")
+	}
+}
+
+func TestAuditLoggerTimestampPreserved(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewAuditLogger(&buf)
+
+	logger.Emit(AuditEvent{
+		Timestamp: "2024-01-01T00:00:00Z",
+		Event:     AuditSessionStart,
+	})
+
+	var event AuditEvent
+	json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &event) //nolint:errcheck
+	if event.Timestamp != "2024-01-01T00:00:00Z" {
+		t.Errorf("timestamp should be preserved, got %q", event.Timestamp)
+	}
+}
+
+func TestAuditLoggerConcurrent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewAuditLogger(&buf)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			logger.Emit(AuditEvent{
+				Event:  AuditToolExec,
+				Fields: map[string]any{"n": n},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 100 {
+		t.Fatalf("expected 100 lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var event AuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Errorf("line %d: invalid JSON: %v", i, err)
+		}
+	}
+}
+
+func TestCorrelationIDContext(t *testing.T) {
+	ctx := context.Background()
+
+	// Missing returns empty string
+	if id := CorrelationIDFromContext(ctx); id != "" {
+		t.Errorf("expected empty, got %q", id)
+	}
+
+	// Round-trip
+	ctx = WithCorrelationID(ctx, "corr-42")
+	if id := CorrelationIDFromContext(ctx); id != "corr-42" {
+		t.Errorf("expected %q, got %q", "corr-42", id)
+	}
+}
+
+func TestTaskIDContext(t *testing.T) {
+	ctx := context.Background()
+
+	// Missing returns empty string
+	if id := TaskIDFromContext(ctx); id != "" {
+		t.Errorf("expected empty, got %q", id)
+	}
+
+	// Round-trip
+	ctx = WithTaskID(ctx, "task-99")
+	if id := TaskIDFromContext(ctx); id != "task-99" {
+		t.Errorf("expected %q, got %q", "task-99", id)
+	}
+}
+
+func TestGenerateID(t *testing.T) {
+	id1 := GenerateID()
+	id2 := GenerateID()
+
+	if len(id1) != 16 {
+		t.Errorf("expected 16-char hex, got %d chars: %q", len(id1), id1)
+	}
+	if len(id2) != 16 {
+		t.Errorf("expected 16-char hex, got %d chars: %q", len(id2), id2)
+	}
+	if id1 == id2 {
+		t.Errorf("two GenerateID calls should produce different values: %q", id1)
+	}
+}

--- a/forge-core/runtime/hooks.go
+++ b/forge-core/runtime/hooks.go
@@ -19,12 +19,14 @@ const (
 
 // HookContext carries data available to hooks at each hook point.
 type HookContext struct {
-	Messages   []llm.ChatMessage
-	Response   *llm.ChatResponse
-	ToolName   string
-	ToolInput  string
-	ToolOutput string
-	Error      error
+	Messages      []llm.ChatMessage
+	Response      *llm.ChatResponse
+	ToolName      string
+	ToolInput     string
+	ToolOutput    string
+	Error         error
+	TaskID        string
+	CorrelationID string
 }
 
 // Hook is a function invoked at a specific point in the agent loop.

--- a/forge-core/security/egress_enforcer.go
+++ b/forge-core/security/egress_enforcer.go
@@ -1,0 +1,138 @@
+package security
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// egressClientKey is the context key for the egress-enforced HTTP client.
+type egressClientKey struct{}
+
+// EgressEnforcer is an http.RoundTripper that validates outbound requests
+// against a domain allowlist before forwarding them to the base transport.
+type EgressEnforcer struct {
+	base          http.RoundTripper
+	mode          EgressMode
+	allowedHosts  map[string]bool
+	wildcardHosts []string // suffix patterns: ".github.com"
+	OnAttempt     func(ctx context.Context, domain string, allowed bool)
+}
+
+// NewEgressEnforcer creates a new EgressEnforcer wrapping the given base transport.
+// If base is nil, http.DefaultTransport is used. Domains may include wildcard
+// prefixes (e.g. "*.github.com") which match any subdomain.
+func NewEgressEnforcer(base http.RoundTripper, mode EgressMode, domains []string) *EgressEnforcer {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	allowed := make(map[string]bool, len(domains))
+	var wildcards []string
+	for _, d := range domains {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d == "" {
+			continue
+		}
+		if strings.HasPrefix(d, "*.") {
+			// *.github.com → suffix ".github.com"
+			wildcards = append(wildcards, d[1:]) // ".github.com"
+		} else {
+			allowed[d] = true
+		}
+	}
+
+	return &EgressEnforcer{
+		base:          base,
+		mode:          mode,
+		allowedHosts:  allowed,
+		wildcardHosts: wildcards,
+	}
+}
+
+// RoundTrip implements http.RoundTripper. It checks the request hostname
+// against the allowlist and fires the OnAttempt callback.
+func (e *EgressEnforcer) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := strings.ToLower(req.URL.Hostname())
+
+	ctx := req.Context()
+
+	// Localhost is always allowed.
+	if isLocalhost(host) {
+		if e.OnAttempt != nil {
+			e.OnAttempt(ctx, host, true)
+		}
+		return e.base.RoundTrip(req)
+	}
+
+	allowed := e.isAllowed(host)
+
+	if e.OnAttempt != nil {
+		e.OnAttempt(ctx, host, allowed)
+	}
+
+	if !allowed {
+		return nil, fmt.Errorf("egress blocked: domain %q not in allowlist (mode=%s)", host, e.mode)
+	}
+
+	return e.base.RoundTrip(req)
+}
+
+// isAllowed checks if a host is permitted under the current mode.
+func (e *EgressEnforcer) isAllowed(host string) bool {
+	switch e.mode {
+	case ModeDevOpen:
+		return true
+	case ModeDenyAll:
+		return false
+	case ModeAllowlist:
+		// Exact match
+		if e.allowedHosts[host] {
+			return true
+		}
+		// Wildcard suffix match: *.github.com matches api.github.com
+		for _, suffix := range e.wildcardHosts {
+			if strings.HasSuffix(host, suffix) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// isLocalhost returns true for loopback addresses.
+func isLocalhost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// WithEgressClient stores an egress-enforced HTTP client in the context.
+func WithEgressClient(ctx context.Context, client *http.Client) context.Context {
+	return context.WithValue(ctx, egressClientKey{}, client)
+}
+
+// EgressClientFromContext retrieves the egress-enforced HTTP client from
+// the context. Returns http.DefaultClient if none is set.
+func EgressClientFromContext(ctx context.Context) *http.Client {
+	if c, ok := ctx.Value(egressClientKey{}).(*http.Client); ok && c != nil {
+		return c
+	}
+	return http.DefaultClient
+}
+
+// EgressTransportFromContext retrieves the transport from the egress client
+// in the context. Returns nil if no egress client is set (so that
+// http.Client{Transport: nil} falls back to http.DefaultTransport).
+func EgressTransportFromContext(ctx context.Context) http.RoundTripper {
+	if c, ok := ctx.Value(egressClientKey{}).(*http.Client); ok && c != nil {
+		return c.Transport
+	}
+	return nil
+}

--- a/forge-core/security/egress_enforcer_test.go
+++ b/forge-core/security/egress_enforcer_test.go
@@ -1,0 +1,284 @@
+package security
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestEgressEnforcerAllowlist(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains []string
+		url     string
+		allowed bool
+	}{
+		{
+			name:    "exact match allowed",
+			domains: []string{"api.openai.com"},
+			url:     "https://api.openai.com/v1/chat",
+			allowed: true,
+		},
+		{
+			name:    "exact match blocked",
+			domains: []string{"api.openai.com"},
+			url:     "https://evil.com/steal",
+			allowed: false,
+		},
+		{
+			name:    "wildcard match subdomain",
+			domains: []string{"*.github.com"},
+			url:     "https://api.github.com/repos",
+			allowed: true,
+		},
+		{
+			name:    "wildcard does not match bare domain",
+			domains: []string{"*.github.com"},
+			url:     "https://github.com/repos",
+			allowed: false,
+		},
+		{
+			name:    "wildcard does not match unrelated",
+			domains: []string{"*.github.com"},
+			url:     "https://notgithub.com/repos",
+			allowed: false,
+		},
+		{
+			name:    "port stripping",
+			domains: []string{"api.openai.com"},
+			url:     "https://api.openai.com:443/v1/chat",
+			allowed: true,
+		},
+		{
+			name:    "case insensitive",
+			domains: []string{"api.openai.com"},
+			url:     "https://API.OpenAI.COM/v1/chat",
+			allowed: true,
+		},
+		{
+			name:    "localhost always allowed",
+			domains: []string{},
+			url:     "http://localhost:8080/test",
+			allowed: true,
+		},
+		{
+			name:    "127.0.0.1 always allowed",
+			domains: []string{},
+			url:     "http://127.0.0.1:9090/test",
+			allowed: true,
+		},
+		{
+			name:    "ipv6 loopback always allowed",
+			domains: []string{},
+			url:     "http://[::1]:8080/test",
+			allowed: true,
+		},
+		{
+			name:    "multiple domains",
+			domains: []string{"api.openai.com", "api.tavily.com"},
+			url:     "https://api.tavily.com/search",
+			allowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a test server to avoid real network calls for allowed requests
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			enforcer := NewEgressEnforcer(http.DefaultTransport, ModeAllowlist, tt.domains)
+
+			req, err := http.NewRequest("GET", tt.url, nil)
+			if err != nil {
+				t.Fatalf("creating request: %v", err)
+			}
+
+			_, err = enforcer.RoundTrip(req)
+			if tt.allowed && err != nil {
+				// Allowed requests may fail with DNS/connection errors
+				// but should NOT fail with "egress blocked"
+				if strings.Contains(err.Error(), "egress blocked") {
+					t.Errorf("expected request to be allowed, got egress blocked: %v", err)
+				}
+			}
+			if !tt.allowed {
+				if err == nil {
+					t.Error("expected request to be blocked, got nil error")
+				} else if !strings.Contains(err.Error(), "egress blocked") {
+					t.Errorf("expected egress blocked error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEgressEnforcerDenyAll(t *testing.T) {
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeDenyAll, nil)
+
+	req, _ := http.NewRequest("GET", "https://api.openai.com/v1/chat", nil)
+	_, err := enforcer.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "egress blocked") {
+		t.Errorf("deny-all should block everything, got: %v", err)
+	}
+}
+
+func TestEgressEnforcerDenyAllAllowsLocalhost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeDenyAll, nil)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/test", nil)
+	resp, err := enforcer.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("localhost should be allowed even in deny-all mode: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+}
+
+func TestEgressEnforcerDevOpen(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeDevOpen, nil)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/test", nil)
+	resp, err := enforcer.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("dev-open should allow everything: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+}
+
+func TestEgressEnforcerOnAttemptCallback(t *testing.T) {
+	var mu sync.Mutex
+	var calls []struct {
+		domain  string
+		allowed bool
+	}
+
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeAllowlist, []string{"api.openai.com"})
+	enforcer.OnAttempt = func(_ context.Context, domain string, allowed bool) {
+		mu.Lock()
+		calls = append(calls, struct {
+			domain  string
+			allowed bool
+		}{domain, allowed})
+		mu.Unlock()
+	}
+
+	// Allowed request
+	req1, _ := http.NewRequest("GET", "https://api.openai.com/v1/chat", nil)
+	enforcer.RoundTrip(req1) //nolint:errcheck
+
+	// Blocked request
+	req2, _ := http.NewRequest("GET", "https://evil.com/steal", nil)
+	enforcer.RoundTrip(req2) //nolint:errcheck
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 callback calls, got %d", len(calls))
+	}
+	if calls[0].domain != "api.openai.com" || !calls[0].allowed {
+		t.Errorf("first call: expected (api.openai.com, true), got (%s, %v)", calls[0].domain, calls[0].allowed)
+	}
+	if calls[1].domain != "evil.com" || calls[1].allowed {
+		t.Errorf("second call: expected (evil.com, false), got (%s, %v)", calls[1].domain, calls[1].allowed)
+	}
+}
+
+func TestEgressEnforcerDevOpenCallback(t *testing.T) {
+	var called bool
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeDevOpen, nil)
+	enforcer.OnAttempt = func(_ context.Context, domain string, allowed bool) {
+		called = true
+		if !allowed {
+			t.Error("dev-open should report allowed=true")
+		}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/test", nil)
+	resp, err := enforcer.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+
+	if !called {
+		t.Error("OnAttempt callback should fire in dev-open mode")
+	}
+}
+
+func TestEgressContextRoundTrip(t *testing.T) {
+	client := &http.Client{Transport: http.DefaultTransport}
+	ctx := WithEgressClient(context.Background(), client)
+
+	got := EgressClientFromContext(ctx)
+	if got != client {
+		t.Error("EgressClientFromContext should return the stored client")
+	}
+
+	transport := EgressTransportFromContext(ctx)
+	if transport != http.DefaultTransport {
+		t.Error("EgressTransportFromContext should return the client's transport")
+	}
+}
+
+func TestEgressContextMissing(t *testing.T) {
+	ctx := context.Background()
+
+	got := EgressClientFromContext(ctx)
+	if got != http.DefaultClient {
+		t.Error("EgressClientFromContext should return http.DefaultClient when missing")
+	}
+
+	transport := EgressTransportFromContext(ctx)
+	if transport != nil {
+		t.Error("EgressTransportFromContext should return nil when missing")
+	}
+}
+
+func TestEgressEnforcerNilBase(t *testing.T) {
+	enforcer := NewEgressEnforcer(nil, ModeAllowlist, []string{"example.com"})
+	if enforcer.base == nil {
+		t.Error("nil base should be replaced with http.DefaultTransport")
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	tests := []struct {
+		host     string
+		expected bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"example.com", false},
+		{"192.168.1.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := isLocalhost(tt.host); got != tt.expected {
+				t.Errorf("isLocalhost(%q) = %v, want %v", tt.host, got, tt.expected)
+			}
+		})
+	}
+}

--- a/forge-core/security/egress_integration_test.go
+++ b/forge-core/security/egress_integration_test.go
@@ -1,0 +1,122 @@
+package security
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestEgressEnforcerIntegration(t *testing.T) {
+	// Start a real test server
+	var hits int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	// Build an enforcer that allows only localhost (test server is localhost)
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeAllowlist, []string{"api.openai.com"})
+
+	var attemptLog []struct {
+		domain  string
+		allowed bool
+	}
+	enforcer.OnAttempt = func(_ context.Context, domain string, allowed bool) {
+		attemptLog = append(attemptLog, struct {
+			domain  string
+			allowed bool
+		}{domain, allowed})
+	}
+
+	client := &http.Client{Transport: enforcer}
+
+	// Request to test server (localhost) — should succeed
+	resp, err := client.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("localhost request should succeed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+	if string(body) != "ok" {
+		t.Errorf("expected body 'ok', got %q", string(body))
+	}
+
+	// Request to blocked domain — should fail
+	_, err = client.Get("https://evil.example.com/steal")
+	if err == nil {
+		t.Fatal("request to blocked domain should fail")
+	}
+
+	// Verify attempt log
+	if len(attemptLog) != 2 {
+		t.Fatalf("expected 2 attempt log entries, got %d", len(attemptLog))
+	}
+	// First: localhost (allowed)
+	if !attemptLog[0].allowed {
+		t.Errorf("first attempt (localhost) should be allowed")
+	}
+	// Second: evil.example.com (blocked)
+	if attemptLog[1].domain != "evil.example.com" || attemptLog[1].allowed {
+		t.Errorf("second attempt should be (evil.example.com, false), got (%s, %v)",
+			attemptLog[1].domain, attemptLog[1].allowed)
+	}
+
+	// Verify test server was actually hit
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Errorf("expected 1 hit to test server, got %d", atomic.LoadInt32(&hits))
+	}
+}
+
+func TestEgressEnforcerDenyAllIntegration(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeDenyAll, nil)
+	client := &http.Client{Transport: enforcer}
+
+	// Localhost should still work even in deny-all
+	resp, err := client.Get(ts.URL + "/test")
+	if err != nil {
+		t.Fatalf("localhost should be allowed even in deny-all: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+}
+
+func TestEgressEnforcerWildcardIntegration(t *testing.T) {
+	enforcer := NewEgressEnforcer(http.DefaultTransport, ModeAllowlist, []string{"*.example.com"})
+
+	var attempts []struct {
+		domain  string
+		allowed bool
+	}
+	enforcer.OnAttempt = func(_ context.Context, domain string, allowed bool) {
+		attempts = append(attempts, struct {
+			domain  string
+			allowed bool
+		}{domain, allowed})
+	}
+
+	client := &http.Client{Transport: enforcer}
+
+	// api.example.com should be allowed (but will fail at DNS — that's fine, we check the enforcer decision)
+	_, _ = client.Get("https://api.example.com/test")
+	// other.com should be blocked
+	_, _ = client.Get("https://other.com/test")
+
+	if len(attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", len(attempts))
+	}
+	if !attempts[0].allowed {
+		t.Error("api.example.com should be allowed by wildcard")
+	}
+	if attempts[1].allowed {
+		t.Error("other.com should be blocked")
+	}
+}

--- a/forge-core/tools/adapters/mcp_call.go
+++ b/forge-core/tools/adapters/mcp_call.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/tools"
 )
 
@@ -60,7 +61,10 @@ func (t *mcpCallTool) Execute(ctx context.Context, args json.RawMessage) (string
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Transport: security.EgressTransportFromContext(ctx),
+		Timeout:   30 * time.Second,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("mcp call: %w", err)

--- a/forge-core/tools/adapters/webhook_call.go
+++ b/forge-core/tools/adapters/webhook_call.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/tools"
 )
 
@@ -53,7 +54,10 @@ func (t *webhookCallTool) Execute(ctx context.Context, args json.RawMessage) (st
 		req.Header.Set(k, v)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Transport: security.EgressTransportFromContext(ctx),
+		Timeout:   30 * time.Second,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("webhook call: %w", err)

--- a/forge-core/tools/builtins/http_request.go
+++ b/forge-core/tools/builtins/http_request.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/tools"
 )
 
@@ -66,7 +67,10 @@ func (t *httpRequestTool) Execute(ctx context.Context, args json.RawMessage) (st
 		req.Header.Set(k, v)
 	}
 
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{
+		Transport: security.EgressTransportFromContext(ctx),
+		Timeout:   timeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("executing request: %w", err)

--- a/forge-core/tools/builtins/web_search_perplexity.go
+++ b/forge-core/tools/builtins/web_search_perplexity.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/initializ/forge/forge-core/security"
 )
 
 // perplexityProvider implements webSearchProvider using the Perplexity API.
@@ -46,7 +48,8 @@ func (p *perplexityProvider) search(ctx context.Context, query string, opts webS
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	client := security.EgressClientFromContext(ctx)
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("calling Perplexity API: %w", err)
 	}

--- a/forge-core/tools/builtins/web_search_tavily.go
+++ b/forge-core/tools/builtins/web_search_tavily.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/initializ/forge/forge-core/security"
 )
 
 // tavilyProvider implements webSearchProvider using the Tavily API.
@@ -57,7 +59,8 @@ func (p *tavilyProvider) search(ctx context.Context, query string, opts webSearc
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	client := security.EgressClientFromContext(ctx)
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("calling Tavily API: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Runtime egress enforcement** via `EgressEnforcer` — an `http.RoundTripper` that validates every outbound HTTP request against the resolved domain allowlist before forwarding. Supports exact match, wildcard domains (`*.github.com`), and always-allowed localhost. Three modes: `deny-all`, `allowlist`, `dev-open`.
- **Structured audit logging** with NDJSON events (`session_start`, `session_end`, `tool_exec`, `egress_allowed`, `egress_blocked`, `llm_call`) and correlation IDs for end-to-end request tracing.
- **Context-threaded correlation** — `TaskID` and `CorrelationID` propagated through context and `HookContext`, attached to all audit events including egress callbacks.
- **Tool wiring** — all HTTP-making tools (`http_request`, `mcp_call`, `webhook_call`, `web_search_tavily`, `web_search_perplexity`) now use the egress-enforced transport/client from context.
- **Comprehensive README rewrite** covering fallback chains, OAuth, memory, runtime security, guardrails, context budgeting, config reference, and environment variables.

## Files changed

| File | Change |
|------|--------|
| `forge-core/security/egress_enforcer.go` | NEW — `http.RoundTripper` wrapper + context helpers |
| `forge-core/security/egress_enforcer_test.go` | NEW — unit tests |
| `forge-core/security/egress_integration_test.go` | NEW — end-to-end tests with httptest |
| `forge-core/runtime/audit.go` | NEW — NDJSON audit logger + context helpers |
| `forge-core/runtime/audit_test.go` | NEW — unit tests |
| `forge-core/runtime/audit_integration_test.go` | NEW — event sequence tests |
| `forge-core/runtime/hooks.go` | MODIFY — add TaskID/CorrelationID to HookContext |
| `forge-core/runtime/loop.go` | MODIFY — populate IDs in all 5 Fire() calls |
| `forge-core/tools/builtins/http_request.go` | MODIFY — use egress transport |
| `forge-core/tools/builtins/web_search_tavily.go` | MODIFY — use egress client |
| `forge-core/tools/builtins/web_search_perplexity.go` | MODIFY — use egress client |
| `forge-core/tools/adapters/mcp_call.go` | MODIFY — use egress transport |
| `forge-core/tools/adapters/webhook_call.go` | MODIFY — use egress transport |
| `forge-cli/runtime/runner.go` | MODIFY — resolve egress, build enforcer, inject context, register audit hooks |
| `README.md` | REWRITE — comprehensive documentation |

## Test plan

- [x] `forge-core/security` — all egress enforcer tests pass (allowlist, deny-all, dev-open, wildcards, localhost, callbacks, context helpers, integration)
- [x] `forge-core/runtime` — all audit logger tests pass (emit, concurrent safety, context round-trips, event sequence)
- [x] `forge-core/tools` — existing tool tests pass unchanged (backward compatible when no egress client in context)
- [x] `forge-cli/runtime` — runner tests pass with updated `registerHandlers` signature
- [x] `golangci-lint` clean on both `forge-core` and `forge-cli`