### PR TITLE
Add K8s incident triage skill, filtering, and inline skill instructions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,3 +27,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,3 +40,23 @@ changelog:
       - "^test:"
       - "^ci:"
       - "^chore:"
+
+brews:
+  - name: forge
+    repository:
+      owner: initializ
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/initializ/forge"
+    description: "Forge is a secure, portable AI Agent runtime. Run agents locally, in cloud, or enterprise environments without exposing inbound tunnels."
+    license: "Apache-2.0"
+    install: |
+      bin.install "forge"
+    test: |
+      system "#{bin}/forge", "--version"
+    commit_author:
+      name: "forge-bot"
+      email: "forge-bot@initializ.ai"
+    commit_msg_template: "chore: update forge formula to {{ .Tag }}"

--- a/forge-cli/cmd/init_test.go
+++ b/forge-cli/cmd/init_test.go
@@ -392,13 +392,13 @@ func TestScaffold_VendorsSkills(t *testing.T) {
 		t.Fatalf("scaffold error: %v", err)
 	}
 
-	skillPath := filepath.Join("skill-test", "skills", "github.md")
+	skillPath := filepath.Join("skill-test", "skills", "github", "SKILL.md")
 	content, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("reading vendored skill: %v", err)
 	}
 	if !strings.Contains(string(content), "## Tool: github_create_issue") {
-		t.Errorf("vendored github.md missing expected tool heading")
+		t.Errorf("vendored SKILL.md missing expected tool heading")
 	}
 }
 

--- a/forge-cli/internal/tui/steps/channel_step.go
+++ b/forge-cli/internal/tui/steps/channel_step.go
@@ -97,7 +97,7 @@ func (s *ChannelStep) updateSelectPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			s.phase = channelTokenPhase
 			s.keyInput = components.NewSecretInput(
 				"Telegram Bot Token (from @BotFather)",
-				true,
+				true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,
@@ -115,7 +115,7 @@ func (s *ChannelStep) updateSelectPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			s.phase = channelTokenPhase
 			s.keyInput = components.NewSecretInput(
 				"Slack App Token (xapp-...)",
-				true,
+				true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,
@@ -157,7 +157,7 @@ func (s *ChannelStep) updateTokenPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			s.phase = channelSlackBotTokenPhase
 			s.keyInput = components.NewSecretInput(
 				"Slack Bot Token (xoxb-...)",
-				true,
+				true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,

--- a/forge-cli/internal/tui/steps/fallback_step.go
+++ b/forge-cli/internal/tui/steps/fallback_step.go
@@ -204,7 +204,7 @@ func (s *FallbackStep) advanceToNextKey() (tui.Step, tea.Cmd) {
 	s.phase = fallbackKeyPhase
 	label := fmt.Sprintf("%s API Key (fallback)", providerDisplayName(provider))
 	s.keyInput = components.NewSecretInput(
-		label, true,
+		label, true, true,
 		s.styles.Theme.Accent,
 		s.styles.Theme.Success,
 		s.styles.Theme.Error,
@@ -229,7 +229,7 @@ func (s *FallbackStep) updateKeyPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			// Retry key input
 			label := fmt.Sprintf("%s API Key (retry — %s)", providerDisplayName(provider), msg.Err)
 			s.keyInput = components.NewSecretInput(
-				label, true,
+				label, true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,

--- a/forge-cli/internal/tui/steps/provider_step.go
+++ b/forge-cli/internal/tui/steps/provider_step.go
@@ -207,7 +207,7 @@ func (s *ProviderStep) updateSelectPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			s.phase = providerKeyPhase
 			label := fmt.Sprintf("%s API Key", providerDisplayName(val))
 			s.keyInput = components.NewSecretInput(
-				label, true,
+				label, true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,
@@ -256,7 +256,7 @@ func (s *ProviderStep) updateAuthMethodPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 		s.phase = providerKeyPhase
 		label := fmt.Sprintf("%s API Key", providerDisplayName(s.provider))
 		s.keyInput = components.NewSecretInput(
-			label, true,
+			label, true, true,
 			s.styles.Theme.Accent,
 			s.styles.Theme.Success,
 			s.styles.Theme.Error,
@@ -283,7 +283,7 @@ func (s *ProviderStep) updateOAuthPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			s.phase = providerKeyPhase
 			label := fmt.Sprintf("%s API Key (OAuth failed — %s)", providerDisplayName(s.provider), msg.Err)
 			s.keyInput = components.NewSecretInput(
-				label, true,
+				label, true, true,
 				s.styles.Theme.Accent,
 				s.styles.Theme.Success,
 				s.styles.Theme.Error,
@@ -346,7 +346,7 @@ func (s *ProviderStep) updateValidatingPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 				s.phase = providerKeyPhase
 				label := fmt.Sprintf("%s API Key (retry — %s)", providerDisplayName(s.provider), msg.Err)
 				s.keyInput = components.NewSecretInput(
-					label, true,
+					label, true, true,
 					s.styles.Theme.Accent,
 					s.styles.Theme.Success,
 					s.styles.Theme.Error,
@@ -458,7 +458,7 @@ func (s *ProviderStep) updateCustomModelPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 		s.phase = providerCustomAuthPhase
 		s.keyInput = components.NewSecretInput(
 			"API key or auth token (optional)",
-			true,
+			true, true,
 			s.styles.Theme.Accent,
 			s.styles.Theme.Success,
 			s.styles.Theme.Error,

--- a/forge-cli/internal/tui/steps/skills_step.go
+++ b/forge-cli/internal/tui/steps/skills_step.go
@@ -338,6 +338,16 @@ func (s *SkillsStep) checkOneOfGroups() bool {
 	return allSatisfied
 }
 
+// isSecretKey returns true if the env var name indicates a secret value
+// that should be masked during input (API keys, tokens, passwords).
+func isSecretKey(key string) bool {
+	upper := strings.ToUpper(key)
+	return strings.HasSuffix(upper, "_API_KEY") ||
+		strings.HasSuffix(upper, "_TOKEN") ||
+		strings.HasSuffix(upper, "_SECRET") ||
+		strings.HasSuffix(upper, "_PASSWORD")
+}
+
 func (s *SkillsStep) initCurrentPrompt() {
 	if s.currentPrompt >= len(s.envPrompts) {
 		return
@@ -346,6 +356,7 @@ func (s *SkillsStep) initCurrentPrompt() {
 	s.keyInput = components.NewSecretInput(
 		prompt.label,
 		prompt.allowSkip,
+		isSecretKey(prompt.envVar),
 		s.styles.Theme.Accent,
 		s.styles.Theme.Success,
 		s.styles.Theme.Error,
@@ -402,9 +413,11 @@ func (s *SkillsStep) Apply(ctx *tui.WizardContext) {
 
 func skillIcon(name string) string {
 	icons := map[string]string{
-		"github":        "🐙",
-		"weather":       "🌤️",
-		"tavily-search": "🔍",
+		"github":              "🐙",
+		"weather":             "🌤️",
+		"tavily-search":       "🔍",
+		"k8s-incident-triage": "☸️",
+		"k8s_incident_triage": "☸️",
 	}
 	if icon, ok := icons[name]; ok {
 		return icon

--- a/forge-cli/internal/tui/steps/tools_step.go
+++ b/forge-cli/internal/tui/steps/tools_step.go
@@ -205,7 +205,7 @@ func (s *ToolsStep) initKeyInput(suffix string) {
 	s.phase = toolsWebSearchKeyPhase
 	s.keyInput = components.NewSecretInput(
 		keyLabel,
-		false, // required — cannot skip
+		false, true, // required — cannot skip; masked
 		s.styles.Theme.Accent,
 		s.styles.Theme.Success,
 		s.styles.Theme.Error,

--- a/forge-core/tools/registry.go
+++ b/forge-core/tools/registry.go
@@ -37,6 +37,13 @@ func (r *Registry) Register(t Tool) error {
 	return nil
 }
 
+// Remove deletes a tool from the registry by name. No-op if not found.
+func (r *Registry) Remove(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tools, name)
+}
+
 // Get returns the tool with the given name, or nil if not found.
 func (r *Registry) Get(name string) Tool {
 	r.mu.RLock()

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -9,18 +9,19 @@ import (
 
 // ForgeConfig represents the top-level forge.yaml configuration.
 type ForgeConfig struct {
-	AgentID    string        `yaml:"agent_id"`
-	Version    string        `yaml:"version"`
-	Framework  string        `yaml:"framework"`
-	Entrypoint string        `yaml:"entrypoint"`
-	Model      ModelRef      `yaml:"model,omitempty"`
-	Tools      []ToolRef     `yaml:"tools,omitempty"`
-	Channels   []string      `yaml:"channels,omitempty"`
-	Registry   string        `yaml:"registry,omitempty"`
-	Egress     EgressRef     `yaml:"egress,omitempty"`
-	Skills     SkillsRef     `yaml:"skills,omitempty"`
-	Memory     MemoryConfig  `yaml:"memory,omitempty"`
-	Secrets    SecretsConfig `yaml:"secrets,omitempty"`
+	AgentID      string        `yaml:"agent_id"`
+	Version      string        `yaml:"version"`
+	Framework    string        `yaml:"framework"`
+	Entrypoint   string        `yaml:"entrypoint"`
+	Model        ModelRef      `yaml:"model,omitempty"`
+	Tools        []ToolRef     `yaml:"tools,omitempty"`
+	BuiltinTools []string      `yaml:"builtin_tools,omitempty"`
+	Channels     []string      `yaml:"channels,omitempty"`
+	Registry     string        `yaml:"registry,omitempty"`
+	Egress       EgressRef     `yaml:"egress,omitempty"`
+	Skills       SkillsRef     `yaml:"skills,omitempty"`
+	Memory       MemoryConfig  `yaml:"memory,omitempty"`
+	Secrets      SecretsConfig `yaml:"secrets,omitempty"`
 }
 
 // SecretsConfig configures secret management providers.

--- a/forge-skills/analyzer/policy_test.go
+++ b/forge-skills/analyzer/policy_test.go
@@ -138,6 +138,46 @@ func TestCheckPolicy_MaxEgressDomains(t *testing.T) {
 	}
 }
 
+func TestCheckPolicy_ExcessiveTagsWarning(t *testing.T) {
+	tags := make([]string, 25)
+	for i := range tags {
+		tags[i] = "tag"
+	}
+	sd := &contract.SkillDescriptor{
+		Name: "many-tags",
+		Tags: tags,
+	}
+	violations := CheckPolicy(sd, false, DefaultPolicy())
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "excessive-tags" && v.Severity == "warning" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected excessive-tags warning for 25 tags")
+	}
+}
+
+func TestCheckPolicy_TagsWithinLimit(t *testing.T) {
+	tags := make([]string, 5)
+	for i := range tags {
+		tags[i] = "tag"
+	}
+	sd := &contract.SkillDescriptor{
+		Name: "few-tags",
+		Tags: tags,
+	}
+	violations := CheckPolicy(sd, false, DefaultPolicy())
+
+	for _, v := range violations {
+		if v.Rule == "excessive-tags" {
+			t.Fatal("should not have excessive-tags violation for 5 tags")
+		}
+	}
+}
+
 func TestCheckPolicy_MaxRiskScore(t *testing.T) {
 	policy := DefaultPolicy()
 	policy.MaxRiskScore = 10

--- a/forge-skills/analyzer/types.go
+++ b/forge-skills/analyzer/types.go
@@ -66,5 +66,6 @@ type SecurityPolicy struct {
 	DeniedEnvPatterns []string `yaml:"denied_env_patterns" json:"denied_env_patterns,omitempty"`
 	ScriptPolicy      string   `yaml:"script_policy" json:"script_policy"` // "allow"|"warn"|"deny"
 	MaxRiskScore      int      `yaml:"max_risk_score" json:"max_risk_score"`
+	MaxTags           int      `yaml:"max_tags" json:"max_tags"`
 	TrustedDomains    []string `yaml:"trusted_domains" json:"trusted_domains,omitempty"`
 }

--- a/forge-skills/compiler/compiler.go
+++ b/forge-skills/compiler/compiler.go
@@ -20,10 +20,16 @@ func Compile(entries []contract.SkillEntry) (*contract.CompiledSkills, error) {
 
 	for _, e := range entries {
 		skill := contract.CompiledSkill{
-			Name:        e.Name,
-			Description: e.Description,
-			InputSpec:   e.InputSpec,
-			OutputSpec:  e.OutputSpec,
+			Name:         e.Name,
+			Description:  e.Description,
+			InputSpec:    e.InputSpec,
+			OutputSpec:   e.OutputSpec,
+			OutputFormat: e.OutputFormat,
+			Body:         e.Body,
+		}
+		if e.Metadata != nil {
+			skill.Category = e.Metadata.Category
+			skill.Tags = e.Metadata.Tags
 		}
 		cs.Skills = append(cs.Skills, skill)
 
@@ -37,6 +43,12 @@ func Compile(entries []contract.SkillEntry) (*contract.CompiledSkills, error) {
 		}
 		if e.OutputSpec != "" {
 			fmt.Fprintf(&promptBuilder, "Output: %s\n", e.OutputSpec)
+		}
+		if e.OutputFormat != "" {
+			fmt.Fprintf(&promptBuilder, "Output format: %s\n", e.OutputFormat)
+		}
+		if e.Body != "" {
+			fmt.Fprintf(&promptBuilder, "\n%s\n", e.Body)
 		}
 		promptBuilder.WriteString("\n")
 	}

--- a/forge-skills/compiler/compiler_test.go
+++ b/forge-skills/compiler/compiler_test.go
@@ -111,6 +111,173 @@ func TestCompile_PromptContainsNames(t *testing.T) {
 	}
 }
 
+func TestCompile_CategoryAndTagsPropagated(t *testing.T) {
+	meta := &contract.SkillMetadata{
+		Name:     "k8s-triage",
+		Category: "sre",
+		Tags:     []string{"kubernetes", "incident-response"},
+	}
+	entries := []contract.SkillEntry{
+		{Name: "k8s_triage", Description: "Diagnose workloads", Metadata: meta},
+	}
+
+	cs, err := Compile(entries)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if cs.Skills[0].Category != "sre" {
+		t.Errorf("Category = %q, want sre", cs.Skills[0].Category)
+	}
+	if len(cs.Skills[0].Tags) != 2 || cs.Skills[0].Tags[0] != "kubernetes" {
+		t.Errorf("Tags = %v, want [kubernetes incident-response]", cs.Skills[0].Tags)
+	}
+}
+
+func TestCompile_NilMetadataNoCategory(t *testing.T) {
+	entries := []contract.SkillEntry{
+		{Name: "simple", Description: "No metadata"},
+	}
+
+	cs, err := Compile(entries)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if cs.Skills[0].Category != "" {
+		t.Errorf("Category should be empty, got %q", cs.Skills[0].Category)
+	}
+	if cs.Skills[0].Tags != nil {
+		t.Errorf("Tags should be nil, got %v", cs.Skills[0].Tags)
+	}
+}
+
+func TestCompile_OutputFormat(t *testing.T) {
+	t.Run("prompt contains output format when set", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "k8s_triage", Description: "Diagnose workloads", OutputFormat: "Use markdown tables for status summaries."},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if !strings.Contains(cs.Prompt, "Output format: Use markdown tables for status summaries.") {
+			t.Errorf("Prompt should contain output format line, got:\n%s", cs.Prompt)
+		}
+	})
+
+	t.Run("compiled skill has OutputFormat populated", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "k8s_triage", Description: "Diagnose workloads", OutputFormat: "Use code blocks."},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if cs.Skills[0].OutputFormat != "Use code blocks." {
+			t.Errorf("OutputFormat = %q, want 'Use code blocks.'", cs.Skills[0].OutputFormat)
+		}
+	})
+
+	t.Run("omitted from prompt when empty", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "simple", Description: "No format hint"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if strings.Contains(cs.Prompt, "Output format:") {
+			t.Errorf("Prompt should not contain 'Output format:' when empty, got:\n%s", cs.Prompt)
+		}
+	})
+
+	t.Run("omitted from JSON when empty", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "simple", Description: "No format hint"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		data, err := json.Marshal(cs.Skills[0])
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(data), "output_format") {
+			t.Errorf("JSON should omit output_format when empty, got: %s", string(data))
+		}
+	})
+}
+
+func TestCompile_Body(t *testing.T) {
+	t.Run("prompt contains body when set", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "k8s_triage", Description: "Diagnose workloads", Body: "## Detection Heuristics\n\n- Check pod status"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if !strings.Contains(cs.Prompt, "## Detection Heuristics") {
+			t.Errorf("Prompt should contain body text, got:\n%s", cs.Prompt)
+		}
+		if !strings.Contains(cs.Prompt, "Check pod status") {
+			t.Errorf("Prompt should contain body details, got:\n%s", cs.Prompt)
+		}
+	})
+
+	t.Run("compiled skill has Body populated", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "k8s_triage", Description: "Diagnose workloads", Body: "Full instructions here"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if cs.Skills[0].Body != "Full instructions here" {
+			t.Errorf("Body = %q, want 'Full instructions here'", cs.Skills[0].Body)
+		}
+	})
+
+	t.Run("omitted from JSON when empty", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "simple", Description: "No extra content"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		data, err := json.Marshal(cs.Skills[0])
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(data), `"body"`) {
+			t.Errorf("JSON should omit body when empty, got: %s", string(data))
+		}
+	})
+
+	t.Run("body not in prompt when empty", func(t *testing.T) {
+		entries := []contract.SkillEntry{
+			{Name: "simple", Description: "No body"},
+		}
+
+		cs, err := Compile(entries)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		// Verify no body content leaked into prompt
+		if strings.Contains(cs.Prompt, "Detection") {
+			t.Errorf("Prompt should not contain body content when body is empty")
+		}
+	})
+}
+
 func TestCompile_EmptyDescription(t *testing.T) {
 	entries := []contract.SkillEntry{
 		{Name: "no_desc_skill", Description: ""},

--- a/forge-skills/contract/filter.go
+++ b/forge-skills/contract/filter.go
@@ -1,0 +1,42 @@
+package contract
+
+import "strings"
+
+// FilterSkills returns the subset of skills matching the given filter.
+// Category is matched case-insensitively (exact match).
+// Tags use AND semantics: a skill must have ALL listed tags to match.
+// Empty filter fields match all skills.
+func FilterSkills(skills []SkillDescriptor, f SkillFilter) []SkillDescriptor {
+	if f.Category == "" && len(f.Tags) == 0 {
+		return skills
+	}
+
+	var result []SkillDescriptor
+	for _, s := range skills {
+		if f.Category != "" && !strings.EqualFold(s.Category, f.Category) {
+			continue
+		}
+		if !hasAllTags(s.Tags, f.Tags) {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result
+}
+
+// hasAllTags returns true if skillTags contains every tag in required.
+func hasAllTags(skillTags, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	set := make(map[string]bool, len(skillTags))
+	for _, t := range skillTags {
+		set[strings.ToLower(t)] = true
+	}
+	for _, t := range required {
+		if !set[strings.ToLower(t)] {
+			return false
+		}
+	}
+	return true
+}

--- a/forge-skills/contract/filter_test.go
+++ b/forge-skills/contract/filter_test.go
@@ -1,0 +1,85 @@
+package contract
+
+import (
+	"testing"
+)
+
+func TestFilterSkills_EmptyFilter(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Category: "sre", Tags: []string{"kubernetes"}},
+		{Name: "b", Category: "dev", Tags: []string{"ci"}},
+	}
+	result := FilterSkills(skills, SkillFilter{})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(result))
+	}
+}
+
+func TestFilterSkills_ByCategory(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Category: "sre"},
+		{Name: "b", Category: "dev"},
+		{Name: "c", Category: "sre"},
+	}
+	result := FilterSkills(skills, SkillFilter{Category: "sre"})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(result))
+	}
+	if result[0].Name != "a" || result[1].Name != "c" {
+		t.Errorf("unexpected skills: %v", result)
+	}
+}
+
+func TestFilterSkills_ByCategoryInsensitive(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Category: "SRE"},
+		{Name: "b", Category: "dev"},
+	}
+	result := FilterSkills(skills, SkillFilter{Category: "sre"})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result))
+	}
+	if result[0].Name != "a" {
+		t.Errorf("expected skill 'a', got %q", result[0].Name)
+	}
+}
+
+func TestFilterSkills_ByTags(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Tags: []string{"kubernetes", "triage"}},
+		{Name: "b", Tags: []string{"kubernetes"}},
+		{Name: "c", Tags: []string{"ci", "triage"}},
+	}
+	result := FilterSkills(skills, SkillFilter{Tags: []string{"kubernetes", "triage"}})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result))
+	}
+	if result[0].Name != "a" {
+		t.Errorf("expected skill 'a', got %q", result[0].Name)
+	}
+}
+
+func TestFilterSkills_CombinedCategoryAndTags(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Category: "sre", Tags: []string{"kubernetes", "triage"}},
+		{Name: "b", Category: "sre", Tags: []string{"ci"}},
+		{Name: "c", Category: "dev", Tags: []string{"kubernetes", "triage"}},
+	}
+	result := FilterSkills(skills, SkillFilter{Category: "sre", Tags: []string{"kubernetes"}})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result))
+	}
+	if result[0].Name != "a" {
+		t.Errorf("expected skill 'a', got %q", result[0].Name)
+	}
+}
+
+func TestFilterSkills_NoMatch(t *testing.T) {
+	skills := []SkillDescriptor{
+		{Name: "a", Category: "sre", Tags: []string{"kubernetes"}},
+	}
+	result := FilterSkills(skills, SkillFilter{Category: "nonexistent"})
+	if len(result) != 0 {
+		t.Fatalf("expected 0 skills, got %d", len(result))
+	}
+}

--- a/forge-skills/local/embedded/k8s-incident-triage/SKILL.md
+++ b/forge-skills/local/embedded/k8s-incident-triage/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: k8s-incident-triage
+category: sre
+tags:
+  - kubernetes
+  - incident-response
+  - triage
+  - reliability
+  - observability
+  - kubectl
+  - oncall
+  - runbooks
+description: Read-only Kubernetes incident triage using kubectl. Accepts natural language or structured input. Produces root-cause hypotheses, evidence, and next-step commands.
+metadata:
+  forge:
+    requires:
+      bins:
+        - kubectl
+      env:
+        required: []
+        one_of: []
+        optional:
+          - KUBECONFIG
+          - K8S_API_DOMAIN
+          - DEFAULT_NAMESPACE
+          - TRIAGE_MAX_PODS
+          - TRIAGE_LOG_LINES
+    egress_domains:
+      - "$K8S_API_DOMAIN"
+    denied_tools:
+      - http_request
+      - web_search
+---
+
+# Kubernetes Incident Triage
+
+Performs read-only triage of Kubernetes workloads and namespaces using `kubectl`.
+
+Supports:
+- Natural language input (human mode)
+- Structured JSON input (automation mode)
+
+This skill NEVER mutates cluster state.
+
+---
+
+## Tool Usage
+
+This skill uses `cli_execute` with `kubectl` commands exclusively.
+NEVER use http_request or web_search to interact with Kubernetes.
+All cluster operations MUST go through kubectl via the cli_execute tool.
+
+---
+
+## Tool: k8s_triage
+
+Diagnose unhealthy Kubernetes workloads, pods, or namespaces.
+
+**Output format:** Use markdown tables for pod/workload status summaries. Wrap kubectl output and log excerpts in ```text code blocks. Use ```bash for recommended next-step commands.
+
+---
+
+## Input Modes
+
+### 1) Human Mode (Natural Language)
+
+Input is a plain string.
+
+Examples:
+
+- `triage payments-prod`
+- `triage deployment payments-api in payments-prod`
+- `why are pods pending in checkout-prod?`
+- `investigate crashloop in payments-prod`
+- `triage pod api-7c9f6d7f86-abcde in payments-prod`
+- `check rollout of deployment payments-api in prod`
+
+Behavior:
+
+- Parse namespace, workload, pod, or selector intent.
+- If namespace omitted, use `$DEFAULT_NAMESPACE` if set.
+- If ambiguity exists, default to namespace-level triage.
+- Never require the user to remember JSON fields.
+
+---
+
+### 2) Automation Mode (Structured JSON)
+
+Input JSON schema:
+
+{
+  "namespace": "payments-prod",
+  "workload_kind": "deployment",
+  "workload_name": "payments-api",
+  "pod_name": null,
+  "label_selector": null,
+  "include_logs": true,
+  "logs_tail_lines": 200,
+  "include_previous_logs": true,
+  "events_limit": 50,
+  "include_node_diagnostics": true,
+  "include_metrics": false,
+  "output_format": "markdown"
+}
+
+Rules:
+
+- `namespace` is required.
+- If `pod_name` provided → pod-level triage.
+- If workload fields provided → workload-level triage.
+- Else → namespace scan.
+
+---
+
+## Triage Process
+
+### Step 0 — Preconditions
+
+Verify cluster access:
+
+kubectl version --client
+kubectl cluster-info
+
+If RBAC denies access:
+
+- Continue with allowed operations.
+- Explicitly report denied commands in output.
+
+---
+
+### Step 1 — Fast Health Snapshot
+
+Namespace scope:
+
+kubectl get pods -n <ns> -o wide
+kubectl get deploy,sts,ds,job,cronjob -n <ns>
+
+Workload scope:
+
+kubectl get <kind> <name> -n <ns>
+kubectl rollout status <kind>/<name> -n <ns> --timeout=10s
+
+Select pods in states:
+
+- CrashLoopBackOff
+- ImagePullBackOff
+- ErrImagePull
+- Pending / Unschedulable
+- Error
+- NotReady
+- OOMKilled
+- High restart count
+
+Limit deep triage to `$TRIAGE_MAX_PODS` (default 5).
+
+---
+
+### Step 2 — Events Timeline
+
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -n <events_limit>
+
+Look for:
+
+- FailedScheduling
+- FailedMount
+- Unhealthy (probe failures)
+- Back-off pulling image
+- Evicted
+- Node pressure signals
+
+---
+
+### Step 3 — Describe Pods & Workloads
+
+For each selected pod:
+
+kubectl describe pod <pod> -n <ns>
+
+Capture:
+
+- Container state and reason
+- Restart count
+- Last termination reason
+- Probe failures
+- Volume mount issues
+- Node assignment
+- Taints / tolerations
+- Affinity constraints
+
+If workload-level triage:
+
+kubectl describe <kind> <name> -n <ns>
+
+---
+
+### Step 4 — Node Diagnostics (Optional)
+
+kubectl get nodes -o wide
+kubectl describe node <node>
+
+Check for:
+
+- NotReady
+- MemoryPressure
+- DiskPressure
+- PIDPressure
+- Evictions
+
+---
+
+### Step 5 — Logs (Optional)
+
+kubectl logs <pod> -n <ns> --all-containers --tail=<N>
+
+If restart loops and include_previous_logs=true:
+
+kubectl logs <pod> -n <ns> --previous --all-containers --tail=<N>
+
+Rules:
+
+- Prefer previous logs for CrashLoopBackOff.
+- Redact obvious sensitive patterns.
+- Never print Secret values.
+
+---
+
+### Step 6 — Optional Metrics
+
+If enabled:
+
+kubectl top pods -n <ns>
+kubectl top node
+
+Gracefully skip if metrics-server is unavailable.
+
+---
+
+## Detection Heuristics
+
+Classify detected issues into:
+
+- CrashLoop / Application Crash
+- OOMKilled / Resource Limits
+- Image Pull Failure
+- Scheduling Constraint
+- Probe Failure
+- PVC / Volume Failure
+- Node Pressure / Eviction
+- Rollout Stuck
+- Unknown / Escalation Needed
+
+For each issue provide:
+
+- Hypothesis
+- Supporting evidence
+- Confidence score (0.0–1.0)
+- Recommended next commands
+
+---
+
+## Output Structure
+
+### 1) Incident Summary
+- Namespace
+- Scope (pod/workload/namespace)
+- Affected resources count
+- Timestamp
+
+### 2) Top Findings
+Concise bullet summary.
+
+### 3) Likely Root Causes (Top 3)
+For each:
+- Description
+- Evidence excerpt
+- Confidence
+- Recommended actions
+
+### 4) Next Commands
+Copy-paste kubectl commands.
+
+### 5) Evidence Appendix
+- Events (recent)
+- Describe excerpts
+- Log excerpts
+
+---
+
+## Safety Constraints
+
+This skill MUST:
+
+- Perform read-only kubectl operations only.
+- Never execute:
+  - apply
+  - patch
+  - delete
+  - exec
+  - port-forward
+  - scale
+  - rollout restart
+- Never print Secret values.
+- Avoid dumping full environment variables.
+
+---
+
+## Autonomous Compatibility
+
+This skill is designed to be invoked by:
+
+- k8s_alert_handler (alert-triggered triage)
+- k8s_patrol (scheduled patrol scans)
+- Humans via natural language CLI
+
+It must:
+
+- Be idempotent
+- Produce deterministic fingerprints
+- Avoid excessive cluster load
+- Limit deep triage scope

--- a/forge-skills/local/registry_embedded_test.go
+++ b/forge-skills/local/registry_embedded_test.go
@@ -16,12 +16,12 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		t.Fatalf("List error: %v", err)
 	}
 
-	if len(skills) != 4 {
+	if len(skills) != 5 {
 		names := make([]string, len(skills))
 		for i, s := range skills {
 			names[i] = s.Name
 		}
-		t.Fatalf("expected 4 skills, got %d: %v", len(skills), names)
+		t.Fatalf("expected 5 skills, got %d: %v", len(skills), names)
 	}
 
 	// Verify all expected skills are present
@@ -31,10 +31,11 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		hasBins     bool
 		hasEgress   bool
 	}{
-		"github":          {displayName: "Github", hasEnv: true, hasBins: true, hasEgress: true},
-		"weather":         {displayName: "Weather", hasEnv: false, hasBins: true, hasEgress: true},
-		"tavily-search":   {displayName: "Tavily Search", hasEnv: true, hasBins: true, hasEgress: true},
-		"tavily-research": {displayName: "Tavily Research", hasEnv: true, hasBins: true, hasEgress: true},
+		"github":              {displayName: "Github", hasEnv: true, hasBins: true, hasEgress: true},
+		"weather":             {displayName: "Weather", hasEnv: false, hasBins: true, hasEgress: true},
+		"tavily-search":       {displayName: "Tavily Search", hasEnv: true, hasBins: true, hasEgress: true},
+		"tavily-research":     {displayName: "Tavily Research", hasEnv: true, hasBins: true, hasEgress: true},
+		"k8s-incident-triage": {displayName: "K8s Incident Triage", hasEnv: false, hasBins: true, hasEgress: false},
 	}
 
 	for _, s := range skills {

--- a/forge-skills/local/scanner.go
+++ b/forge-skills/local/scanner.go
@@ -71,10 +71,13 @@ func Scan(fsys fs.FS) ([]contract.SkillDescriptor, error) {
 				sd.Description = meta.Description
 			}
 
+			sd.Category = meta.Category
+			sd.Tags = meta.Tags
+
 			// Extract forge-specific fields
 			if meta.Metadata != nil {
 				if forgeMap, ok := meta.Metadata["forge"]; ok {
-					sd.RequiredBins, sd.RequiredEnv, sd.OneOfEnv, sd.OptionalEnv, sd.EgressDomains, sd.TimeoutHint = extractFromForgeMap(forgeMap)
+					sd.RequiredBins, sd.RequiredEnv, sd.OneOfEnv, sd.OptionalEnv, sd.EgressDomains, sd.DeniedTools, sd.TimeoutHint = extractFromForgeMap(forgeMap)
 				}
 			}
 
@@ -102,13 +105,24 @@ func Scan(fsys fs.FS) ([]contract.SkillDescriptor, error) {
 }
 
 // extractFromForgeMap extracts typed fields from the forge metadata map.
-func extractFromForgeMap(forgeMap map[string]any) (bins, reqEnv, oneOfEnv, optEnv, egress []string, timeoutHint int) {
+func extractFromForgeMap(forgeMap map[string]any) (bins, reqEnv, oneOfEnv, optEnv, egress, deniedTools []string, timeoutHint int) {
 	// Extract egress_domains
 	if raw, ok := forgeMap["egress_domains"]; ok {
 		if arr, ok := raw.([]any); ok {
 			for _, v := range arr {
 				if s, ok := v.(string); ok {
 					egress = append(egress, s)
+				}
+			}
+		}
+	}
+
+	// Extract denied_tools
+	if raw, ok := forgeMap["denied_tools"]; ok {
+		if arr, ok := raw.([]any); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					deniedTools = append(deniedTools, s)
 				}
 			}
 		}

--- a/forge-skills/requirements/derive.go
+++ b/forge-skills/requirements/derive.go
@@ -39,6 +39,8 @@ func DeriveCLIConfig(reqs *contract.AggregatedRequirements) *contract.DerivedCLI
 		AllowedBinaries: reqs.Bins, // already sorted from AggregateRequirements
 		EnvPassthrough:  envPass,
 		TimeoutHint:     reqs.MaxTimeoutHint,
+		DeniedTools:     reqs.DeniedTools,   // already sorted from AggregateRequirements
+		EgressDomains:   reqs.EgressDomains, // already sorted from AggregateRequirements
 	}
 }
 

--- a/skills/k8s-incident-triage/SKILL.md
+++ b/skills/k8s-incident-triage/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: k8s-incident-triage
+category: sre
+tags:
+  - kubernetes
+  - incident-response
+  - triage
+  - reliability
+  - observability
+  - kubectl
+  - oncall
+  - runbooks
+description: Read-only Kubernetes incident triage using kubectl. Accepts natural language or structured input. Produces root-cause hypotheses, evidence, and next-step commands.
+metadata:
+  forge:
+    requires:
+      bins:
+        - kubectl
+      env:
+        required: []
+        one_of: []
+        optional:
+          - KUBECONFIG
+          - K8S_API_DOMAIN
+          - DEFAULT_NAMESPACE
+          - TRIAGE_MAX_PODS
+          - TRIAGE_LOG_LINES
+    egress_domains:
+      - "$K8S_API_DOMAIN"
+    denied_tools:
+      - http_request
+      - web_search
+---
+
+# Kubernetes Incident Triage
+
+Performs read-only triage of Kubernetes workloads and namespaces using `kubectl`.
+
+Supports:
+- Natural language input (human mode)
+- Structured JSON input (automation mode)
+
+This skill NEVER mutates cluster state.
+
+---
+
+## Tool Usage
+
+This skill uses `cli_execute` with `kubectl` commands exclusively.
+NEVER use http_request or web_search to interact with Kubernetes.
+All cluster operations MUST go through kubectl via the cli_execute tool.
+
+---
+
+## Tool: k8s_triage
+
+Diagnose unhealthy Kubernetes workloads, pods, or namespaces.
+
+---
+
+## Input Modes
+
+### 1) Human Mode (Natural Language)
+
+Input is a plain string.
+
+Examples:
+
+- `triage payments-prod`
+- `triage deployment payments-api in payments-prod`
+- `why are pods pending in checkout-prod?`
+- `investigate crashloop in payments-prod`
+- `triage pod api-7c9f6d7f86-abcde in payments-prod`
+- `check rollout of deployment payments-api in prod`
+
+Behavior:
+
+- Parse namespace, workload, pod, or selector intent.
+- If namespace omitted, use `$DEFAULT_NAMESPACE` if set.
+- If ambiguity exists, default to namespace-level triage.
+- Never require the user to remember JSON fields.
+
+---
+
+### 2) Automation Mode (Structured JSON)
+
+Input JSON schema:
+
+{
+  "namespace": "payments-prod",
+  "workload_kind": "deployment",
+  "workload_name": "payments-api",
+  "pod_name": null,
+  "label_selector": null,
+  "include_logs": true,
+  "logs_tail_lines": 200,
+  "include_previous_logs": true,
+  "events_limit": 50,
+  "include_node_diagnostics": true,
+  "include_metrics": false,
+  "output_format": "markdown"
+}
+
+Rules:
+
+- `namespace` is required.
+- If `pod_name` provided → pod-level triage.
+- If workload fields provided → workload-level triage.
+- Else → namespace scan.
+
+---
+
+## Triage Process
+
+### Step 0 — Preconditions
+
+Verify cluster access:
+
+kubectl version --client
+kubectl cluster-info
+
+If RBAC denies access:
+
+- Continue with allowed operations.
+- Explicitly report denied commands in output.
+
+---
+
+### Step 1 — Fast Health Snapshot
+
+Namespace scope:
+
+kubectl get pods -n <ns> -o wide
+kubectl get deploy,sts,ds,job,cronjob -n <ns>
+
+Workload scope:
+
+kubectl get <kind> <name> -n <ns>
+kubectl rollout status <kind>/<name> -n <ns> --timeout=10s
+
+Select pods in states:
+
+- CrashLoopBackOff
+- ImagePullBackOff
+- ErrImagePull
+- Pending / Unschedulable
+- Error
+- NotReady
+- OOMKilled
+- High restart count
+
+Limit deep triage to `$TRIAGE_MAX_PODS` (default 5).
+
+---
+
+### Step 2 — Events Timeline
+
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -n <events_limit>
+
+Look for:
+
+- FailedScheduling
+- FailedMount
+- Unhealthy (probe failures)
+- Back-off pulling image
+- Evicted
+- Node pressure signals
+
+---
+
+### Step 3 — Describe Pods & Workloads
+
+For each selected pod:
+
+kubectl describe pod <pod> -n <ns>
+
+Capture:
+
+- Container state and reason
+- Restart count
+- Last termination reason
+- Probe failures
+- Volume mount issues
+- Node assignment
+- Taints / tolerations
+- Affinity constraints
+
+If workload-level triage:
+
+kubectl describe <kind> <name> -n <ns>
+
+---
+
+### Step 4 — Node Diagnostics (Optional)
+
+kubectl get nodes -o wide
+kubectl describe node <node>
+
+Check for:
+
+- NotReady
+- MemoryPressure
+- DiskPressure
+- PIDPressure
+- Evictions
+
+---
+
+### Step 5 — Logs (Optional)
+
+kubectl logs <pod> -n <ns> --all-containers --tail=<N>
+
+If restart loops and include_previous_logs=true:
+
+kubectl logs <pod> -n <ns> --previous --all-containers --tail=<N>
+
+Rules:
+
+- Prefer previous logs for CrashLoopBackOff.
+- Redact obvious sensitive patterns.
+- Never print Secret values.
+
+---
+
+### Step 6 — Optional Metrics
+
+If enabled:
+
+kubectl top pods -n <ns>
+kubectl top node
+
+Gracefully skip if metrics-server is unavailable.
+
+---
+
+## Detection Heuristics
+
+Classify detected issues into:
+
+- CrashLoop / Application Crash
+- OOMKilled / Resource Limits
+- Image Pull Failure
+- Scheduling Constraint
+- Probe Failure
+- PVC / Volume Failure
+- Node Pressure / Eviction
+- Rollout Stuck
+- Unknown / Escalation Needed
+
+For each issue provide:
+
+- Hypothesis
+- Supporting evidence
+- Confidence score (0.0–1.0)
+- Recommended next commands
+
+---
+
+## Output Structure
+
+### 1) Incident Summary
+- Namespace
+- Scope (pod/workload/namespace)
+- Affected resources count
+- Timestamp
+
+### 2) Top Findings
+Concise bullet summary.
+
+### 3) Likely Root Causes (Top 3)
+For each:
+- Description
+- Evidence excerpt
+- Confidence
+- Recommended actions
+
+### 4) Next Commands
+Copy-paste kubectl commands.
+
+### 5) Evidence Appendix
+- Events (recent)
+- Describe excerpts
+- Log excerpts
+
+---
+
+## Safety Constraints
+
+This skill MUST:
+
+- Perform read-only kubectl operations only.
+- Never execute:
+  - apply
+  - patch
+  - delete
+  - exec
+  - port-forward
+  - scale
+  - rollout restart
+- Never print Secret values.
+- Avoid dumping full environment variables.
+
+---
+
+## Autonomous Compatibility
+
+This skill is designed to be invoked by:
+
+- k8s_alert_handler (alert-triggered triage)
+- k8s_patrol (scheduled patrol scans)
+- Humans via natural language CLI
+
+It must:
+
+- Be idempotent
+- Produce deterministic fingerprints
+- Avoid excessive cluster load
+- Limit deep triage scope


### PR DESCRIPTION
## Summary

- **K8s Incident Triage skill** — new embedded skill for read-only Kubernetes cluster triage using `kubectl`. Supports natural language and structured JSON input, with detection heuristics (CrashLoop, OOMKilled, scheduling, probes, etc.), structured output, and strict safety constraints (no mutating operations).
- **Full SKILL.md body in system prompt** — threads the complete markdown body through parser → compiler → runtime so the LLM receives all skill instructions (triage steps, detection heuristics, output structure, safety constraints) inline, without requiring a `read_skill` tool call.
- **Skill filtering** — skills can declare `category` and `tags` in frontmatter (kebab-case, deduplicated). New `forge skills list --category sre --tags kubernetes` with AND semantics. Adds `FilterSkills()` to contract package.
- **Skill-as-tool adapter** — script-backed skills auto-register as first-class LLM tools at runtime.
- **Tavily Research skill** — embedded async two-tool pattern (submit + poll) for deep research.
- **Subprocess egress proxy** — local HTTP/HTTPS forward proxy enforcing domain allowlists for `curl`, `wget`, and other subprocess HTTP clients.
- **Channel enhancements** — large response splitting (summary + file attachment) for Slack and Telegram.
- **Homebrew tap** — goreleaser config for `brew install initializ/tap/forge`.
- **README updates** — documents all new features, updated architecture tree, and command reference.

## Test plan

- [x] `forge-skills` tests pass (`go test ./...`) — parser body capture, compiler body propagation, filter logic, scanner, requirements, analyzer
- [x] `forge-cli` tests pass (`go test ./...`) — runner skill catalog, skill discovery, egress domain expansion
- [x] `golangci-lint` clean for both modules
- [x] `gofmt` applied