### PR TITLE
feat: skill builder UI, daemon lifecycle, update notifications

### DIFF
--- a/forge-ui/process.go
+++ b/forge-ui/process.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -71,7 +72,11 @@ func (pm *ProcessManager) Start(agentID string, info *AgentInfo, passphrase stri
 	port := pm.ports.Allocate()
 	pm.allocated[agentID] = port
 
-	cmd := exec.Command(pm.exePath, "serve", "start", "--port", strconv.Itoa(port), "--no-auth")
+	args := []string{"serve", "start", "--port", strconv.Itoa(port)}
+	if len(info.Channels) > 0 {
+		args = append(args, "--with", strings.Join(info.Channels, ","))
+	}
+	cmd := exec.Command(pm.exePath, args...)
 	cmd.Dir = info.Directory
 
 	if passphrase != "" {


### PR DESCRIPTION
## Summary

- **Daemon Agent Lifecycle**: Agents now run as `forge serve` daemon processes via `exec.Command` instead of in-process goroutines — agents survive UI shutdown and are auto-detected on restart via `.forge/serve.json` + TCP probe. Scanner is the single source of truth (removed `MergeState`, `AgentStartFunc`, `External` field).
- **Auth & Channels**: Agents start with bearer token auth enabled (no more `--no-auth`); configured channels (Slack/Telegram) passed via `--with` flag automatically.
- **Skill Builder UI**: Interactive LLM-powered skill creation wizard with real-time streaming chat, YAML frontmatter validation, and one-click save to agent config.
- **Update Notifications**: Dashboard checks GitHub Releases API (30-min cache, semver comparison) and shows animated "Update Available" banner when a newer version exists.
- **Version Display**: Sidebar footer shows current Forge version and link to useforge.ai.
- **Install Script**: One-line `curl | bash` installer/upgrader at repo root.
- **Code Review Skills**: diff, file, standards, and github review skills.
- **Codegen Skills**: React and HTML code generation embedded skills.
- **A2A Auth**: Bearer token authentication for A2A server.
- **Documentation**: Updated dashboard docs with skill builder section, installation docs with install script.

## Test plan
- [ ] `cd forge-ui && go test ./...` — all tests pass
- [ ] `cd forge-cli && go test ./...` — all tests pass
- [ ] Start UI → start an agent → verify it shows as running with auth enabled
- [ ] Stop UI (Ctrl+C) → verify agent is still running
- [ ] Restart UI → verify agent shows as running (detected by scanner)
- [ ] Stop agent from UI → verify it stops
- [ ] Verify agent starts with channels when configured in forge.yaml
- [ ] Skill Builder: open chat, generate a skill, validate, save
- [ ] Update banner appears when running an older version