### PR TITLE
fix: inject channel env vars into K8s manifests (closes #50)

### DIFF
--- a/docs/core-concepts/channels.md
+++ b/docs/core-concepts/channels.md
@@ -185,7 +185,8 @@ When channels are configured in `forge.yaml`, the build pipeline automatically:
 
 1. **Includes channel config files** — `slack-config.yaml`, `telegram-config.yaml`, etc. are copied into the Docker build context alongside `forge.yaml`
 2. **Adds `--with` to the entrypoint** — The container entrypoint becomes `["forge", "run", "--host", "0.0.0.0", "--with", "slack,telegram"]`
-3. **Handles auth loopback** — When [external auth](runtime.md#external-authentication) is configured, channel adapters authenticate to the A2A server using an internal token, bypassing the external auth provider
+3. **Surfaces channel env vars in the manifests** — Every `_env`-suffixed setting in each `<channel>-config.yaml` (e.g. `bot_token_env: SLACK_BOT_TOKEN`) is unioned into the Kubernetes `secrets.yaml` and `deployment.yaml` (via `secretKeyRef`) and into the docker-compose adapter services. Both outputs derive from the same source — see [Kubernetes — Env Var Injection](../deployment/kubernetes.md#env-var-injection)
+4. **Handles auth loopback** — When [external auth](runtime.md#external-authentication) is configured, channel adapters authenticate to the A2A server using an internal token, bypassing the external auth provider
 
 Pass channel secrets via environment variables:
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -14,9 +14,32 @@ Every `forge build` generates container-ready artifacts:
 | `Dockerfile` | Container image with minimal attack surface |
 | `deployment.yaml` | Kubernetes Deployment manifest |
 | `service.yaml` | Kubernetes Service manifest |
+| `secrets.yaml` | Kubernetes Secret with one empty entry per required env var |
 | `network-policy.yaml` | NetworkPolicy restricting pod egress to allowed domains |
 | `egress_allowlist.json` | Machine-readable domain allowlist |
 | `checksums.json` | SHA-256 checksums + Ed25519 signature |
+
+## Env Var Injection
+
+`deployment.yaml` wires each required env var to a `secretKeyRef` against the agent's `<agent_id>-secrets` Secret. The required set is the union of:
+
+- **Skill env vars** — `metadata.forge.requires.env.required` from every `SKILL.md`.
+- **Channel env vars** — every `_env`-suffixed setting in each `<channel>-config.yaml` referenced by `channels:` in `forge.yaml`. For example, `bot_token_env: SLACK_BOT_TOKEN` in `slack-config.yaml` adds `SLACK_BOT_TOKEN` to the required set.
+
+The same canonical source feeds `docker-compose.yaml` when `forge package --with-channels` is used, so the two output paths produce a consistent set.
+
+Adding a new channel env var requires zero edits to the build pipeline — append a new `_env`-suffixed setting to the channel YAML and the next `forge build` picks it up. To wire the secret values into the cluster, populate `secrets.yaml` (or replace it with a sealed-secret / ExternalSecret) before applying.
+
+```yaml
+# slack-config.yaml — operator adds a per-project override
+adapter: slack
+settings:
+  app_token_env: SLACK_APP_TOKEN
+  bot_token_env: SLACK_BOT_TOKEN
+  custom_env: MY_PROJECT_SLACK_OVERRIDE   # ← appears in secrets.yaml + deployment.yaml
+```
+
+A channel listed in `forge.yaml` whose `<channel>-config.yaml` is missing produces a build warning, not an error — the manifest is generated without that channel's env vars.
 
 ## Air-Gap Deployments
 

--- a/forge-cli/build/channels_stage.go
+++ b/forge-cli/build/channels_stage.go
@@ -1,0 +1,77 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	clichannels "github.com/initializ/forge/forge-cli/channels"
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/pipeline"
+)
+
+// ChannelsStage unions env var names declared by the project's configured
+// communication channels into Spec.Requirements.EnvRequired so the generated
+// Kubernetes secrets and deployment manifests include them alongside skill
+// env vars.
+//
+// The canonical source is the per-channel YAML (workDir/<channel>-config.yaml)
+// — every setting key ending in "_env" declares an env-var name. Adding a new
+// channel adapter that ships its own config template will pick up here with
+// no edits to this file.
+type ChannelsStage struct{}
+
+func (s *ChannelsStage) Name() string { return "channel-env-vars" }
+
+func (s *ChannelsStage) Execute(ctx context.Context, bc *pipeline.BuildContext) error {
+	if bc.Config == nil || len(bc.Config.Channels) == 0 {
+		return nil
+	}
+
+	channelEnv, missing, err := clichannels.EnvVarsFromConfig(bc.Opts.WorkDir, bc.Config.Channels)
+	if err != nil {
+		return fmt.Errorf("reading channel env vars: %w", err)
+	}
+	for _, name := range missing {
+		bc.AddWarning(fmt.Sprintf("channel %q is configured but %s-config.yaml is missing; its env vars will not be included in the generated manifests", name, name))
+	}
+	if len(channelEnv) == 0 {
+		return nil
+	}
+
+	if bc.Spec == nil {
+		return nil
+	}
+	if bc.Spec.Requirements == nil {
+		bc.Spec.Requirements = &agentspec.AgentRequirements{}
+	}
+
+	// Union with existing skill-required env vars, dedup, sort.
+	seen := make(map[string]bool, len(bc.Spec.Requirements.EnvRequired)+len(channelEnv))
+	merged := make([]string, 0, len(bc.Spec.Requirements.EnvRequired)+len(channelEnv))
+	for _, v := range bc.Spec.Requirements.EnvRequired {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		merged = append(merged, v)
+	}
+	// Skill-declared optional env vars stay optional even if a channel marks
+	// them required — but in practice channel and skill env-var namespaces
+	// don't overlap, so this is just defense-in-depth.
+	optional := make(map[string]bool, len(bc.Spec.Requirements.EnvOptional))
+	for _, v := range bc.Spec.Requirements.EnvOptional {
+		optional[v] = true
+	}
+	for _, v := range channelEnv {
+		if seen[v] || optional[v] {
+			continue
+		}
+		seen[v] = true
+		merged = append(merged, v)
+	}
+	sort.Strings(merged)
+	bc.Spec.Requirements.EnvRequired = merged
+
+	return nil
+}

--- a/forge-cli/build/channels_stage_test.go
+++ b/forge-cli/build/channels_stage_test.go
@@ -1,0 +1,176 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+func writeChannelYAML(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name+"-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+func TestChannelsStage_UnionsWithSkillEnvRequired(t *testing.T) {
+	dir := t.TempDir()
+	writeChannelYAML(t, dir, "slack", `
+adapter: slack
+settings:
+  app_token_env: SLACK_APP_TOKEN
+  bot_token_env: SLACK_BOT_TOKEN
+`)
+	writeChannelYAML(t, dir, "telegram", `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+`)
+
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{WorkDir: dir})
+	bc.Config = &types.ForgeConfig{Channels: []string{"slack", "telegram"}}
+	bc.Spec = &agentspec.AgentSpec{
+		Requirements: &agentspec.AgentRequirements{
+			EnvRequired: []string{"SKILL_API_KEY"},
+		},
+	}
+
+	if err := (&ChannelsStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("ChannelsStage.Execute: %v", err)
+	}
+
+	want := []string{"SKILL_API_KEY", "SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "TELEGRAM_BOT_TOKEN"}
+	if !slices.Equal(bc.Spec.Requirements.EnvRequired, want) {
+		t.Errorf("EnvRequired = %v, want %v", bc.Spec.Requirements.EnvRequired, want)
+	}
+}
+
+func TestChannelsStage_PopulatesRequirementsWhenNil(t *testing.T) {
+	// Project with channels but no skills — Spec.Requirements starts nil
+	// because RequirementsStage early-returns. ChannelsStage must still
+	// surface channel env vars to the manifests.
+	dir := t.TempDir()
+	writeChannelYAML(t, dir, "slack", `
+adapter: slack
+settings:
+  bot_token_env: SLACK_BOT_TOKEN
+`)
+
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{WorkDir: dir})
+	bc.Config = &types.ForgeConfig{Channels: []string{"slack"}}
+	bc.Spec = &agentspec.AgentSpec{} // Requirements nil
+
+	if err := (&ChannelsStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bc.Spec.Requirements == nil {
+		t.Fatal("Requirements should be created when channels declare env vars")
+	}
+	if !slices.Equal(bc.Spec.Requirements.EnvRequired, []string{"SLACK_BOT_TOKEN"}) {
+		t.Errorf("EnvRequired = %v, want [SLACK_BOT_TOKEN]", bc.Spec.Requirements.EnvRequired)
+	}
+}
+
+func TestChannelsStage_NoChannels(t *testing.T) {
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{WorkDir: t.TempDir()})
+	bc.Config = &types.ForgeConfig{}
+	bc.Spec = &agentspec.AgentSpec{}
+
+	if err := (&ChannelsStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bc.Spec.Requirements != nil {
+		t.Error("expected Requirements to stay nil for project with no channels")
+	}
+}
+
+// TestChannelsStage_FlowsThroughToK8sManifests is the end-to-end regression
+// for issue #50: channel env vars must appear in the generated K8s deployment
+// and secret manifests, not only in docker-compose.
+func TestChannelsStage_FlowsThroughToK8sManifests(t *testing.T) {
+	workDir := t.TempDir()
+	outDir := t.TempDir()
+	writeChannelYAML(t, workDir, "slack", `
+adapter: slack
+settings:
+  app_token_env: SLACK_APP_TOKEN
+  bot_token_env: SLACK_BOT_TOKEN
+`)
+	writeChannelYAML(t, workDir, "telegram", `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+`)
+
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{
+		WorkDir:   workDir,
+		OutputDir: outDir,
+	})
+	bc.Config = &types.ForgeConfig{Channels: []string{"slack", "telegram"}}
+	bc.Spec = &agentspec.AgentSpec{
+		AgentID: "test-agent",
+		Version: "0.1.0",
+		Runtime: &agentspec.RuntimeConfig{
+			Image:      "python:3.12-slim",
+			Entrypoint: []string{"python", "agent.py"},
+			Port:       8080,
+		},
+	}
+
+	if err := (&ChannelsStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("ChannelsStage.Execute: %v", err)
+	}
+	if err := (&K8sStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("K8sStage.Execute: %v", err)
+	}
+
+	dep := readFile(t, filepath.Join(outDir, "k8s", "deployment.yaml"))
+	sec := readFile(t, filepath.Join(outDir, "k8s", "secrets.yaml"))
+
+	for _, want := range []string{"SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "TELEGRAM_BOT_TOKEN"} {
+		if !strings.Contains(dep, want) {
+			t.Errorf("deployment.yaml missing channel env var %q", want)
+		}
+		if !strings.Contains(sec, want) {
+			t.Errorf("secrets.yaml missing channel env var %q", want)
+		}
+	}
+	if !strings.Contains(dep, "secretKeyRef:") {
+		t.Error("deployment.yaml should reference channel env vars via secretKeyRef")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestChannelsStage_MissingConfigWarns(t *testing.T) {
+	// channels: [slack] declared, but no slack-config.yaml on disk.
+	// The stage must surface a warning and not fail the build.
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{WorkDir: t.TempDir()})
+	bc.Config = &types.ForgeConfig{Channels: []string{"slack"}}
+	bc.Spec = &agentspec.AgentSpec{}
+
+	if err := (&ChannelsStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bc.Warnings) != 1 || !strings.Contains(bc.Warnings[0], "slack") {
+		t.Errorf("expected one warning mentioning slack, got %v", bc.Warnings)
+	}
+	if bc.Spec.Requirements != nil {
+		t.Error("Requirements should stay nil when no channel env vars discovered")
+	}
+}

--- a/forge-cli/channels/env.go
+++ b/forge-cli/channels/env.go
@@ -1,0 +1,55 @@
+package channels
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// EnvVarsFromConfig returns the sorted, deduped union of env-var names that
+// the configured channel adapters require. The canonical source is the
+// project's per-channel YAML — every setting key ending in "_env" declares
+// an env var name (e.g. "bot_token_env: SLACK_BOT_TOKEN"), matching the
+// runtime contract used by channels.ResolveEnvVars.
+//
+// channelNames are the values from forge.yaml's `channels:` list. For each
+// name, the file workDir/<name>-config.yaml is consulted. A missing file is
+// reported via missing[] and produces no env vars; parse errors are returned.
+//
+// This is the single canonical source — build stages, container packaging,
+// and any other tooling that needs to know "which env vars do my channels
+// require" should call this. Adding a new channel adapter requires no edits
+// here: it ships its own *-config.yaml template and the helper picks it up.
+func EnvVarsFromConfig(workDir string, channelNames []string) (envVars []string, missing []string, err error) {
+	seen := make(map[string]bool)
+	for _, name := range channelNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		path := filepath.Join(workDir, name+"-config.yaml")
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			missing = append(missing, name)
+			continue
+		}
+		cfg, loadErr := LoadChannelConfig(path)
+		if loadErr != nil {
+			return nil, missing, fmt.Errorf("channel %q: %w", name, loadErr)
+		}
+		for k, v := range cfg.Settings {
+			base, ok := strings.CutSuffix(k, "_env")
+			if !ok || base == "" {
+				continue
+			}
+			if v == "" || seen[v] {
+				continue
+			}
+			seen[v] = true
+			envVars = append(envVars, v)
+		}
+	}
+	sort.Strings(envVars)
+	return envVars, missing, nil
+}

--- a/forge-cli/channels/env_test.go
+++ b/forge-cli/channels/env_test.go
@@ -1,0 +1,127 @@
+package channels
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func writeChannelConfig(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name+"-config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+func TestEnvVarsFromConfig_ExtractsEnvSuffixSettings(t *testing.T) {
+	dir := t.TempDir()
+	writeChannelConfig(t, dir, "slack", `
+adapter: slack
+settings:
+  app_token_env: SLACK_APP_TOKEN
+  bot_token_env: SLACK_BOT_TOKEN
+`)
+	writeChannelConfig(t, dir, "telegram", `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+  mode: polling
+`)
+
+	got, missing, err := EnvVarsFromConfig(dir, []string{"slack", "telegram"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want none", missing)
+	}
+	want := []string{"SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "TELEGRAM_BOT_TOKEN"}
+	if !slices.Equal(got, want) {
+		t.Errorf("EnvVarsFromConfig = %v, want %v", got, want)
+	}
+}
+
+func TestEnvVarsFromConfig_IgnoresNonEnvSettings(t *testing.T) {
+	dir := t.TempDir()
+	writeChannelConfig(t, dir, "telegram", `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+  mode: polling
+  webhook_path: /tg
+`)
+
+	got, _, err := EnvVarsFromConfig(dir, []string{"telegram"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the _env-suffix key should be picked up; mode/webhook_path are not env names.
+	if !slices.Equal(got, []string{"TELEGRAM_BOT_TOKEN"}) {
+		t.Errorf("got %v, want [TELEGRAM_BOT_TOKEN] (non-env settings should be ignored)", got)
+	}
+}
+
+func TestEnvVarsFromConfig_DedupsAcrossChannels(t *testing.T) {
+	dir := t.TempDir()
+	// Two channels declaring the same env var name (e.g. two slack-like
+	// adapters sharing a credential). The union must dedup.
+	writeChannelConfig(t, dir, "slack", `
+adapter: slack
+settings:
+  bot_token_env: SHARED_TOKEN
+`)
+	writeChannelConfig(t, dir, "slack-replica", `
+adapter: slack
+settings:
+  bot_token_env: SHARED_TOKEN
+`)
+
+	got, _, err := EnvVarsFromConfig(dir, []string{"slack", "slack-replica"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(got, []string{"SHARED_TOKEN"}) {
+		t.Errorf("dedup failed: got %v", got)
+	}
+}
+
+func TestEnvVarsFromConfig_MissingFileReported(t *testing.T) {
+	dir := t.TempDir()
+	writeChannelConfig(t, dir, "telegram", `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+`)
+
+	got, missing, err := EnvVarsFromConfig(dir, []string{"slack", "telegram"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(missing, []string{"slack"}) {
+		t.Errorf("missing = %v, want [slack]", missing)
+	}
+	if !slices.Equal(got, []string{"TELEGRAM_BOT_TOKEN"}) {
+		t.Errorf("got %v, want only telegram's env (slack file missing)", got)
+	}
+}
+
+func TestEnvVarsFromConfig_EmptyChannels(t *testing.T) {
+	got, missing, err := EnvVarsFromConfig(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 || len(missing) != 0 {
+		t.Errorf("expected empty results for no channels, got env=%v missing=%v", got, missing)
+	}
+}
+
+func TestEnvVarsFromConfig_ParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeChannelConfig(t, dir, "slack", "this is: not: valid: yaml: [")
+	_, _, err := EnvVarsFromConfig(dir, []string{"slack"})
+	if err == nil {
+		t.Fatal("expected parse error for invalid YAML")
+	}
+}

--- a/forge-cli/cmd/build.go
+++ b/forge-cli/cmd/build.go
@@ -114,6 +114,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		&build.SkillsStage{},
 		&build.SecurityAnalysisStage{},
 		&build.RequirementsStage{},
+		&build.ChannelsStage{},
 		&build.PolicyStage{},
 		&build.EgressStage{},
 		&build.DockerfileStage{},

--- a/forge-cli/cmd/package.go
+++ b/forge-cli/cmd/package.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 	"time"
 
+	clichannels "github.com/initializ/forge/forge-cli/channels"
 	"github.com/initializ/forge/forge-cli/config"
 	"github.com/initializ/forge/forge-cli/container"
 	"github.com/initializ/forge/forge-cli/templates"
@@ -203,7 +204,7 @@ func runPackage(cmd *cobra.Command, args []string) error {
 	// Generate docker-compose.yaml if --with-channels is set
 	if withChannels && len(cfg.Channels) > 0 {
 		composePath := filepath.Join(outDir, "docker-compose.yaml")
-		if err := generateDockerCompose(composePath, imageTag, cfg, 8080); err != nil {
+		if err := generateDockerCompose(composePath, imageTag, cfg, filepath.Dir(cfgPath), 8080); err != nil {
 			return fmt.Errorf("generating docker-compose.yaml: %w", err)
 		}
 		fmt.Printf("Generated %s\n", composePath)
@@ -267,7 +268,7 @@ type composeData struct {
 	Channels      []channelComposeData
 }
 
-func generateDockerCompose(path string, imageTag string, cfg *types.ForgeConfig, port int) error {
+func generateDockerCompose(path string, imageTag string, cfg *types.ForgeConfig, workDir string, port int) error {
 	if port == 0 {
 		port = 8080
 	}
@@ -282,22 +283,21 @@ func generateDockerCompose(path string, imageTag string, cfg *types.ForgeConfig,
 		return fmt.Errorf("parsing docker-compose template: %w", err)
 	}
 
+	// Build per-channel env var lists from the same canonical source the
+	// build pipeline uses for the K8s manifests — each project channel's
+	// *-config.yaml. Channels without a config file contribute no env vars.
 	var channels []channelComposeData
 	for _, ch := range cfg.Channels {
-		if ch != "slack" && ch != "telegram" {
+		envVars, _, envErr := clichannels.EnvVarsFromConfig(workDir, []string{ch})
+		if envErr != nil {
+			return fmt.Errorf("reading channel %q env vars: %w", ch, envErr)
+		}
+		if len(envVars) == 0 {
 			continue
 		}
-		cd := channelComposeData{Name: ch}
-		switch ch {
-		case "slack":
-			cd.EnvVars = []string{
-				"SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET}",
-				"SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}",
-			}
-		case "telegram":
-			cd.EnvVars = []string{
-				"TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}",
-			}
+		cd := channelComposeData{Name: ch, EnvVars: make([]string, 0, len(envVars))}
+		for _, name := range envVars {
+			cd.EnvVars = append(cd.EnvVars, fmt.Sprintf("%s=${%s}", name, name))
 		}
 		channels = append(channels, cd)
 	}

--- a/forge-cli/cmd/package_test.go
+++ b/forge-cli/cmd/package_test.go
@@ -130,6 +130,19 @@ func TestWithChannelsFlagDefault(t *testing.T) {
 
 func TestGenerateDockerCompose(t *testing.T) {
 	dir := t.TempDir()
+	// Seed the per-channel config files that the generator now reads to
+	// derive env vars. These mirror the templates shipped by `forge init`.
+	writeFile(t, filepath.Join(dir, "slack-config.yaml"), `
+adapter: slack
+settings:
+  app_token_env: SLACK_APP_TOKEN
+  bot_token_env: SLACK_BOT_TOKEN
+`)
+	writeFile(t, filepath.Join(dir, "telegram-config.yaml"), `
+adapter: telegram
+settings:
+  bot_token_env: TELEGRAM_BOT_TOKEN
+`)
 	path := filepath.Join(dir, "docker-compose.yaml")
 
 	cfg := &types.ForgeConfig{
@@ -147,7 +160,7 @@ func TestGenerateDockerCompose(t *testing.T) {
 		},
 	}
 
-	err := generateDockerCompose(path, "my-agent:0.1.0", cfg, 8080)
+	err := generateDockerCompose(path, "my-agent:0.1.0", cfg, dir, 8080)
 	if err != nil {
 		t.Fatalf("generateDockerCompose() error: %v", err)
 	}
@@ -186,26 +199,34 @@ func TestGenerateDockerCompose(t *testing.T) {
 		t.Error("missing egress mode label")
 	}
 
-	// Check slack adapter
+	// Slack adapter env vars come from slack-config.yaml. The current Slack
+	// adapter is Socket Mode (app_token + bot_token), so signing_secret is
+	// not declared in the YAML and therefore not injected — switching to the
+	// YAML-driven source corrects a long-standing inaccuracy in the prior
+	// hardcoded map.
 	if !strings.Contains(content, "slack-adapter:") {
 		t.Error("missing slack-adapter service")
 	}
-	if !strings.Contains(content, "SLACK_SIGNING_SECRET") {
-		t.Error("missing SLACK_SIGNING_SECRET env var")
+	if !strings.Contains(content, "SLACK_APP_TOKEN=${SLACK_APP_TOKEN}") {
+		t.Error("missing SLACK_APP_TOKEN env var")
 	}
-	if !strings.Contains(content, "SLACK_BOT_TOKEN") {
+	if !strings.Contains(content, "SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}") {
 		t.Error("missing SLACK_BOT_TOKEN env var")
+	}
+	if strings.Contains(content, "SLACK_SIGNING_SECRET") {
+		t.Error("SLACK_SIGNING_SECRET should not be injected: not declared in slack-config.yaml and unused by Socket Mode adapter")
 	}
 
 	// Check telegram adapter
 	if !strings.Contains(content, "telegram-adapter:") {
 		t.Error("missing telegram-adapter service")
 	}
-	if !strings.Contains(content, "TELEGRAM_BOT_TOKEN") {
+	if !strings.Contains(content, "TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}") {
 		t.Error("missing TELEGRAM_BOT_TOKEN env var")
 	}
 
-	// Non-adapter channels (a2a) should be skipped
+	// Channels without a *-config.yaml (a2a here) contribute no env vars
+	// and so produce no adapter service.
 	if strings.Contains(content, "a2a-adapter") {
 		t.Error("a2a should not generate an adapter service")
 	}
@@ -230,7 +251,7 @@ func TestGenerateDockerCompose_NoAdapters(t *testing.T) {
 		Channels:   []string{"a2a", "http"},
 	}
 
-	err := generateDockerCompose(path, "my-agent:0.1.0", cfg, 8080)
+	err := generateDockerCompose(path, "my-agent:0.1.0", cfg, dir, 8080)
 	if err != nil {
 		t.Fatalf("generateDockerCompose() error: %v", err)
 	}
@@ -241,5 +262,12 @@ func TestGenerateDockerCompose_NoAdapters(t *testing.T) {
 	// Only agent service, no adapters
 	if strings.Contains(content, "-adapter:") {
 		t.Error("should not generate adapter services for non-adapter channels")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #50 — `forge build` and `forge package` now include communication-channel env vars (e.g. `SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`) in the generated Kubernetes `deployment.yaml` and `secrets.yaml`. They were silently dropped before; only the hardcoded path in `cmd/package.go` (docker-compose) injected them.

## Approach

Both output paths now use a single canonical source: each project's per-channel YAML (`<workDir>/<channel>-config.yaml`). The `_env` suffix convention (`bot_token_env: SLACK_BOT_TOKEN`) is already the runtime contract via `channels.ResolveEnvVars` — this PR just makes the build pipeline honor the same convention.

| Layer | Change |
|---|---|
| `forge-cli/channels/env.go` (new) | `EnvVarsFromConfig(workDir, channels)` returns the sorted/deduped union of env-var names across channel YAMLs, plus a list of channels whose config file is missing. |
| `forge-cli/build/channels_stage.go` (new) | `ChannelsStage` unions the helper's output into `Spec.Requirements.EnvRequired` (creating `Requirements` if `RequirementsStage` left it nil for channels-only projects). Inserted in the pipeline between `RequirementsStage` and `PolicyStage`. Missing channel YAMLs surface a build warning, not an error. |
| `forge-cli/cmd/package.go` | `generateDockerCompose` now accepts `workDir` and calls the same helper instead of a hardcoded `case "slack" / case "telegram"` switch. |
| `forge-cli/cmd/build.go` | Inserted `&build.ChannelsStage{}` into the build pipeline. |

Templates (`deployment.yaml.tmpl`, `secrets.yaml.tmpl`) are untouched — they already iterate `RequiredEnvVars`, so unioning channel env vars into that field is enough.

## Behavior change worth calling out

`forge package --with-channels` **no longer injects `SLACK_SIGNING_SECRET`** into `docker-compose.yaml`. The prior hardcoded switch listed it, but the Slack adapter is Socket Mode (`forge-plugins/channels/slack/slack.go:55-67`) and never reads it. The shipped `slack-config.yaml.tmpl` also doesn't declare it. Switching to the YAML-driven source corrects that long-standing inaccuracy.

Operators who need `SLACK_SIGNING_SECRET` for a custom adapter setup can add `signing_secret_env: SLACK_SIGNING_SECRET` to their `slack-config.yaml` — the helper will pick it up automatically. This flips the question from "is this in our hardcoded list?" to "is this in your project config?".

## Tests

```
gofmt -l forge-core/ forge-cli/ forge-plugins/                        # clean
golangci-lint run ./{forge-core,forge-cli,forge-plugins}/...          # 0 issues
cd forge-core && go test ./...                                        # pass
cd forge-cli && go test ./...                                         # pass
cd forge-plugins && go test ./...                                     # pass
```

New tests:

- `forge-cli/channels/env_test.go` — extracts `_env` suffix settings, ignores non-env settings (`mode`, `webhook_path`), dedups across channels, reports missing config files, returns clean empty results for no channels, surfaces parse errors.
- `forge-cli/build/channels_stage_test.go`:
  - `TestChannelsStage_UnionsWithSkillEnvRequired` — channel env vars merge with skill `EnvRequired`.
  - `TestChannelsStage_PopulatesRequirementsWhenNil` — channels-only projects.
  - `TestChannelsStage_NoChannels` — no-op when `cfg.Channels` is empty.
  - **`TestChannelsStage_FlowsThroughToK8sManifests`** — end-to-end regression for #50: with `slack-config.yaml` and `telegram-config.yaml` on disk, running `ChannelsStage` then `K8sStage` produces a `deployment.yaml` and `secrets.yaml` containing `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN` referenced via `secretKeyRef`.
  - `TestChannelsStage_MissingConfigWarns` — missing channel YAML produces a warning, build continues.

Updated:

- `forge-cli/cmd/package_test.go` — `TestGenerateDockerCompose` now seeds channel YAMLs in the temp workDir, passes the new `workDir` parameter, asserts the YAML-declared vars are present, and asserts `SLACK_SIGNING_SECRET` is absent.

## Acceptance criteria from #50

- [x] With `channels: [slack, telegram]` in `forge.yaml`, `k8s/secrets.yaml` lists the declared channel env vars and `k8s/deployment.yaml` references them via `secretKeyRef`.
- [x] Adding a new channel adapter requires zero edits to `k8s_stage.go`, `requirements_stage.go`, `template_data.go`, any template, or `cmd/package.go`. The new adapter ships its own `<name>-config.yaml` template through `forge init` and the helper picks it up.
- [x] `docker-compose.yaml` (`--with-channels`) and `k8s/{deployment,secrets}.yaml` produce a consistent set of channel env vars from the same source.
- [x] Skill env vars continue to appear in the K8s manifests (no regression — union logic preserves them).
- [x] Missing channel config files do not fail the build; they surface as build warnings so the operator sees what's missing.

> The AC also said "if a channel adapter declares an env var as optional vs. required, the K8s manifest reflects that distinction". The current `_env` convention in the channel YAMLs makes no required/optional distinction — every `_env` setting is treated as required (matching the Slack/Telegram adapters, which all fail at `Init` time when their tokens are missing). Adding an optional flavor (e.g. `_env_optional` suffix) is a clean follow-up that builds on this PR's helper.

## Test plan

- [ ] `forge init my-agent --framework forge`, add `channels: [slack, telegram]` to `forge.yaml`, run `forge build`. Confirm `k8s/secrets.yaml` lists `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN` and `k8s/deployment.yaml` references them via `secretKeyRef`.
- [ ] Run `forge package --with-channels`. Confirm `docker-compose.yaml` contains the same channel env-var set.
- [ ] Configure `channels: [slack]` but delete `slack-config.yaml`. Confirm `forge build` succeeds with a warning that mentions slack.
- [ ] Add `custom_env: MY_CUSTOM_SECRET` to a project's `slack-config.yaml`. Re-run `forge build`. Confirm `MY_CUSTOM_SECRET` flows into both the K8s manifest and `docker-compose.yaml` with no code changes.