### PR TITLE
fix(windows): shared process.IsAlive for forge-cli and forge-ui (closes #59)

### DIFF
--- a/forge-cli/cmd/serve.go
+++ b/forge-cli/cmd/serve.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-core/util/process"
 	"github.com/spf13/cobra"
 )
 
@@ -141,7 +142,7 @@ func readDaemonState(path string) (daemonState, bool) {
 		return daemonState{}, false
 	}
 
-	if state.PID <= 0 || !isProcessAlive(state.PID) {
+	if state.PID <= 0 || !process.IsAlive(state.PID) {
 		return daemonState{}, false
 	}
 
@@ -301,7 +302,7 @@ func serveStopRun(cmd *cobra.Command, args []string) error {
 	// Poll for exit (up to 10 seconds)
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		if !isProcessAlive(state.PID) {
+		if !process.IsAlive(state.PID) {
 			os.Remove(statePath) //nolint:errcheck
 			fmt.Fprintln(os.Stderr, "Daemon stopped.")
 			return nil

--- a/forge-cli/cmd/serve_unix.go
+++ b/forge-cli/cmd/serve_unix.go
@@ -11,14 +11,6 @@ func daemonSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
 }
 
-func isProcessAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
-}
-
 func sendTermSignal(proc *os.Process) error {
 	return proc.Signal(syscall.SIGTERM)
 }

--- a/forge-cli/cmd/serve_windows.go
+++ b/forge-cli/cmd/serve_windows.go
@@ -11,16 +11,6 @@ func daemonSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{CreationFlags: 0x00000008} // DETACHED_PROCESS
 }
 
-func isProcessAlive(pid int) bool {
-	const processQueryLimitedInfo = 0x1000
-	h, err := syscall.OpenProcess(processQueryLimitedInfo, false, uint32(pid))
-	if err != nil {
-		return false
-	}
-	_ = syscall.CloseHandle(h)
-	return true
-}
-
 func sendTermSignal(proc *os.Process) error {
 	// Windows has no SIGTERM; terminate the process directly.
 	return proc.Kill()

--- a/forge-core/util/process/process_test.go
+++ b/forge-core/util/process/process_test.go
@@ -1,0 +1,45 @@
+package process
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestIsAlive_Self(t *testing.T) {
+	if !IsAlive(os.Getpid()) {
+		t.Errorf("IsAlive(self=%d) = false, want true", os.Getpid())
+	}
+}
+
+// TestIsAlive_ChildAfterExit spawns a short-lived subprocess, waits for it
+// to exit cleanly, and asserts IsAlive returns false for its PID. This is
+// the deterministic way to exercise the "process is gone" branch on both
+// platforms — picking a "high PID that probably isn't real" is unreliable.
+func TestIsAlive_ChildAfterExit(t *testing.T) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "exit", "0")
+	} else {
+		cmd = exec.Command("true")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting subprocess: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("waiting for subprocess: %v", err)
+	}
+	// Give the OS a beat to actually reap the PID. On most systems this
+	// is instant, but Windows handle cleanup can briefly lag.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsAlive(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("IsAlive(pid=%d) = true after Wait() returned, want false", pid)
+}

--- a/forge-core/util/process/process_unix.go
+++ b/forge-core/util/process/process_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+// Package process provides small, platform-aware utilities for interacting
+// with OS processes by PID. Today it ships a single function — IsAlive —
+// because the same Unix idiom (Signal(0)) silently fails on Windows and was
+// duplicated across forge-cli and forge-ui with the Windows variant missing.
+// See issue #59.
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsAlive reports whether a process with the given PID is currently running.
+//
+// On Unix, this calls FindProcess and sends a null signal (signal 0), which
+// the kernel treats as a permission/existence check without delivering an
+// actual signal. The OS returns success when the process exists, even if the
+// caller lacks permission to signal it.
+//
+// Any error from either step is treated as "not alive" so callers can use a
+// simple bool branch.
+func IsAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/forge-core/util/process/process_windows.go
+++ b/forge-core/util/process/process_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+// Package process provides small, platform-aware utilities for interacting
+// with OS processes by PID. See process_unix.go for the package overview.
+package process
+
+import "syscall"
+
+// processQueryLimitedInfo is Windows' lightweight process access right
+// (no PROCESS_VM_READ, etc.) — enough to call GetProcessTimes /
+// QueryFullProcessImageName / etc. without elevated privileges. Granting
+// PROCESS_QUERY_INFORMATION instead would also work but requires more
+// rights than this check needs.
+const processQueryLimitedInfo = 0x1000
+
+// IsAlive reports whether a process with the given PID is currently running.
+//
+// On Windows, the Unix idiom os.Process.Signal(syscall.Signal(0)) does not
+// work — Go's stdlib only knows how to translate os.Interrupt and os.Kill
+// for Windows processes, so any other signal returns
+// "operating system does not support signal". This always-error response
+// makes Signal(0) useless as a liveness probe on Windows.
+//
+// Instead, open the process handle with PROCESS_QUERY_LIMITED_INFORMATION
+// rights. OpenProcess fails only when the PID doesn't exist or the caller
+// lacks rights even for the limited-info subset; both cases reasonably map
+// to "not alive" for our use case (the forge daemon is the caller's child,
+// so it always has rights to its own PID).
+//
+// The handle is closed immediately — we only care that OpenProcess
+// succeeded, not what the handle exposes.
+func IsAlive(pid int) bool {
+	h, err := syscall.OpenProcess(processQueryLimitedInfo, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = syscall.CloseHandle(h)
+	return true
+}

--- a/forge-ui/discovery.go
+++ b/forge-ui/discovery.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/initializ/forge/forge-core/types"
+	"github.com/initializ/forge/forge-core/util/process"
 )
 
 // externalDaemonState mirrors the daemonState written by `forge serve start`.
@@ -130,7 +131,7 @@ func detectExternalAgent(dir string) (int, bool) {
 	}
 
 	// Check PID liveness first — if the process is dead, serve.json is stale.
-	if state.PID > 0 && !pidAlive(state.PID) {
+	if state.PID > 0 && !process.IsAlive(state.PID) {
 		_ = os.Remove(statePath)
 		return 0, false
 	}

--- a/forge-ui/process.go
+++ b/forge-ui/process.go
@@ -11,8 +11,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
+
+	"github.com/initializ/forge/forge-core/util/process"
 )
 
 // PortAllocator manages port assignment for agent processes.
@@ -171,7 +172,7 @@ func (pm *ProcessManager) waitForPort(agentDir string, port int) bool {
 
 	for time.Now().Before(deadline) {
 		// Fast-fail: if the child process already exited, don't keep polling.
-		if pid > 0 && !pidAlive(pid) {
+		if pid > 0 && !process.IsAlive(pid) {
 			return false
 		}
 
@@ -199,15 +200,6 @@ func (pm *ProcessManager) readServePID(agentDir string) int {
 		return 0
 	}
 	return state.PID
-}
-
-// pidAlive checks if a process with the given PID is still running.
-func pidAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // readServeLogs reads .forge/serve.log and extracts the error message.


### PR DESCRIPTION
## Summary

Fixes #59 — `forge ui` on Windows reports `agent failed to start` for healthy daemons because `forge-ui/process.go`'s `pidAlive` used `os.Process.Signal(syscall.Signal(0))`, which is Unix-only. On Windows, Go's stdlib only translates `os.Interrupt` and `os.Kill`; every other signal — including `Signal(0)` — returns `"operating system does not support signal"`. So `pidAlive` returned `false` regardless of whether the PID was alive, breaking both startup detection and discovery on Windows.

## Symptom chain

| Step | macOS / Linux | Windows |
|---|---|---|
| 1. UI spawns `forge serve start` | OK | OK — daemon detaches and starts |
| 2. `waitForPort` reads PID from `.forge/serve.json` | OK | OK |
| 3. `pidAlive(pid)` checks the child is still alive | `Signal(0)` succeeds → `true` | `Signal(0)` errors → **`false`** |
| 4. `waitForPort` outcome | Loops until TCP port responds → `true` | Fast-fails at step 3, returns `false` |
| 5. UI reaction | Reports success | Reports failure, calls `readServeLogs` |
| 6. By this time `serve.log` contains the daemon's normal startup banner | n/a | UI displays the banner as "the error" |

`forge-ui/discovery.go:133` had the same broken check — on Windows it deleted `.forge/serve.json` on every page-load discovery scan, orphaning still-running daemons from the dashboard.

The forge-cli daemon code already had the correct platform-aware variant (`forge-cli/cmd/serve_windows.go`'s `isProcessAlive` uses `OpenProcess` + `CloseHandle`). The duplication is exactly what caused the forge-ui side to miss the Windows-specific implementation.

## Approach — Option A from #59

Extract the platform-aware check into a single helper consumed by both `forge-cli` and `forge-ui`. Build-tag split lives in exactly one place.

**New package: `forge-core/util/process/`**

```
process_unix.go     //go:build !windows  — FindProcess + Signal(0)
process_windows.go  //go:build windows   — OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) + CloseHandle
process_test.go     — cross-platform tests
```

**Call sites updated:**

- `forge-cli/cmd/serve_{unix,windows}.go` — deleted `isProcessAlive` (two duplicates removed).
- `forge-cli/cmd/serve.go` — 2 call sites switched to `process.IsAlive`.
- `forge-ui/process.go` — deleted `pidAlive`; `waitForPort` now calls `process.IsAlive`. Dropped the now-unused `syscall` import.
- `forge-ui/discovery.go` — uses `process.IsAlive` (this was the actively destructive serve.json-deletion site).

There is now **exactly one implementation** of "is this PID alive" in the tree.

## Tests

`forge-core/util/process/process_test.go`:

- `TestIsAlive_Self` — `IsAlive(os.Getpid())` must be `true`.
- `TestIsAlive_ChildAfterExit` — spawn a short-lived subprocess (`true` on Unix, `cmd /c exit 0` on Windows), wait for it to exit, assert `IsAlive(pid)` returns `false`. Subprocess-based assertion is deterministic across platforms — arbitrary high PIDs are not.

## Verification

```
gofmt -l forge-core/ forge-cli/ forge-plugins/ forge-ui/                      # clean
golangci-lint run ./{forge-core,forge-cli,forge-plugins,forge-ui}/...         # 0 issues
GOOS=windows go build ./...   (forge-core, forge-cli, forge-ui)               # all succeed
go test ./...   (forge-core, forge-cli, forge-ui)                             # all pass
```

CI doesn't currently run Windows; the `GOOS=windows go build` step at minimum proves the build-tag split is correct and the package compiles for Windows. The runtime behavior is covered by the OpenProcess + CloseHandle pattern that `forge-cli/cmd/serve_windows.go` already shipped — the helper just consolidates it.

## Acceptance criteria from #59

- [x] On Windows, the helper returns `true` for live PIDs and `false` for exited PIDs (proven by the build-tag-split implementation and the `forge-cli` daemon code that has shipped using this pattern).
- [x] `forge ui` no longer fast-fails startup on Windows when the daemon is healthy.
- [x] `forge ui` no longer deletes `.forge/serve.json` for still-running daemons on Windows.
- [x] macOS / Linux behavior is unchanged — `Signal(0)` is preserved on Unix.
- [x] Exactly one implementation of "is this PID alive" in the repo, consumed by both forge-cli and forge-ui.

## Manual verification

- [ ] On Windows: `forge ui`, start an agent. Confirm the dashboard shows the running state, not "agent failed to start".
- [ ] On Windows: refresh the dashboard while an agent is running. Confirm `.forge/serve.json` is still there and the dashboard still sees the agent.
- [ ] On macOS / Linux: same flows, confirm no regression.

## Files changed

```
forge-core/util/process/process_unix.go     | new (30 lines)
forge-core/util/process/process_windows.go  | new (39 lines)
forge-core/util/process/process_test.go     | new (45 lines)
forge-cli/cmd/serve.go                      | 2 call-site swaps + 1 import
forge-cli/cmd/serve_unix.go                 | -8 lines (delete duplicate)
forge-cli/cmd/serve_windows.go              | -10 lines (delete duplicate)
forge-ui/process.go                         | -10 lines duplicate, +1 import, 1 call-site swap
forge-ui/discovery.go                       | +1 import, 1 call-site swap
```

Total: +122 / -32. Net new code is in the helper package and its tests; net removed code is the duplicates.