### PR TITLE
feat(skills): add linear embedded skill (closes #66)

### DIFF
--- a/forge-skills/local/embedded/linear/SKILL.md
+++ b/forge-skills/local/embedded/linear/SKILL.md
@@ -102,18 +102,27 @@ Fetch a Linear issue by its human identifier.
 
 ## Tool: linear_search_issues
 
-Filter issues across one team (or across all teams if no team is given and no default is configured).
+Filter issues across one team — or across **all teams** the API key can see, if no team is supplied. **All parameters are optional.** Call this tool with `{}` when the user asks something broad like "list open issues" or "what's in the backlog" — do not ask for a team_id first; the result will include the team key in each issue's identifier (e.g. `ENG-12` vs `OPS-7`) and the user can drill down from there.
 
 **Input:**
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| team_id | string | no | Linear team UUID. Defaults to `$LINEAR_DEFAULT_TEAM_ID` when set. |
+| team_id | string | no | Linear team UUID **or** team key like `ENG`. Auto-detects which form. Defaults to `$LINEAR_DEFAULT_TEAM_ID` when set. |
 | state | string | no | Workflow state type (`unstarted`, `started`, `completed`, `canceled`, `triage`, `backlog`). |
 | assignee_email | string | no | Filter by assignee email. |
 | label | string | no | Filter by label name. |
 | query | string | no | Free-text search over title and description. |
 | limit | integer | no | Max results (default 20, capped at 100). |
+
+**Examples — call the tool directly, do not ask the user for an ID:**
+
+| User says | Tool input |
+| --- | --- |
+| "list open issues" / "what's in the backlog" | `{}` |
+| "show me INI tickets" | `{"team_id": "INI"}` (team key works) |
+| "open bugs in ENG" | `{"team_id": "ENG", "state": "unstarted", "label": "bug"}` |
+| "what's @alice working on?" | `{"assignee_email": "alice@example.com", "state": "started"}` |
 
 **Output:**
 

--- a/forge-skills/local/embedded/linear/SKILL.md
+++ b/forge-skills/local/embedded/linear/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: linear
+icon: 📋
+category: project-management
+tags:
+  - linear
+  - issue-tracking
+  - tickets
+  - workflow
+description: Read Linear issues, transition state, and post comments. The entry point for ticket-driven agent workflows.
+metadata:
+  forge:
+    requires:
+      bins:
+        - curl
+        - jq
+      env:
+        required:
+          - LINEAR_API_KEY
+        one_of: []
+        optional:
+          - LINEAR_DEFAULT_TEAM_ID
+    egress_domains:
+      - api.linear.app
+    timeout_hint: 60
+    guardrails:
+      deny_output:
+        - pattern: '"apiKey"\s*:\s*"[^"]+"'
+          action: redact
+        - pattern: 'Bearer\s+lin_api_[A-Za-z0-9]+'
+          action: redact
+---
+
+# Linear Skill
+
+You can read, search, and update Linear issues, list workflow states, and post comments. Use this skill as the entry point for ticket-driven workflows — turn `ENG-123` into a structured payload, transition state, comment on progress.
+
+## When to use this skill
+
+- The user references a Linear issue by identifier (`ENG-123`, `OPS-7`, etc.).
+- The user asks for "my tickets" / "open issues" / "what's assigned to me".
+- An automation needs to mark work started, post a PR link as a comment, or move a ticket through workflow states.
+
+## Issue identifier format
+
+Linear identifiers look like `<TEAM_KEY>-<NUMBER>` — `ENG-123`, `OPS-7`. They are **not** GraphQL UUIDs. The Linear API accepts both forms on `issue(id:)`, so always pass the human identifier the user gave you. Never invent or normalise identifiers — use them verbatim.
+
+## State transition pattern (hard rule)
+
+You MUST call `linear_get_workflow_states` first and use the resolved `id` when calling `linear_update_issue_state`. State IDs are per-team UUIDs; state names like `"Todo"` or `"In Progress"` are not portable across teams and cannot be passed to `linear_update_issue_state` directly.
+
+Workflow:
+
+1. `linear_get_issue` to find the issue's `team.id`.
+2. `linear_get_workflow_states` with that `team_id` to enumerate the team's states.
+3. Pick the state by matching its `name` (case-insensitive) or `type` (`unstarted`, `started`, `completed`, `canceled`, `triage`, `backlog`).
+4. `linear_update_issue_state` with the issue identifier and the resolved `state_id`.
+
+## Commenting etiquette
+
+Post a comment when:
+
+- Work has been picked up (one comment, e.g. `"Working on this."`).
+- A pull request has been opened (one comment with the PR URL).
+- Work is blocked and the user should know.
+- Work is complete (one comment summarising what shipped).
+
+Do not chatter. Post no more than **one comment per agent action**. Do not narrate intermediate tool calls, file edits, or reasoning into Linear comments — the channel-side conversation is the place for that. Comments are durable artifacts on the ticket; treat them like git commit messages, not Slack messages.
+
+## Safety rules
+
+- Never include secrets, tokens, or environment variable values in comment bodies.
+- Never transition an issue to a "Done" or "Completed" state without explicit user confirmation.
+- Never delete issues, comments, or projects through this skill — the tools don't support it. If the user asks, tell them this skill is read/comment/transition only.
+- When the user asks for "my tickets", default to state filter `"Todo"` or `"In Progress"` (state types `unstarted`, `started`) unless they specify otherwise.
+
+## Tool: linear_get_issue
+
+Fetch a Linear issue by its human identifier.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| identifier | string | yes | Issue identifier like `ENG-123` |
+
+**Output:**
+
+```json
+{
+  "identifier": "ENG-123",
+  "title": "...",
+  "description": "...",
+  "state": { "id": "...", "name": "In Progress", "type": "started" },
+  "assignee": { "email": "...", "name": "..." },
+  "team": { "id": "...", "key": "ENG", "name": "Engineering" },
+  "labels": ["bug", "p1"],
+  "priority": 2,
+  "url": "https://linear.app/..."
+}
+```
+
+## Tool: linear_search_issues
+
+Filter issues across one team (or across all teams if no team is given and no default is configured).
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| team_id | string | no | Linear team UUID. Defaults to `$LINEAR_DEFAULT_TEAM_ID` when set. |
+| state | string | no | Workflow state type (`unstarted`, `started`, `completed`, `canceled`, `triage`, `backlog`). |
+| assignee_email | string | no | Filter by assignee email. |
+| label | string | no | Filter by label name. |
+| query | string | no | Free-text search over title and description. |
+| limit | integer | no | Max results (default 20, capped at 100). |
+
+**Output:**
+
+```json
+{
+  "count": 3,
+  "issues": [
+    { "identifier": "ENG-1", "title": "...", "state": "Todo", "assignee_email": "...", "url": "..." }
+  ]
+}
+```
+
+## Tool: linear_list_my_issues
+
+List issues assigned to the API key's owner (`viewer`).
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| state | string | no | Comma-separated state types. Default: `"started,unstarted"` ("In Progress" / "Todo"). |
+| limit | integer | no | Max results (default 20, capped at 100). |
+
+**Output:** same shape as `linear_search_issues`.
+
+## Tool: linear_get_workflow_states
+
+Enumerate a team's workflow states. **Required before `linear_update_issue_state`.**
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| team_id | string | yes | Linear team UUID (from `linear_get_issue`'s `team.id`). |
+
+**Output:**
+
+```json
+{
+  "team_id": "...",
+  "states": [
+    { "id": "...", "name": "Todo",        "type": "unstarted", "position": 0 },
+    { "id": "...", "name": "In Progress", "type": "started",   "position": 1 },
+    { "id": "...", "name": "Done",        "type": "completed", "position": 2 }
+  ]
+}
+```
+
+States are sorted by `position`.
+
+## Tool: linear_update_issue_state
+
+Transition an issue to a different workflow state. The `state_id` must come from `linear_get_workflow_states` — do not invent or guess it.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| identifier | string | yes | Issue identifier like `ENG-123`. |
+| state_id | string | yes | Workflow state UUID from `linear_get_workflow_states`. |
+
+**Output:**
+
+```json
+{
+  "success": true,
+  "identifier": "ENG-123",
+  "state": { "id": "...", "name": "In Progress", "type": "started" }
+}
+```
+
+## Tool: linear_add_comment
+
+Post a markdown comment to an issue.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| identifier | string | yes | Issue identifier like `ENG-123`. |
+| body | string | yes | Markdown comment body. Capped at 10 000 characters; longer bodies are truncated client-side. |
+
+**Output:**
+
+```json
+{
+  "success": true,
+  "comment": { "id": "...", "url": "https://linear.app/...", "created_at": "2026-05-20T..." }
+}
+```

--- a/forge-skills/local/embedded/linear/scripts/common.sh
+++ b/forge-skills/local/embedded/linear/scripts/common.sh
@@ -45,10 +45,11 @@ linear_graphql() {
     --max-time 30 \
     -d "$body" \
     "$LINEAR_API_URL")" || linear_die "network error calling Linear API"
-  # Surface GraphQL errors clearly.
+  # Surface GraphQL errors clearly — include message + path + extensions so
+  # validation failures point at the offending argument.
   if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
     local err
-    err="$(echo "$resp" | jq -r '.errors[0].message')"
+    err="$(echo "$resp" | jq -c '.errors[0] | {message, path, extensions}' 2>/dev/null)"
     linear_die "linear api error: $err"
   fi
   echo "$resp" | jq '.data'

--- a/forge-skills/local/embedded/linear/scripts/common.sh
+++ b/forge-skills/local/embedded/linear/scripts/common.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shared helpers for linear skill scripts.
+# Do not run this file directly — it is sourced.
+
+LINEAR_API_URL="https://api.linear.app/graphql"
+
+# Read JSON arg from $1 or stdin, validate, set INPUT_JSON.
+linear_read_input() {
+  if [ -n "${1:-}" ]; then
+    INPUT_JSON="$1"
+  else
+    INPUT_JSON="$(cat)"
+  fi
+  if ! echo "$INPUT_JSON" | jq -e . >/dev/null 2>&1; then
+    linear_die "invalid JSON input"
+  fi
+}
+
+# Emit error to stderr as JSON, exit 1.
+linear_die() {
+  jq -n --arg msg "$1" '{"error": $msg}' >&2
+  exit 1
+}
+
+# Require an env var to be set, else die.
+linear_require_env() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    linear_die "missing required environment variable: $var"
+  fi
+}
+
+# POST a GraphQL query. Args: $1 = query, $2 = variables JSON.
+# Echoes the data payload on success, dies on error.
+linear_graphql() {
+  local query="$1"
+  local variables="${2:-{\}}"
+  linear_require_env LINEAR_API_KEY
+  local body
+  body="$(jq -n --arg q "$query" --argjson v "$variables" '{query: $q, variables: $v}')"
+  local resp
+  resp="$(curl -sS -X POST \
+    -H "Authorization: $LINEAR_API_KEY" \
+    -H "Content-Type: application/json" \
+    --max-time 30 \
+    -d "$body" \
+    "$LINEAR_API_URL")" || linear_die "network error calling Linear API"
+  # Surface GraphQL errors clearly.
+  if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+    local err
+    err="$(echo "$resp" | jq -r '.errors[0].message')"
+    linear_die "linear api error: $err"
+  fi
+  echo "$resp" | jq '.data'
+}

--- a/forge-skills/local/embedded/linear/scripts/linear-add-comment.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-add-comment.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# linear-add-comment.sh — Post a markdown comment to a Linear issue.
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Body is capped at 10 000 chars client-side; longer bodies are truncated.
+# Usage: ./linear-add-comment.sh '{"identifier":"ENG-123","body":"Working on this."}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+IDENT="$(echo "$INPUT_JSON" | jq -r '.identifier // empty')"
+BODY="$(echo "$INPUT_JSON" | jq -r '.body // empty')"
+[ -n "$IDENT" ] || linear_die "identifier field is required (e.g. \"ENG-123\")"
+[ -n "$BODY" ] || linear_die "body field is required"
+
+# Cap body length at 10 000 characters.
+BODY="$(printf '%s' "$BODY" | head -c 10000)"
+
+# commentCreate expects the issue UUID, not the human identifier. Resolve it.
+RESOLVE_QUERY='query($id: String!) { issue(id: $id) { id } }'
+RESOLVE_VARS="$(jq -n --arg id "$IDENT" '{id: $id}')"
+RESOLVE_DATA="$(linear_graphql "$RESOLVE_QUERY" "$RESOLVE_VARS")"
+ISSUE_UUID="$(echo "$RESOLVE_DATA" | jq -r '.issue.id // empty')"
+[ -n "$ISSUE_UUID" ] || linear_die "issue not found: $IDENT"
+
+MUTATION='mutation($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id url createdAt }
+  }
+}'
+
+VARS="$(jq -n --arg id "$ISSUE_UUID" --arg b "$BODY" '{issueId: $id, body: $b}')"
+DATA="$(linear_graphql "$MUTATION" "$VARS")"
+
+SUCCESS="$(echo "$DATA" | jq -r '.commentCreate.success // false')"
+if [ "$SUCCESS" != "true" ]; then
+  linear_die "commentCreate returned success=false for $IDENT"
+fi
+
+echo "$DATA" | jq '{
+  success: .commentCreate.success,
+  comment: {
+    id: .commentCreate.comment.id,
+    url: .commentCreate.comment.url,
+    created_at: .commentCreate.comment.createdAt
+  }
+}'

--- a/forge-skills/local/embedded/linear/scripts/linear-get-issue.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-get-issue.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# linear-get-issue.sh — Fetch one Linear issue by its human identifier.
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Usage: ./linear-get-issue.sh '{"identifier": "ENG-123"}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+IDENT="$(echo "$INPUT_JSON" | jq -r '.identifier // empty')"
+[ -n "$IDENT" ] || linear_die "identifier field is required (e.g. \"ENG-123\")"
+
+QUERY='query($id: String!) {
+  issue(id: $id) {
+    identifier
+    title
+    description
+    state { id name type }
+    assignee { email name }
+    team { id key name }
+    labels { nodes { name } }
+    priority
+    url
+  }
+}'
+
+VARS="$(jq -n --arg id "$IDENT" '{id: $id}')"
+DATA="$(linear_graphql "$QUERY" "$VARS")"
+
+ISSUE="$(echo "$DATA" | jq '.issue')"
+if [ "$ISSUE" = "null" ]; then
+  linear_die "issue not found: $IDENT"
+fi
+
+echo "$ISSUE" | jq '{
+  identifier,
+  title,
+  description,
+  state,
+  assignee,
+  team,
+  labels: [(.labels.nodes // [])[].name],
+  priority,
+  url
+}'

--- a/forge-skills/local/embedded/linear/scripts/linear-get-workflow-states.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-get-workflow-states.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# linear-get-workflow-states.sh — List a team's workflow states (Todo, In Progress, ...).
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Must be called before linear_update_issue_state to discover the team's state IDs.
+# Usage: ./linear-get-workflow-states.sh '{"team_id":"abc-..."}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+TEAM_ID="$(echo "$INPUT_JSON" | jq -r '.team_id // empty')"
+[ -n "$TEAM_ID" ] || linear_die "team_id field is required"
+
+QUERY='query($teamId: String!) {
+  team(id: $teamId) {
+    states { nodes { id name type position } }
+  }
+}'
+
+VARS="$(jq -n --arg id "$TEAM_ID" '{teamId: $id}')"
+DATA="$(linear_graphql "$QUERY" "$VARS")"
+
+TEAM="$(echo "$DATA" | jq '.team')"
+if [ "$TEAM" = "null" ]; then
+  linear_die "team not found: $TEAM_ID"
+fi
+
+echo "$DATA" | jq --arg tid "$TEAM_ID" '{
+  team_id: $tid,
+  states: [.team.states.nodes[] | {id, name, type, position}] | sort_by(.position)
+}'

--- a/forge-skills/local/embedded/linear/scripts/linear-list-my-issues.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-list-my-issues.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# linear-list-my-issues.sh — List issues assigned to the API key's owner.
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Usage: ./linear-list-my-issues.sh '{"state":"started,unstarted","limit":20}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+STATE_CSV="$(echo "$INPUT_JSON" | jq -r '.state // "started,unstarted"')"
+LIMIT="$(echo "$INPUT_JSON" | jq -r '.limit // 20')"
+
+if [ "$LIMIT" -gt 100 ] 2>/dev/null; then
+  LIMIT=100
+elif ! [ "$LIMIT" -gt 0 ] 2>/dev/null; then
+  LIMIT=20
+fi
+
+# Convert CSV to JSON array.
+STATE_ARRAY="$(echo "$STATE_CSV" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')"
+
+# Resolve viewer.id first.
+VIEWER_DATA="$(linear_graphql 'query { viewer { id } }' '{}')"
+VIEWER_ID="$(echo "$VIEWER_DATA" | jq -r '.viewer.id // empty')"
+[ -n "$VIEWER_ID" ] || linear_die "could not resolve viewer id — is LINEAR_API_KEY valid?"
+
+FILTER="$(jq -n --arg vid "$VIEWER_ID" --argjson states "$STATE_ARRAY" \
+  '{assignee: {id: {eq: $vid}}, state: {type: {in: $states}}}')"
+
+GQL='query($filter: IssueFilter, $first: Int!) {
+  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+    nodes {
+      identifier
+      title
+      url
+      state { name type }
+      assignee { email }
+    }
+  }
+}'
+
+VARS="$(jq -n --argjson f "$FILTER" --argjson n "$LIMIT" '{filter: $f, first: $n}')"
+DATA="$(linear_graphql "$GQL" "$VARS")"
+
+echo "$DATA" | jq '{
+  count: (.issues.nodes | length),
+  issues: [.issues.nodes[] | {
+    identifier,
+    title,
+    state: (.state.name // null),
+    assignee_email: (.assignee.email // null),
+    url
+  }]
+}'

--- a/forge-skills/local/embedded/linear/scripts/linear-list-my-issues.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-list-my-issues.sh
@@ -30,7 +30,7 @@ FILTER="$(jq -n --arg vid "$VIEWER_ID" --argjson states "$STATE_ARRAY" \
   '{assignee: {id: {eq: $vid}}, state: {type: {in: $states}}}')"
 
 GQL='query($filter: IssueFilter, $first: Int!) {
-  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+  issues(filter: $filter, first: $first) {
     nodes {
       identifier
       title

--- a/forge-skills/local/embedded/linear/scripts/linear-search-issues.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-search-issues.sh
@@ -29,9 +29,16 @@ elif ! [ "$LIMIT" -gt 0 ] 2>/dev/null; then
 fi
 
 # Build the filter object incrementally.
+# Linear's TeamFilter accepts either an `id` (UUID) or a `key` (short team
+# prefix like "ENG"). Auto-detect which form was supplied so the same
+# parameter works whether the caller passes a UUID or a team key.
 FILTER='{}'
 if [ -n "$TEAM_ID" ]; then
-  FILTER="$(echo "$FILTER" | jq --arg id "$TEAM_ID" '. + {team: {id: {eq: $id}}}')"
+  if [[ "$TEAM_ID" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+    FILTER="$(echo "$FILTER" | jq --arg id "$TEAM_ID" '. + {team: {id: {eq: $id}}}')"
+  else
+    FILTER="$(echo "$FILTER" | jq --arg key "$TEAM_ID" '. + {team: {key: {eq: $key}}}')"
+  fi
 fi
 if [ -n "$STATE" ]; then
   FILTER="$(echo "$FILTER" | jq --arg t "$STATE" '. + {state: {type: {eq: $t}}}')"
@@ -46,19 +53,39 @@ if [ -n "$QUERY_TEXT" ]; then
   FILTER="$(echo "$FILTER" | jq --arg q "$QUERY_TEXT" '. + {searchableContent: {contains: $q}}')"
 fi
 
-GQL='query($filter: IssueFilter, $first: Int!) {
-  issues(filter: $filter, first: $first, orderBy: updatedAt) {
-    nodes {
-      identifier
-      title
-      url
-      state { name type }
-      assignee { email }
+# If the filter object has zero fields, omit it from variables so Linear
+# treats the argument as "unset" rather than "an empty filter input".
+# `orderBy` is dropped — Linear's default ordering is fine and the bare
+# enum form was the leading suspect for the schema-validation rejection.
+HAS_FILTER="$(echo "$FILTER" | jq 'length > 0')"
+if [ "$HAS_FILTER" = "true" ]; then
+  GQL='query($filter: IssueFilter, $first: Int!) {
+    issues(filter: $filter, first: $first) {
+      nodes {
+        identifier
+        title
+        url
+        state { name type }
+        assignee { email }
+      }
     }
-  }
-}'
+  }'
+  VARS="$(jq -n --argjson f "$FILTER" --argjson n "$LIMIT" '{filter: $f, first: $n}')"
+else
+  GQL='query($first: Int!) {
+    issues(first: $first) {
+      nodes {
+        identifier
+        title
+        url
+        state { name type }
+        assignee { email }
+      }
+    }
+  }'
+  VARS="$(jq -n --argjson n "$LIMIT" '{first: $n}')"
+fi
 
-VARS="$(jq -n --argjson f "$FILTER" --argjson n "$LIMIT" '{filter: $f, first: $n}')"
 DATA="$(linear_graphql "$GQL" "$VARS")"
 
 echo "$DATA" | jq '{

--- a/forge-skills/local/embedded/linear/scripts/linear-search-issues.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-search-issues.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# linear-search-issues.sh — Filter Linear issues by team/state/assignee/label/query.
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Usage: ./linear-search-issues.sh '{"team_id":"...","state":"started","limit":10}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+TEAM_ID="$(echo "$INPUT_JSON" | jq -r '.team_id // empty')"
+STATE="$(echo "$INPUT_JSON" | jq -r '.state // empty')"
+ASSIGNEE_EMAIL="$(echo "$INPUT_JSON" | jq -r '.assignee_email // empty')"
+LABEL="$(echo "$INPUT_JSON" | jq -r '.label // empty')"
+QUERY_TEXT="$(echo "$INPUT_JSON" | jq -r '.query // empty')"
+LIMIT="$(echo "$INPUT_JSON" | jq -r '.limit // 20')"
+
+# Fall back to default team if not provided.
+if [ -z "$TEAM_ID" ] && [ -n "${LINEAR_DEFAULT_TEAM_ID:-}" ]; then
+  TEAM_ID="$LINEAR_DEFAULT_TEAM_ID"
+fi
+
+# Cap limit at 100.
+if [ "$LIMIT" -gt 100 ] 2>/dev/null; then
+  LIMIT=100
+elif ! [ "$LIMIT" -gt 0 ] 2>/dev/null; then
+  LIMIT=20
+fi
+
+# Build the filter object incrementally.
+FILTER='{}'
+if [ -n "$TEAM_ID" ]; then
+  FILTER="$(echo "$FILTER" | jq --arg id "$TEAM_ID" '. + {team: {id: {eq: $id}}}')"
+fi
+if [ -n "$STATE" ]; then
+  FILTER="$(echo "$FILTER" | jq --arg t "$STATE" '. + {state: {type: {eq: $t}}}')"
+fi
+if [ -n "$ASSIGNEE_EMAIL" ]; then
+  FILTER="$(echo "$FILTER" | jq --arg e "$ASSIGNEE_EMAIL" '. + {assignee: {email: {eq: $e}}}')"
+fi
+if [ -n "$LABEL" ]; then
+  FILTER="$(echo "$FILTER" | jq --arg l "$LABEL" '. + {labels: {name: {eq: $l}}}')"
+fi
+if [ -n "$QUERY_TEXT" ]; then
+  FILTER="$(echo "$FILTER" | jq --arg q "$QUERY_TEXT" '. + {searchableContent: {contains: $q}}')"
+fi
+
+GQL='query($filter: IssueFilter, $first: Int!) {
+  issues(filter: $filter, first: $first, orderBy: updatedAt) {
+    nodes {
+      identifier
+      title
+      url
+      state { name type }
+      assignee { email }
+    }
+  }
+}'
+
+VARS="$(jq -n --argjson f "$FILTER" --argjson n "$LIMIT" '{filter: $f, first: $n}')"
+DATA="$(linear_graphql "$GQL" "$VARS")"
+
+echo "$DATA" | jq '{
+  count: (.issues.nodes | length),
+  issues: [.issues.nodes[] | {
+    identifier,
+    title,
+    state: (.state.name // null),
+    assignee_email: (.assignee.email // null),
+    url
+  }]
+}'

--- a/forge-skills/local/embedded/linear/scripts/linear-update-issue-state.sh
+++ b/forge-skills/local/embedded/linear/scripts/linear-update-issue-state.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# linear-update-issue-state.sh — Transition an issue to a different workflow state.
+# shellcheck disable=SC2016  # GraphQL query strings use $var literally
+# Resolve the state_id via linear-get-workflow-states.sh first.
+# Usage: ./linear-update-issue-state.sh '{"identifier":"ENG-123","state_id":"uuid"}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+linear_read_input "$@"
+
+IDENT="$(echo "$INPUT_JSON" | jq -r '.identifier // empty')"
+STATE_ID="$(echo "$INPUT_JSON" | jq -r '.state_id // empty')"
+[ -n "$IDENT" ] || linear_die "identifier field is required (e.g. \"ENG-123\")"
+[ -n "$STATE_ID" ] || linear_die "state_id field is required — call linear_get_workflow_states first"
+
+MUTATION='mutation($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue { identifier state { id name type } }
+  }
+}'
+
+VARS="$(jq -n --arg id "$IDENT" --arg sid "$STATE_ID" '{id: $id, stateId: $sid}')"
+DATA="$(linear_graphql "$MUTATION" "$VARS")"
+
+SUCCESS="$(echo "$DATA" | jq -r '.issueUpdate.success // false')"
+if [ "$SUCCESS" != "true" ]; then
+  linear_die "issueUpdate returned success=false for $IDENT"
+fi
+
+echo "$DATA" | jq '{
+  success: .issueUpdate.success,
+  identifier: .issueUpdate.issue.identifier,
+  state: .issueUpdate.issue.state
+}'

--- a/forge-skills/local/registry_embedded_test.go
+++ b/forge-skills/local/registry_embedded_test.go
@@ -16,12 +16,12 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		t.Fatalf("List error: %v", err)
 	}
 
-	if len(skills) != 13 {
+	if len(skills) != 14 {
 		names := make([]string, len(skills))
 		for i, s := range skills {
 			names[i] = s.Name
 		}
-		t.Fatalf("expected 13 skills, got %d: %v", len(skills), names)
+		t.Fatalf("expected 14 skills, got %d: %v", len(skills), names)
 	}
 
 	// Verify all expected skills are present
@@ -44,6 +44,7 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		"codegen-html":          {displayName: "Codegen Html", hasEnv: false, hasBins: true, hasEgress: true},
 		"k8s-pod-rightsizer":    {displayName: "K8s Pod Rightsizer", hasEnv: false, hasBins: true, hasEgress: false},
 		"k8s-cost-visibility":   {displayName: "K8s Cost Visibility", hasEnv: false, hasBins: true, hasEgress: true},
+		"linear":                {displayName: "Linear", hasEnv: true, hasBins: true, hasEgress: true},
 	}
 
 	for _, s := range skills {
@@ -193,6 +194,81 @@ func TestEmbeddedRegistry_TavilyResearchDetails(t *testing.T) {
 	// Check timeout hint
 	if s.TimeoutHint != 300 {
 		t.Errorf("TimeoutHint = %d, want 300", s.TimeoutHint)
+	}
+}
+
+func TestEmbeddedRegistry_LinearDetails(t *testing.T) {
+	reg, err := NewEmbeddedRegistry()
+	if err != nil {
+		t.Fatalf("NewEmbeddedRegistry error: %v", err)
+	}
+
+	s := reg.Get("linear")
+	if s == nil {
+		t.Fatal("Get(\"linear\") returned nil")
+	}
+	if s.Icon != "📋" {
+		t.Errorf("Icon = %q, want 📋", s.Icon)
+	}
+	if s.Category != "project-management" {
+		t.Errorf("Category = %q, want project-management", s.Category)
+	}
+	if len(s.RequiredEnv) != 1 || s.RequiredEnv[0] != "LINEAR_API_KEY" {
+		t.Errorf("RequiredEnv = %v, want [LINEAR_API_KEY]", s.RequiredEnv)
+	}
+	if len(s.RequiredBins) < 2 {
+		t.Errorf("RequiredBins = %v, want at least [curl, jq]", s.RequiredBins)
+	}
+
+	foundDomain := false
+	for _, d := range s.EgressDomains {
+		if d == "api.linear.app" {
+			foundDomain = true
+		}
+	}
+	if !foundDomain {
+		t.Errorf("EgressDomains = %v, want api.linear.app", s.EgressDomains)
+	}
+
+	// Linear is a multi-script skill — verify all 6 per-tool scripts + the
+	// sourced helper. (The helper is named common.sh, not _common.sh, because
+	// //go:embed excludes files starting with '_'.)
+	expectedScripts := []string{
+		"common.sh",
+		"linear-add-comment.sh",
+		"linear-get-issue.sh",
+		"linear-get-workflow-states.sh",
+		"linear-list-my-issues.sh",
+		"linear-search-issues.sh",
+		"linear-update-issue-state.sh",
+	}
+	gotScripts := reg.ListScripts("linear")
+	gotSet := make(map[string]bool, len(gotScripts))
+	for _, n := range gotScripts {
+		gotSet[n] = true
+	}
+	for _, want := range expectedScripts {
+		if !gotSet[want] {
+			t.Errorf("missing expected script %q (got: %v)", want, gotScripts)
+		}
+	}
+
+	// Verify the SKILL.md content references the canonical tool names.
+	content, err := reg.LoadContent("linear")
+	if err != nil {
+		t.Fatalf("LoadContent error: %v", err)
+	}
+	for _, tool := range []string{
+		"linear_get_issue",
+		"linear_search_issues",
+		"linear_list_my_issues",
+		"linear_get_workflow_states",
+		"linear_update_issue_state",
+		"linear_add_comment",
+	} {
+		if !strings.Contains(string(content), "## Tool: "+tool) {
+			t.Errorf("SKILL.md missing '## Tool: %s' heading", tool)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

New script-backed embedded skill that exposes Linear (GraphQL) read, search, transition, and commenting as 6 first-class LLM tools. Entry point for ticket-driven agent workflows — turn \`ENG-123\` into a structured payload, transition state, post progress comments. Closes #66.

## Tools (auto-registered from \`## Tool:\` headings)

| Tool | Required | Optional | Purpose |
|---|---|---|---|
| \`linear_get_issue\` | \`identifier\` | — | Fetch one issue |
| \`linear_search_issues\` | — | \`team_id\`, \`state\`, \`assignee_email\`, \`label\`, \`query\`, \`limit\` | Filter issues |
| \`linear_list_my_issues\` | — | \`state\` (default \`started,unstarted\`), \`limit\` | Viewer's issues |
| \`linear_get_workflow_states\` | \`team_id\` | — | Enumerate team states (required before transitioning) |
| \`linear_update_issue_state\` | \`identifier\`, \`state_id\` | — | Transition issue |
| \`linear_add_comment\` | \`identifier\`, \`body\` | — | Post markdown comment (10K cap) |

## Layout

```
forge-skills/local/embedded/linear/
  SKILL.md
  scripts/
    common.sh                         (sourced helper)
    linear-get-issue.sh
    linear-search-issues.sh
    linear-list-my-issues.sh
    linear-get-workflow-states.sh
    linear-update-issue-state.sh
    linear-add-comment.sh
```

The runtime auto-maps tool names (\`linear_get_issue\`) to script files (\`linear-get-issue.sh\`) via \`strings.ReplaceAll(name, \"_\", \"-\")\` in \`forge-cli/runtime/runner.go\`. No Go code changes outside the registry test.

### Note on \`common.sh\` (not \`_common.sh\`)

The issue brief named the helper \`_common.sh\`. Go's \`//go:embed\` directive **excludes** files and directories starting with \`_\` or \`.\` from the embedded FS. Since \`forge-skills/local/embed.go\` uses \`//go:embed embedded\` (without an \`all:\` prefix), a leading-underscore filename would silently be omitted. The intentionally-hidden \`embedded/_template/\` directory relies on this behaviour, so switching to \`all:\` would surface it as a real skill. The minimal fix is to rename the helper to \`common.sh\` — same role, valid include.

## Frontmatter

- \`category: project-management\`, \`icon: 📋\`, \`tags\` kebab-case (validated by existing tests)
- \`requires.env.required: [LINEAR_API_KEY]\`, optional \`[LINEAR_DEFAULT_TEAM_ID]\`
- \`egress_domains: [api.linear.app]\`, \`timeout_hint: 60\`, per-call \`curl --max-time 30\`
- \`guardrails.deny_output\` redacts any \`apiKey\` JSON field or \`Bearer lin_api_...\` token that might leak back through a Linear error payload

## Authentication

Raw API key in the \`Authorization\` header — **no \`Bearer\` prefix**. This is the single most common Linear integration mistake; \`scripts/common.sh\` does it correctly and the SKILL.md frontmatter does not even mention OAuth.

## Tests

- \`forge-skills/local/registry_embedded_test.go\`:
  - Bumped expected skill count 13 → 14.
  - Added \`linear\` to the \`expectedSkills\` map with \`hasEnv: true, hasBins: true, hasEgress: true\`.
  - New \`TestEmbeddedRegistry_LinearDetails\` — verifies icon, category, env, bins, egress, the 7 scripts in \`ListScripts(\"linear\")\`, and that the SKILL.md contains all 6 canonical \`## Tool: linear_*\` headings.
- \`shellcheck -x\` clean on all 7 scripts (info-level SC1091 only when run without the script dir as cwd, which is expected).
- Smoke-tested error paths from a fresh shell:
  - Missing \`LINEAR_API_KEY\` → \`{\"error\": \"missing required environment variable: LINEAR_API_KEY\"}\` + exit 1.
  - Invalid JSON → \`{\"error\": \"invalid JSON input\"}\` + exit 1.
  - Missing required field → \`{\"error\": \"identifier field is required ...\"}\` + exit 1.

## Test plan

- [x] \`go test ./forge-skills/...\` — all green
- [x] \`go test ./forge-core/...\` \`./forge-cli/...\` \`./forge-plugins/...\` — no regressions
- [x] \`gofmt -w\`, \`golangci-lint run ./forge-skills/...\` — 0 issues
- [x] \`shellcheck -x scripts/*.sh\` (from the scripts dir) — exit 0
- [x] Per-script smoke tests for missing env / bad JSON / missing required field
- [ ] Manual: \`forge init\` shows \"📋 Linear\" in the skills picker
- [ ] Manual: live \`linear_get_issue\` call against a real workspace with \`LINEAR_API_KEY\` set

## Out of scope (deferred)

- OAuth authentication (\`LINEAR_OAUTH_*\` env vars). Personal API keys are sufficient for v1.
- Webhooks / event subscriptions.
- Project, cycle, or milestone operations.
- Bulk operations.
- Linear Insights / views / templates.
- \`linear_delete_issue\` / \`linear_archive_issue\` — the tools don't exist; the SKILL.md tells the LLM that, so it doesn't promise users it can delete things.
- Any orchestration logic chaining Linear → GitHub → code-agent. That belongs in the agent's system prompt or a future \`dev-agent\` pack manifest.