### PR TITLE
feat(skills): add code-plan embedded skill (closes #68)

### DIFF
--- a/forge-skills/local/embedded/code-plan/SKILL.md
+++ b/forge-skills/local/embedded/code-plan/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: code-plan
+icon: 🗺️
+category: developer
+tags:
+  - planning
+  - code-generation
+  - ticket-to-pr
+  - llm-powered
+description: Turn a task description and repository into a structured implementation plan (files to create, files to modify, tests to add, risks).
+metadata:
+  forge:
+    requires:
+      bins:
+        - curl
+        - jq
+        - git
+      env:
+        required: []
+        one_of:
+          - ANTHROPIC_API_KEY
+          - OPENAI_API_KEY
+        optional:
+          - PLAN_MODEL
+          - PLAN_MAX_REPO_SIGNAL_BYTES
+    egress_domains:
+      - api.anthropic.com
+      - api.openai.com
+    timeout_hint: 180
+    guardrails:
+      deny_output:
+        - pattern: 'sk-[A-Za-z0-9]{20,}'
+          action: redact
+        - pattern: 'sk-ant-[A-Za-z0-9\-]+'
+          action: redact
+---
+
+# Code Plan Skill
+
+Generate a structured plan for implementing a task in a specific repository. The plan is the bridge between "I have a ticket" and "let me start writing code" — it lists files to create, files to modify, tests to add, and risks before any code is written.
+
+This skill produces JSON. It does **not** write code; that is `code_agent_*`'s job.
+
+## When to use this skill
+
+- The user provides a Linear ticket, GitHub issue, or free-form task description and asks you to implement it.
+- **Before** any `code_agent_write`, `code_agent_edit`, or `github_commit` tool call.
+- When the user explicitly asks for a plan.
+
+## When NOT to use this skill
+
+- Tiny single-file edits (1–3 lines). Just edit directly.
+- Pure exploration tasks. Use `grep_search` / `directory_tree` instead.
+- Pure scaffolding tasks (e.g. "create a new React app"). Use `code_agent_scaffold` instead.
+
+## Plan-then-execute discipline
+
+Once a plan is generated, present its `summary` and `files_to_modify` / `files_to_create` lists to the user before writing code. Do NOT proceed to implementation if the plan returns `complexity: "high"` or non-empty `risks` without acknowledging them to the user. The plan is a contract: subsequent code-writing tool calls should match files listed in the plan. If the plan turns out to be wrong, regenerate it rather than silently drifting from it.
+
+## Workflow integration
+
+Canonical sequence for a ticket-to-PR flow:
+
+```
+linear_get_issue
+  → code_plan_create                  [present summary + risks to user]
+  → code_agent_write / code_agent_edit
+  → code_plan_validate                [optional sanity check before commit]
+  → github_commit
+  → github_create_pr
+```
+
+## Repo signal extraction (informational)
+
+`code_plan_create` automatically samples the repository so the LLM has enough context to plan without you pre-reading files. It collects:
+
+1. The top entries of `git ls-files` (the repo tree).
+2. The contents of detected manifest files: `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `pom.xml`, `build.gradle*`.
+3. The first ~4 KB of `README.md` if present.
+
+The total signal is size-bounded (default 256 KB, override via `PLAN_MAX_REPO_SIGNAL_BYTES`). If the repo is too large to fit, the tool returns `status: "repo_too_large"` rather than truncating silently — pass `context_files` to scope the plan to the relevant files, or call from a subdirectory.
+
+Just pass `repo_path`. Do not pre-read the repo with `grep_search` before calling this tool.
+
+## Tool: code_plan_create
+
+Generate a structured implementation plan for a task in a repository. One LLM call, one plan.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| repo_path | string | yes | Absolute or `~`-prefixed path to the repo. Required because scripts run in the agent's working directory, not the user's project. |
+| task | string | yes | Task description — Linear ticket body verbatim, or a free-form ask. Markdown ok. |
+| context_files | string[] | no | Repo-relative paths to include in full as additional context (e.g. `["src/auth/login.go"]`). Capped at 5 files, 50 KB total. |
+| target_branch | string | no | Branch name being worked on (informational, helps the LLM pick consistent naming). |
+| ticket_id | string | no | Linear identifier or GitHub issue number. Echoed back in the output for traceability. |
+
+**Output — success:**
+
+```json
+{
+  "status": "ok",
+  "ticket_id": "ENG-123",
+  "stack_detected": "go",
+  "summary": "One-paragraph plain-English description of the planned change.",
+  "approach": "Higher-level reasoning: why this approach, what alternatives were considered.",
+  "files_to_create": [
+    { "path": "src/billing/invoice.go", "purpose": "New domain type and constructor for Invoice." }
+  ],
+  "files_to_modify": [
+    { "path": "src/api/routes.go", "change": "Register /invoices route group, wire to handler." }
+  ],
+  "tests_to_add": [
+    { "path": "src/billing/invoice_test.go", "covers": "Construction, validation, JSON round-trip." }
+  ],
+  "risks": [
+    { "severity": "medium", "risk": "Existing customers will see a 422 on legacy payloads.", "mitigation": "Add a feature flag and default to the new behavior only for accounts created after launch date." }
+  ],
+  "complexity": "medium",
+  "estimated_file_count": 3,
+  "open_questions": [
+    "Should invoice numbers be globally unique or per-customer?"
+  ]
+}
+```
+
+`complexity` is one of `low`, `medium`, `high`. `risks[].severity` is one of `low`, `medium`, `high`.
+
+**Output — repo too large:**
+
+```json
+{
+  "status": "repo_too_large",
+  "tree_bytes": 524288,
+  "limit_bytes": 262144,
+  "suggestion": "Pass context_files explicitly to scope the plan, or run from a subdirectory."
+}
+```
+
+**Output — no recognizable stack:**
+
+If no manifest (`package.json`, `go.mod`, etc.) is found, the plan is still attempted but `stack_detected: "unknown"` is set and an explicit risk is added noting that the stack could not be inferred.
+
+## Tool: code_plan_validate
+
+Filesystem-only audit of a previously-generated plan against the current repo state. **No LLM call.** Cheap and idempotent — call it any time a plan was generated more than a few minutes ago, after pulling from remote, or before committing.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| repo_path | string | yes | Path to the repo. |
+| plan | object | yes | A previously-generated plan object (or its `files_to_create` / `files_to_modify` subset). |
+
+**Output:**
+
+```json
+{
+  "status": "ok",
+  "files_to_modify_exist": [
+    { "path": "src/api/routes.go", "exists": true }
+  ],
+  "files_to_create_collisions": [
+    { "path": "src/billing/invoice.go", "exists": false }
+  ],
+  "warnings": [
+    "files_to_modify[2] (src/legacy/old.go) does not exist in the repo; the plan may be stale."
+  ]
+}
+```
+
+A `files_to_modify` entry whose path does not exist becomes a warning. A `files_to_create` entry whose path already exists becomes a warning too — the plan would clobber existing code. Empty `warnings` means the plan still matches the repo.
+
+## Safety constraints
+
+- This skill never writes to the filesystem (`writes_files: false`). It returns JSON; downstream skills consume it.
+- Repo content is sent to the configured LLM provider; egress is restricted to `api.anthropic.com` and `api.openai.com`.
+- API keys are read from env vars, never logged. `guardrails.deny_output` redacts any key that leaks through an error payload.
+- Repo signal is **size-bounded**. Over budget → `repo_too_large`, never silent truncation.
+- One LLM call per `code_plan_create` invocation (plus one retry if the response fails schema validation).

--- a/forge-skills/local/embedded/code-plan/scripts/code-plan-create.sh
+++ b/forge-skills/local/embedded/code-plan/scripts/code-plan-create.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# code-plan-create.sh — Generate a structured implementation plan for a task.
+# Usage: ./code-plan-create.sh '{"repo_path":"~/work/app","task":"...","ticket_id":"ENG-1"}'
+#
+# Requires: curl, jq, git
+# Env: ANTHROPIC_API_KEY or OPENAI_API_KEY (at least one)
+# Optional: PLAN_MODEL, PLAN_MAX_REPO_SIGNAL_BYTES
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+plan_read_input "$@"
+
+REPO_PATH="$(echo "$INPUT_JSON" | jq -r '.repo_path // empty')"
+TASK="$(echo "$INPUT_JSON" | jq -r '.task // empty')"
+TICKET_ID="$(echo "$INPUT_JSON" | jq -r '.ticket_id // empty')"
+TARGET_BRANCH="$(echo "$INPUT_JSON" | jq -r '.target_branch // empty')"
+CONTEXT_FILES="$(echo "$INPUT_JSON" | jq -c '.context_files // []')"
+
+[ -n "$REPO_PATH" ] || plan_die "repo_path is required"
+[ -n "$TASK" ] || plan_die "task is required"
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+  plan_die "either ANTHROPIC_API_KEY or OPENAI_API_KEY must be set"
+fi
+
+REPO_PATH="$(plan_resolve_repo_path "$REPO_PATH")"
+STACK="$(plan_detect_stack "$REPO_PATH")"
+
+BUDGET="${PLAN_MAX_REPO_SIGNAL_BYTES:-$PLAN_DEFAULT_REPO_SIGNAL_BYTES}"
+SIGNAL="$(plan_extract_repo_signal "$REPO_PATH" "$BUDGET")"
+if [ -z "$SIGNAL" ]; then
+  # Probe the unbounded size so the caller knows how far over budget they are.
+  RAW_SIZE="$(cd "$REPO_PATH" && { git ls-files 2>/dev/null || find . -maxdepth 4 -type f -not -path '*/.*'; } | wc -c)"
+  jq -n --argjson tb "$RAW_SIZE" --argjson lb "$BUDGET" \
+    '{status:"repo_too_large", tree_bytes:$tb, limit_bytes:$lb, suggestion:"Pass context_files explicitly to scope the plan, or run from a subdirectory."}'
+  exit 0
+fi
+
+# Append context_files content (capped at 5 files, 50 KB total).
+CONTEXT_SECTION=""
+if [ "$(echo "$CONTEXT_FILES" | jq 'length')" -gt 0 ]; then
+  CONTEXT_SECTION=$'\n## context_files\n'
+  total_bytes=0
+  count=0
+  while IFS= read -r rel; do
+    [ "$count" -ge 5 ] && break
+    [ -z "$rel" ] && continue
+    abs="$REPO_PATH/$rel"
+    if [ -f "$abs" ]; then
+      file_size=$(wc -c <"$abs" | tr -d ' ')
+      remaining=$((51200 - total_bytes))
+      [ "$remaining" -le 0 ] && break
+      take=$file_size
+      [ "$take" -gt "$remaining" ] && take=$remaining
+      CONTEXT_SECTION+="--- $rel ---"$'\n'
+      CONTEXT_SECTION+="$(head -c "$take" "$abs")"$'\n\n'
+      total_bytes=$((total_bytes + take))
+      count=$((count + 1))
+    fi
+  done < <(echo "$CONTEXT_FILES" | jq -r '.[]')
+fi
+
+# --- System prompt: schema + rules. The LLM must return only JSON. ---
+SYSTEM_PROMPT='You are a senior engineer producing a structured implementation plan for a specific task in a specific repository.
+
+Return a single JSON object matching this exact schema:
+
+{
+  "summary": "One-paragraph plain-English description of the planned change.",
+  "approach": "Higher-level reasoning: why this approach, what alternatives were considered.",
+  "files_to_create": [
+    { "path": "relative/path", "purpose": "Why this file is needed." }
+  ],
+  "files_to_modify": [
+    { "path": "relative/path", "change": "What changes here and why." }
+  ],
+  "tests_to_add": [
+    { "path": "relative/path", "covers": "What this test exercises." }
+  ],
+  "risks": [
+    { "severity": "low|medium|high", "risk": "What might go wrong.", "mitigation": "How to mitigate." }
+  ],
+  "complexity": "low|medium|high",
+  "estimated_file_count": 0,
+  "open_questions": [ "Unresolved question if the task is ambiguous." ]
+}
+
+Rules:
+- Return ONLY a JSON object matching the schema. No markdown fences. No explanation outside the JSON.
+- If the task is ambiguous, include the ambiguity in open_questions rather than guessing. Empty open_questions is acceptable if the task is fully specified.
+- If the task description references files or symbols not present in the repo signal, do not invent them. Add a risk noting the absence.
+- Prefer modifying existing files over creating new ones unless the task clearly introduces a new concept.
+- Tests are not optional. Every plan must include tests_to_add unless the task is documentation-only.
+- Use repo-relative paths only (e.g. "src/foo.go", never absolute or with ~).
+- estimated_file_count must equal len(files_to_create) + len(files_to_modify) + len(tests_to_add).'
+
+# Build the user prompt.
+USER_PROMPT="## task"$'\n'"$TASK"$'\n\n'
+if [ -n "$TICKET_ID" ]; then
+  USER_PROMPT+="ticket_id: $TICKET_ID"$'\n'
+fi
+if [ -n "$TARGET_BRANCH" ]; then
+  USER_PROMPT+="target_branch: $TARGET_BRANCH"$'\n'
+fi
+USER_PROMPT+=$'\n'"## stack_detected"$'\n'"$STACK"$'\n\n'
+USER_PROMPT+="## repo_signal"$'\n'"$SIGNAL"
+if [ -n "$CONTEXT_SECTION" ]; then
+  USER_PROMPT+="$CONTEXT_SECTION"
+fi
+
+# --- One LLM call. Retry once if the response fails schema validation. ---
+
+REQUIRED_KEYS='["summary","approach","files_to_create","files_to_modify","tests_to_add","risks","complexity","estimated_file_count","open_questions"]'
+
+validate_plan() {
+  local json="$1"
+  if ! echo "$json" | jq -e . >/dev/null 2>&1; then
+    return 1
+  fi
+  for key in summary approach files_to_create files_to_modify tests_to_add risks complexity estimated_file_count open_questions; do
+    if ! echo "$json" | jq -e "has(\"$key\")" >/dev/null; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+RAW="$(plan_call_llm "$SYSTEM_PROMPT" "$USER_PROMPT")"
+
+if ! validate_plan "$RAW"; then
+  # Retry once with an explicit schema-reminder follow-up.
+  RETRY_USER="$USER_PROMPT"$'\n\nYour previous response did not match the schema. Required top-level keys: '"$REQUIRED_KEYS"$'. Return ONLY the JSON object, no markdown fences, no commentary.'
+  RAW="$(plan_call_llm "$SYSTEM_PROMPT" "$RETRY_USER")"
+fi
+
+if ! validate_plan "$RAW"; then
+  # Final emission: structured error including the raw text (capped) for debugging.
+  jq -n --arg raw "$(echo "$RAW" | head -c 2000)" \
+    '{status:"error", error:"llm output did not match plan schema", raw:$raw}'
+  exit 0
+fi
+
+# Compose final output: prepend status + ticket_id + stack_detected.
+echo "$RAW" | jq --arg tid "$TICKET_ID" --arg stack "$STACK" \
+  '{status:"ok", ticket_id:$tid, stack_detected:$stack} + .'

--- a/forge-skills/local/embedded/code-plan/scripts/code-plan-validate.sh
+++ b/forge-skills/local/embedded/code-plan/scripts/code-plan-validate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# code-plan-validate.sh — Filesystem-only audit of a plan against repo state.
+# Usage: ./code-plan-validate.sh '{"repo_path":"~/work/app","plan":{...}}'
+#
+# No LLM call. Pure filesystem checks: do files_to_modify exist? Do
+# files_to_create collide with existing files?
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh"
+
+plan_read_input "$@"
+
+REPO_PATH="$(echo "$INPUT_JSON" | jq -r '.repo_path // empty')"
+PLAN="$(echo "$INPUT_JSON" | jq -c '.plan // empty')"
+
+[ -n "$REPO_PATH" ] || plan_die "repo_path is required"
+[ -n "$PLAN" ] || plan_die "plan is required"
+REPO_PATH="$(plan_resolve_repo_path "$REPO_PATH")"
+
+# Build files_to_modify_exist: for each entry, did the file survive?
+MODIFY_PATHS="$(echo "$PLAN" | jq -r '(.files_to_modify // [])[].path // empty')"
+CREATE_PATHS="$(echo "$PLAN" | jq -r '(.files_to_create // [])[].path // empty')"
+
+MODIFY_RESULTS='[]'
+WARNINGS='[]'
+idx=0
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  abs="$REPO_PATH/$rel"
+  if [ -f "$abs" ]; then
+    exists=true
+  else
+    exists=false
+    WARNINGS="$(echo "$WARNINGS" | jq --arg msg "files_to_modify[$idx] ($rel) does not exist in the repo; the plan may be stale." '. + [$msg]')"
+  fi
+  MODIFY_RESULTS="$(echo "$MODIFY_RESULTS" | jq --arg p "$rel" --argjson e "$exists" '. + [{path:$p, exists:$e}]')"
+  idx=$((idx + 1))
+done <<< "$MODIFY_PATHS"
+
+CREATE_RESULTS='[]'
+idx=0
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  abs="$REPO_PATH/$rel"
+  if [ -f "$abs" ]; then
+    exists=true
+    WARNINGS="$(echo "$WARNINGS" | jq --arg msg "files_to_create[$idx] ($rel) already exists in the repo; the plan would clobber it." '. + [$msg]')"
+  else
+    exists=false
+  fi
+  CREATE_RESULTS="$(echo "$CREATE_RESULTS" | jq --arg p "$rel" --argjson e "$exists" '. + [{path:$p, exists:$e}]')"
+  idx=$((idx + 1))
+done <<< "$CREATE_PATHS"
+
+jq -n \
+  --argjson modify "$MODIFY_RESULTS" \
+  --argjson create "$CREATE_RESULTS" \
+  --argjson warnings "$WARNINGS" \
+  '{status:"ok", files_to_modify_exist:$modify, files_to_create_collisions:$create, warnings:$warnings}'

--- a/forge-skills/local/embedded/code-plan/scripts/common.sh
+++ b/forge-skills/local/embedded/code-plan/scripts/common.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # sed/regex strings use $ as anchor, not shell var
+# Shared helpers for code-plan skill scripts.
+# Do not run this file directly — it is sourced by code-plan-*.sh.
+
+# Default budget for the repo signal sent to the LLM. 256 KB keeps the prompt
+# well under provider request limits even with the task description and full
+# system prompt appended.
+PLAN_DEFAULT_REPO_SIGNAL_BYTES=262144
+
+# Read JSON arg from $1 or stdin, validate, set INPUT_JSON.
+plan_read_input() {
+  if [ -n "${1:-}" ]; then
+    INPUT_JSON="$1"
+  else
+    INPUT_JSON="$(cat)"
+  fi
+  if ! echo "$INPUT_JSON" | jq -e . >/dev/null 2>&1; then
+    plan_die "invalid JSON input"
+  fi
+}
+
+# Emit error to stderr as JSON, exit 1.
+plan_die() {
+  jq -n --arg msg "$1" '{"error": $msg}' >&2
+  exit 1
+}
+
+# Require an env var to be set, else die.
+plan_require_env() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    plan_die "missing required environment variable: $var"
+  fi
+}
+
+# Expand ~ to $HOME, verify the path exists and is a directory, echo the
+# resolved absolute path. Dies on missing path so callers don't have to
+# re-check.
+plan_resolve_repo_path() {
+  local p="$1"
+  p="${p/#\~/$HOME}"
+  if [ ! -d "$p" ]; then
+    plan_die "repo_path does not exist or is not a directory: $p"
+  fi
+  echo "$p"
+}
+
+# Inspect repo_path and return a short stack identifier:
+#   node | go | python | rust | java | unknown
+# Looks at manifest presence, not file contents. First match wins.
+plan_detect_stack() {
+  local repo="$1"
+  if [ -f "$repo/go.mod" ]; then
+    echo "go"
+  elif [ -f "$repo/package.json" ]; then
+    echo "node"
+  elif [ -f "$repo/pyproject.toml" ] || [ -f "$repo/setup.py" ] || [ -f "$repo/requirements.txt" ]; then
+    echo "python"
+  elif [ -f "$repo/Cargo.toml" ]; then
+    echo "rust"
+  elif [ -f "$repo/pom.xml" ] || ls "$repo"/build.gradle* >/dev/null 2>&1; then
+    echo "java"
+  else
+    echo "unknown"
+  fi
+}
+
+# Extract a bounded "repo signal" for the LLM: tree listing + manifest
+# contents + README excerpt. Echoes the signal on stdout; echoes empty
+# string when the total exceeds the byte budget (caller emits
+# repo_too_large).
+#
+# Arguments:
+#   $1 = repo_path (already resolved)
+#   $2 = optional byte budget; defaults to $PLAN_MAX_REPO_SIGNAL_BYTES env
+#        or PLAN_DEFAULT_REPO_SIGNAL_BYTES.
+plan_extract_repo_signal() {
+  local repo="$1"
+  local budget="${2:-${PLAN_MAX_REPO_SIGNAL_BYTES:-$PLAN_DEFAULT_REPO_SIGNAL_BYTES}}"
+  local out=""
+
+  # Tree: top 200 entries from git ls-files; fall back to find if not a git repo.
+  local tree
+  if (cd "$repo" && git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    tree="$(cd "$repo" && git ls-files 2>/dev/null | head -200)"
+  else
+    tree="$(cd "$repo" && find . -maxdepth 4 -type f -not -path '*/.*' 2>/dev/null | sed 's|^\./||' | head -200)"
+  fi
+  out+=$'## tree\n'"$tree"$'\n\n'
+
+  # Manifests — concatenate each that exists.
+  out+=$'## manifest\n'
+  local manifest_count=0
+  for m in go.mod package.json pyproject.toml setup.py requirements.txt Cargo.toml pom.xml build.gradle build.gradle.kts; do
+    if [ -f "$repo/$m" ]; then
+      out+="--- $m ---"$'\n'
+      out+="$(cat "$repo/$m")"$'\n\n'
+      manifest_count=$((manifest_count + 1))
+    fi
+  done
+  if [ "$manifest_count" -eq 0 ]; then
+    out+=$'(no recognised manifest)\n\n'
+  fi
+
+  # README excerpt — first 4 KB.
+  if [ -f "$repo/README.md" ]; then
+    out+=$'## readme\n'
+    out+="$(head -c 4096 "$repo/README.md")"$'\n'
+  fi
+
+  # Size-budget check.
+  local size=${#out}
+  if [ "$size" -gt "$budget" ]; then
+    echo ""
+    return 0
+  fi
+  printf '%s' "$out"
+}
+
+# Call the configured LLM with a system + user prompt. Strips markdown fences
+# from the response. Echoes the raw text content on stdout. Dies on HTTP error
+# or empty response.
+#
+# Provider selection: ANTHROPIC_API_KEY wins if set, else OPENAI_API_KEY.
+# Model override via PLAN_MODEL env var.
+plan_call_llm() {
+  local system_prompt="$1"
+  local user_prompt="$2"
+
+  local sys_tmp user_tmp resp http_code body text
+  sys_tmp="$(mktemp)"
+  user_tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$sys_tmp' '$user_tmp'" RETURN
+  printf '%s' "$system_prompt" > "$sys_tmp"
+  printf '%s' "$user_prompt" > "$user_tmp"
+
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    local model="${PLAN_MODEL:-claude-sonnet-4-5}"
+    local payload
+    payload="$(jq -n \
+      --arg model "$model" \
+      --rawfile system "$sys_tmp" \
+      --rawfile user "$user_tmp" \
+      '{model: $model, max_tokens: 4096, system: $system, messages: [{role: "user", content: $user}]}')"
+    resp="$(curl -sS --max-time 150 \
+      -w "\n%{http_code}" \
+      -X POST "https://api.anthropic.com/v1/messages" \
+      -H "Content-Type: application/json" \
+      -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+      -H "anthropic-version: 2023-06-01" \
+      -d "$payload")" || plan_die "network error calling Anthropic API"
+    http_code="$(echo "$resp" | tail -1)"
+    body="$(echo "$resp" | sed '$d')"
+    if [ "$http_code" -ne 200 ]; then
+      plan_die "Anthropic API returned status $http_code"
+    fi
+    text="$(echo "$body" | jq -r '.content[0].text // empty')"
+  elif [ -n "${OPENAI_API_KEY:-}" ]; then
+    local model="${PLAN_MODEL:-gpt-4.1}"
+    local base="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+    local payload
+    payload="$(jq -n \
+      --arg model "$model" \
+      --rawfile system "$sys_tmp" \
+      --rawfile user "$user_tmp" \
+      '{model: $model, max_tokens: 4096, messages: [{role: "system", content: $system}, {role: "user", content: $user}]}')"
+    resp="$(curl -sS --max-time 150 \
+      -w "\n%{http_code}" \
+      -X POST "${base}/chat/completions" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+      -d "$payload")" || plan_die "network error calling OpenAI API"
+    http_code="$(echo "$resp" | tail -1)"
+    body="$(echo "$resp" | sed '$d')"
+    if [ "$http_code" -ne 200 ]; then
+      plan_die "OpenAI API returned status $http_code"
+    fi
+    text="$(echo "$body" | jq -r '.choices[0].message.content // empty')"
+  else
+    plan_die "either ANTHROPIC_API_KEY or OPENAI_API_KEY must be set"
+  fi
+
+  if [ -z "$text" ]; then
+    plan_die "LLM returned empty response"
+  fi
+
+  # Strip markdown fences if present (```json ... ```).
+  text="$(echo "$text" | sed -E 's/^```([a-zA-Z]+)?$//; s/```$//' | sed '/^$/d')"
+  printf '%s' "$text"
+}

--- a/forge-skills/local/registry_embedded_test.go
+++ b/forge-skills/local/registry_embedded_test.go
@@ -16,12 +16,12 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		t.Fatalf("List error: %v", err)
 	}
 
-	if len(skills) != 13 {
+	if len(skills) != 14 {
 		names := make([]string, len(skills))
 		for i, s := range skills {
 			names[i] = s.Name
 		}
-		t.Fatalf("expected 13 skills, got %d: %v", len(skills), names)
+		t.Fatalf("expected 14 skills, got %d: %v", len(skills), names)
 	}
 
 	// Verify all expected skills are present
@@ -32,6 +32,7 @@ func TestEmbeddedRegistry_DiscoverAll(t *testing.T) {
 		hasEgress   bool
 	}{
 		"code-agent":            {displayName: "Code Agent", hasEnv: false, hasBins: false, hasEgress: false},
+		"code-plan":             {displayName: "Code Plan", hasEnv: false, hasBins: true, hasEgress: true},
 		"github":                {displayName: "Github", hasEnv: false, hasBins: true, hasEgress: true},
 		"weather":               {displayName: "Weather", hasEnv: false, hasBins: true, hasEgress: true},
 		"tavily-search":         {displayName: "Tavily Search", hasEnv: true, hasBins: true, hasEgress: true},
@@ -193,6 +194,75 @@ func TestEmbeddedRegistry_TavilyResearchDetails(t *testing.T) {
 	// Check timeout hint
 	if s.TimeoutHint != 300 {
 		t.Errorf("TimeoutHint = %d, want 300", s.TimeoutHint)
+	}
+}
+
+func TestEmbeddedRegistry_CodePlanDetails(t *testing.T) {
+	reg, err := NewEmbeddedRegistry()
+	if err != nil {
+		t.Fatalf("NewEmbeddedRegistry error: %v", err)
+	}
+
+	s := reg.Get("code-plan")
+	if s == nil {
+		t.Fatal("Get(\"code-plan\") returned nil")
+	}
+	if s.Icon != "🗺️" {
+		t.Errorf("Icon = %q, want 🗺️", s.Icon)
+	}
+	if s.Category != "developer" {
+		t.Errorf("Category = %q, want developer", s.Category)
+	}
+	if len(s.OneOfEnv) != 2 {
+		t.Errorf("OneOfEnv = %v, want [ANTHROPIC_API_KEY OPENAI_API_KEY]", s.OneOfEnv)
+	}
+	if len(s.RequiredBins) < 3 {
+		t.Errorf("RequiredBins = %v, want at least [curl, jq, git]", s.RequiredBins)
+	}
+	if s.TimeoutHint != 180 {
+		t.Errorf("TimeoutHint = %d, want 180", s.TimeoutHint)
+	}
+
+	foundAnthropic := false
+	foundOpenAI := false
+	for _, d := range s.EgressDomains {
+		switch d {
+		case "api.anthropic.com":
+			foundAnthropic = true
+		case "api.openai.com":
+			foundOpenAI = true
+		}
+	}
+	if !foundAnthropic || !foundOpenAI {
+		t.Errorf("EgressDomains = %v, want api.anthropic.com AND api.openai.com", s.EgressDomains)
+	}
+
+	// Multi-script skill — verify both per-tool scripts + the sourced helper.
+	expectedScripts := []string{
+		"common.sh",
+		"code-plan-create.sh",
+		"code-plan-validate.sh",
+	}
+	gotScripts := reg.ListScripts("code-plan")
+	gotSet := make(map[string]bool, len(gotScripts))
+	for _, n := range gotScripts {
+		gotSet[n] = true
+	}
+	for _, want := range expectedScripts {
+		if !gotSet[want] {
+			t.Errorf("missing expected script %q (got: %v)", want, gotScripts)
+		}
+	}
+
+	// Verify the SKILL.md content references the canonical tool names.
+	content, err := reg.LoadContent("code-plan")
+	if err != nil {
+		t.Fatalf("LoadContent error: %v", err)
+	}
+	for _, tool := range []string{"code_plan_create", "code_plan_validate"} {
+		if !strings.Contains(string(content), "## Tool: "+tool) {
+			t.Errorf("SKILL.md missing '## Tool: %s' heading", tool)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

New script-backed LLM-powered embedded skill that turns a free-form task description plus a repository on disk into a **structured implementation plan** — files to create, files to modify, tests to add, risks, complexity. Returns JSON only; execution happens in downstream skills (\`code-agent\`, \`github\`). Closes #68.

Same shape as the existing \`code-review\` skill: one LLM call, structured output, validated schema.

## Tools (auto-registered from \`## Tool:\` headings)

| Tool | Required | Optional | Purpose |
|---|---|---|---|
| \`code_plan_create\` | \`repo_path\`, \`task\` | \`context_files\`, \`target_branch\`, \`ticket_id\` | One LLM call, returns a plan or \`{status:\"repo_too_large\"}\` if the repo signal exceeds the byte budget |
| \`code_plan_validate\` | \`repo_path\`, \`plan\` | — | Pure filesystem audit of a plan; **no LLM call**. Reports presence/collisions and warnings. |

## Layout

```
forge-skills/local/embedded/code-plan/
  SKILL.md
  scripts/
    common.sh                (sourced helper)
    code-plan-create.sh
    code-plan-validate.sh
```

Tool names map underscore → hyphen for filenames (\`code_plan_create\` → \`code-plan-create.sh\`), via the existing \`forge-cli/runtime/runner.go\` auto-mapping. No Go code changes outside the registry test.

Helper is \`common.sh\` (not \`_common.sh\`) — \`//go:embed embedded\` excludes underscore-prefixed entries, same constraint as #66 / PR #67.

## Provider selection

- \`ANTHROPIC_API_KEY\` wins if set, else \`OPENAI_API_KEY\` (\`one_of\`)
- \`PLAN_MODEL\` env overrides defaults: Anthropic \`claude-sonnet-4-5\`, OpenAI \`gpt-4.1\`
- \`PLAN_MAX_REPO_SIGNAL_BYTES\` (default 256 KB) bounds the prompt size

## Repo signal extraction

\`code_plan_create\` automatically samples the repo so the LLM has enough context without the agent pre-reading files:

1. Top 200 entries of \`git ls-files\` (or \`find\` fallback for non-git dirs)
2. Manifest files: \`go.mod\`, \`package.json\`, \`pyproject.toml\`, \`setup.py\`, \`requirements.txt\`, \`Cargo.toml\`, \`pom.xml\`, \`build.gradle*\`
3. First 4 KB of \`README.md\` if present

If the total signal exceeds the byte budget, the tool returns \`{status:\"repo_too_large\", tree_bytes, limit_bytes, suggestion}\` rather than truncating silently.

## Schema validation

After the LLM call, the script validates that all 9 top-level keys exist (\`summary\`, \`approach\`, \`files_to_create\`, \`files_to_modify\`, \`tests_to_add\`, \`risks\`, \`complexity\`, \`estimated_file_count\`, \`open_questions\`). On failure, retries **once** with a schema-reminder follow-up. Still failing → \`{status:\"error\", error:\"llm output did not match plan schema\", raw:\"...\"}\`. \`ticket_id\` from input is echoed verbatim in the output.

## System prompt rules (verbatim in the LLM call)

1. Return ONLY a JSON object matching the schema. No markdown fences. No explanation outside the JSON.
2. If the task is ambiguous, include the ambiguity in \`open_questions\` rather than guessing.
3. If the task references files or symbols not in the repo signal, do not invent them. Add a risk.
4. Prefer modifying existing files over creating new ones unless the task clearly introduces a new concept.
5. Tests are not optional. Every plan must include \`tests_to_add\` unless the task is documentation-only.
6. Use repo-relative paths only.

## Tests

- \`forge-skills/local/registry_embedded_test.go\`:
  - Bumped expected skill count 13 → 14
  - Added \`code-plan\` to the \`expectedSkills\` map (\`hasEnv: false\` because the env is \`one_of\` not \`required\`; \`hasBins: true\`, \`hasEgress: true\`)
  - New \`TestEmbeddedRegistry_CodePlanDetails\` covers icon, category, \`OneOfEnv\` (\`[ANTHROPIC_API_KEY, OPENAI_API_KEY]\`), bins, \`timeout_hint=180\`, both egress domains, the 3 scripts, and both \`## Tool:\` headings.
- \`shellcheck -x\` clean on all 3 scripts (SC2016 suppressed in \`common.sh\` only where sed regex anchors use \`\$\` literally).
- Validator dry-run against this repo matches the issue's expected output:
  - \`go.work\` flagged as existing
  - \`src/totally-new.txt\` flagged as non-existent, no warnings
- Error paths smoke-tested: missing \`repo_path\` / missing \`task\` / missing API keys all emit structured JSON errors on stderr and exit 1.

## Test plan

- [x] \`go test ./forge-skills/...\` — all green (incl. existing kategorie/icon/load-content tests)
- [x] \`go test ./forge-core/...\` \`./forge-cli/...\` \`./forge-plugins/...\` — no regressions
- [x] \`gofmt -w\`, \`golangci-lint run ./forge-skills/...\` — 0 issues
- [x] \`shellcheck -x scripts/*.sh\` (from the scripts dir) — exit 0
- [x] Validator dry-run matches the issue's expected output
- [x] Error-path smoke tests pass
- [ ] Manual: \`forge init\` shows \"🗺️ Code Plan\" in the skills picker
- [ ] Manual: with \`ANTHROPIC_API_KEY\` or \`OPENAI_API_KEY\` exported, a smoke \`code_plan_create\` call returns valid JSON with all required fields populated

## Out of scope (deferred)

- Multi-step planning (sub-plans, hierarchies)
- Plan refinement based on user feedback (single-shot only in v1)
- Cost or time-in-hours estimation
- Plan persistence to disk or a database
- Integration with Linear / GitHub trackers (input is just a string)
- LLM providers other than Anthropic and OpenAI

## Relation to PR #67 (linear skill)

This PR is independent of #67 (still open). Both touch \`forge-skills/local/registry_embedded_test.go\` — both bump the count and add their skill to the map. Whichever lands first will require a trivial conflict resolution on the count (13 → 14 vs 14 → 15) and a one-line addition to the \`expectedSkills\` map. No semantic conflicts.