### PR TITLE
feat(skills/github): ticket-driven PR creation + branch-name helper (closes #70)

### DIFF
--- a/docs/skills/embedded-skills.md
+++ b/docs/skills/embedded-skills.md
@@ -210,16 +210,17 @@ The `github` skill provides a complete git + GitHub workflow through script-back
 forge skills add github
 ```
 
-This registers fourteen tools:
+This registers fifteen tools:
 
 | Tool | Purpose |
 |------|---------|
 | `github_clone` | Clone a repository and create a feature branch |
 | `github_checkout` | Switch to or create a branch |
+| `github_branch_name_from_ticket` | Generate a conventional branch name from a ticket ID + title (e.g. `ENG-123` + title → `feat/eng-123-add-invoice-creation-endpoint`). No network call — pure string transform. |
 | `github_status` | Show git status for a cloned project |
 | `github_commit` | Stage and commit changes |
 | `github_push` | Push a feature branch to the remote |
-| `github_create_pr` | Create a pull request |
+| `github_create_pr` | Create a pull request. Optional `ticket_id` / `ticket_url` parameters auto-suffix the title with `[<ticket_id>]` and append a `Tracks:` back-link footer to the body. |
 | `github_create_issue` | Create a GitHub issue |
 | `github_list_issues` | List open issues for a repository |
 | `github_list_prs` | List pull requests with state filter and pagination |
@@ -230,6 +231,21 @@ This registers fourteen tools:
 | `github_stargazer_profiles` | List stargazers and fetch their full profiles (compound 2-step) |
 
 **Workflow:** Clone → explore → edit → status → commit → push → create PR. The skill's system prompt enforces this sequence and prevents raw `git` commands via `cli_execute`.
+
+**Workflow-completion rule:** the skill normally requires driving the full sequence in one session without stopping after exploration. Three exceptions allow pausing:
+
+- **Ticket-driven mode** — if the task originated from a `linear_get_issue` call (or any external ticket) and the ticket leaves a material question unanswered, post a `linear_add_comment` asking the question, then stop and wait. Do not guess on irreversible decisions like API contract shape or data-model changes.
+- **Code planning** — if `code_plan_create` returns `complexity: "high"` or non-empty `risks`, present the plan to the user and confirm before writing code.
+- **Genuine ambiguity** — if you cannot determine what to change even after thorough exploration, stop and ask. Do not invent a change.
+
+**Ticket-driven PR conventions:** when the work originates from a Linear ticket or GitHub issue:
+
+1. Call `github_branch_name_from_ticket` first to generate a conventional branch name. Do not invent your own scheme like `claude/fix-thing`.
+2. Pass `ticket_id` (and `ticket_url` if available) to `github_create_pr` — the skill builds the back-link footer automatically.
+3. PR title format: `<type>(<scope>): <short description> [<ticket-id>]`. Examples: `feat(billing): add invoice creation endpoint [ENG-123]`, `fix(auth): reject empty refresh tokens [ENG-456]`, `chore(deps): bump go to 1.25.3 [INFRA-7]`.
+4. After `github_create_pr` returns the PR URL, post a single comment back on the originating ticket using the tracker's skill (e.g. `linear_add_comment`). Do **not** post the PR URL into the PR itself.
+
+`github_branch_name_from_ticket` accepts a `prefix` (default `feat`; allow-list `feat`/`fix`/`chore`/`docs`/`refactor`), lowercases the ticket ID, slugifies the title (lowercase, non-alnum → `-`, strip leading/trailing `-`), and truncates to 60 chars cutting at the last hyphen boundary so no half-word is emitted.
 
 **Pagination:** List tools (`github_list_prs`, `github_list_stargazers`, `github_list_forks`, `github_pr_author_profiles`, `github_stargazer_profiles`) support `page` (1-based) and `per_page` (default 30, max 100) parameters. Responses include `pagination.has_next_page` to indicate more results are available.
 

--- a/forge-skills/local/embedded/github/SKILL.md
+++ b/forge-skills/local/embedded/github/SKILL.md
@@ -11,6 +11,8 @@ tags:
   - stargazers
   - forks
   - users
+  - ticket-driven
+  - linear-compatible
 description: Create issues, PRs, clone repos, and manage git workflows
 metadata:
   forge:
@@ -55,8 +57,17 @@ The `repo` parameter accepts any of these formats:
 - ALL tools that accept `project_dir` (github tools, code-agent tools) accept BOTH `openclaw` and `workspace/openclaw` — the `workspace/` prefix is stripped automatically.
 - For `directory_tree`, `grep_search`, `glob_search` use `workspace/<project_dir>` as the `path` (e.g. `workspace/openclaw`).
 
-**You MUST complete the entire workflow — do NOT stop after exploring.**
-When asked to fix a bug or make changes, you must: explore → understand → edit → commit → push → create PR. Do NOT stop after step 2 to report findings. Complete ALL steps in ONE session. Only stop early if you genuinely cannot determine what to change.
+**Workflow completion rule:**
+
+When asked to fix a bug or make changes, you must drive the full sequence: explore → understand → edit → commit → push → create PR. Do NOT stop after exploration to report findings. Complete the full sequence in one session.
+
+**Exceptions where pausing is correct:**
+
+- **Ticket-driven mode**: if the task originated from a `linear_get_issue` call (or any external ticket) and the ticket leaves a material question unanswered, post a `linear_add_comment` (or the equivalent for your tracker) asking the question, then stop and wait. Do NOT guess on irreversible decisions like API contract shape, data model changes, or user-facing copy.
+- **Code planning**: if `code_plan_create` returns `complexity: "high"` or non-empty `risks`, present the plan to the user and confirm before writing code.
+- **Genuine ambiguity**: if you cannot determine what to change even after thorough exploration, stop and ask. Do not invent a change.
+
+Outside these exceptions, complete all steps in one session.
 
 **Exploration strategy — bug fixes:**
 1. `directory_tree` to understand project structure.
@@ -86,6 +97,28 @@ When asked to fix a bug or make changes, you must: explore → understand → ed
 - `github_clone` automatically creates a feature branch after cloning.
 - `github_commit`, `github_push`, and `github_checkout` refuse to operate on main/master.
 - Always use `github_status` before committing to review what changed.
+
+**When working from a ticket**, prefer to:
+1. Call `github_branch_name_from_ticket` first with the ticket ID and title.
+2. Pass the resulting `branch` to `github_clone` via its `branch` parameter.
+
+This produces consistent naming across runs. Do not invent branch names like `claude/fix-thing` or `agent-branch-1`.
+
+**Ticket-driven PR conventions:**
+
+When the work originates from a Linear ticket or GitHub issue:
+
+1. Use `github_branch_name_from_ticket` to generate a conventional branch name from the identifier and title. Do not invent your own naming scheme.
+2. Pass `ticket_id` (and `ticket_url` if available) to `github_create_pr`. The skill builds the PR body with a back-link automatically.
+3. The PR title format is: `<type>(<scope>): <short description> [<ticket-id>]` — examples below.
+4. After `github_create_pr` returns the PR URL, post a comment back on the originating ticket with the PR URL using the appropriate tracker skill. Do NOT post the PR URL into the PR itself as a comment.
+
+Title examples:
+- `feat(billing): add invoice creation endpoint [ENG-123]`
+- `fix(auth): reject empty refresh tokens [ENG-456]`
+- `chore(deps): bump go to 1.25.3 [INFRA-7]`
+
+If no clear conventional-commit type applies, use `chore`. Never invent a type like `wip` or `tmp`.
 
 **Pagination:**
 For tools that return lists (`github_list_prs`, `github_list_stargazers`, `github_list_forks`, `github_pr_author_profiles`, `github_stargazer_profiles`), use `page` (1-based) and `per_page` (default 30, max 100) parameters. The response includes a `pagination` object with `has_next_page` — if true, increment `page` to fetch the next batch.
@@ -125,6 +158,13 @@ Switch to or create a branch. Refuses to switch to main/master.
 **Input:** project_dir (string), branch (string: target branch name), create (boolean, optional: create new branch — default false)
 **Output:** `{status, branch}`
 
+## Tool: github_branch_name_from_ticket
+
+Generate a conventional branch name from a ticket identifier and title. Use this instead of inventing branch names manually — it ensures consistency across agents and humans. No network call.
+
+**Input:** ticket_id (string), title (string), prefix (string, optional: `feat`/`fix`/`chore`/`docs`/`refactor`, default `feat`)
+**Output:** `{branch: "feat/eng-123-add-invoice-creation-endpoint"}`
+
 ## Tool: github_create_issue
 
 Create a GitHub issue.
@@ -141,9 +181,20 @@ List open issues for a repository.
 
 ## Tool: github_create_pr
 
-Create a pull request.
+Create a pull request. When `ticket_id` is supplied, the title is auto-suffixed with `[<ticket_id>]` (if not already present) and a `Tracks:` back-link footer is appended to the body — the LLM does not need to format the back-link manually.
 
-**Input:** repo (string), title (string), body (string), head (string), base (string)
+**Input:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| repo | string | yes | `owner/repo`, SSH URL, or HTTPS URL |
+| title | string | yes | PR title |
+| body | string | yes | PR body (markdown) |
+| head | string | yes | Source branch |
+| base | string | no | Target branch. Default `main`. |
+| ticket_id | string | no | External ticket identifier (e.g. `ENG-123`). Appended to title and PR body if not already present. |
+| ticket_url | string | no | Full URL to the ticket. When provided alongside `ticket_id`, added as a back-link in the PR body as `Tracks: [<ticket_id>](<ticket_url>)`. |
+
 **Output:** Pull request URL
 
 ## Tool: github_list_prs

--- a/forge-skills/local/embedded/github/scripts/github-branch-name-from-ticket.sh
+++ b/forge-skills/local/embedded/github/scripts/github-branch-name-from-ticket.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# github-branch-name-from-ticket.sh — Generate a conventional branch name
+# from a ticket identifier and title.
+# Usage: ./github-branch-name-from-ticket.sh '{"ticket_id":"ENG-123","title":"Add invoice creation"}'
+#
+# No network call. Pure string transformation. Output:
+#   {"branch": "<prefix>/<lower-id>-<slug>"}
+set -euo pipefail
+
+INPUT_JSON="${1:-$(cat)}"
+if ! printf '%s' "$INPUT_JSON" | jq empty 2>/dev/null; then
+  echo '{"error": "invalid JSON input"}' >&2
+  exit 1
+fi
+
+TICKET_ID="$(printf '%s' "$INPUT_JSON" | jq -r '.ticket_id // empty')"
+TITLE="$(printf '%s' "$INPUT_JSON" | jq -r '.title // empty')"
+PREFIX="$(printf '%s' "$INPUT_JSON" | jq -r '.prefix // "feat"')"
+
+if [ -z "$TICKET_ID" ]; then
+  echo '{"error": "ticket_id is required"}' >&2
+  exit 1
+fi
+if [ -z "$TITLE" ]; then
+  echo '{"error": "title is required"}' >&2
+  exit 1
+fi
+
+# Validate prefix against allow-list; fall back to feat for any other value.
+case "$PREFIX" in
+  feat|fix|chore|docs|refactor) ;;
+  *) PREFIX="feat" ;;
+esac
+
+LOWER_ID="$(printf '%s' "$TICKET_ID" | tr '[:upper:]' '[:lower:]')"
+
+# Slugify: lowercase, non-alnum → -, collapse repeats, trim leading/trailing -.
+SLUG="$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g' \
+  | sed -E 's/^-+//' \
+  | sed -E 's/-+$//')"
+
+# Truncate slug to 60 chars; if a hyphen exists in the truncated string,
+# cut back to it so we don't leave a half-word at the end.
+if [ "${#SLUG}" -gt 60 ]; then
+  SLUG="${SLUG:0:60}"
+  case "$SLUG" in
+    *-*) SLUG="${SLUG%-*}" ;;
+  esac
+fi
+
+BRANCH="$PREFIX/$LOWER_ID-$SLUG"
+
+jq -n --arg branch "$BRANCH" '{branch: $branch}'

--- a/forge-skills/local/embedded/github/scripts/github-create-pr.sh
+++ b/forge-skills/local/embedded/github/scripts/github-create-pr.sh
@@ -21,6 +21,8 @@ TITLE=$(printf '%s' "$INPUT" | jq -r '.title // empty')
 BODY=$(printf '%s' "$INPUT" | jq -r '.body // empty')
 HEAD=$(printf '%s' "$INPUT" | jq -r '.head // empty')
 BASE=$(printf '%s' "$INPUT" | jq -r '.base // empty')
+TICKET_ID=$(printf '%s' "$INPUT" | jq -r '.ticket_id // empty')
+TICKET_URL=$(printf '%s' "$INPUT" | jq -r '.ticket_url // empty')
 
 if [ -z "$REPO" ]; then
   echo '{"error": "repo is required"}' >&2
@@ -50,6 +52,29 @@ fi
 # Default base branch to main
 if [ -z "$BASE" ]; then
   BASE="main"
+fi
+
+# --- Apply ticket-driven conventions ---
+# When ticket_id is provided, suffix the title with [<ticket_id>] if not
+# already present, and append a "Tracks:" back-link footer to the body.
+# This lets callers pass an unmodified title/body and have the skill
+# enforce the convention uniformly.
+if [ -n "$TICKET_ID" ]; then
+  case "$TITLE" in
+    *"[$TICKET_ID]"*) ;;
+    *) TITLE="$TITLE [$TICKET_ID]" ;;
+  esac
+  if [ -n "$TICKET_URL" ]; then
+    BODY="$BODY
+
+---
+Tracks: [$TICKET_ID]($TICKET_URL)"
+  else
+    BODY="$BODY
+
+---
+Tracks: $TICKET_ID"
+  fi
 fi
 
 # --- Create PR via gh CLI ---


### PR DESCRIPTION
## Summary

Additive update to the existing `github` embedded skill. **No breaking changes** — both new `github_create_pr` parameters (`ticket_id`, `ticket_url`) are optional; absent both → byte-identical behaviour to today. Closes #70.

## Tools

| Tool | Status | New params | Purpose |
|---|---|---|---|
| `github_create_pr` | **updated** (additive) | `ticket_id`, `ticket_url` (both optional) | When `ticket_id` is set, auto-suffix the title with `[<ticket_id>]` if not already present; if `ticket_url` is set, append a `Tracks: [<ticket_id>](<ticket_url>)` footer to the body. |
| `github_branch_name_from_ticket` | **new** | `ticket_id`, `title`, optional `prefix` | Pure string transform: lowercase ID + slugify title + compose `<prefix>/<lower-id>-<slug>`, capped at 60 chars cut at the last hyphen boundary. No network call. |
| All others (`github_clone`, `github_checkout`, `github_commit`, `github_push`, `github_status`, `github_create_issue`, `github_list_issues`, `github_list_prs`, `github_get_user`, `github_list_stargazers`, `github_list_forks`, `github_pr_author_profiles`, `github_stargazer_profiles`) | **unchanged** | — | — |

## SKILL.md changes

- **Tags**: added `ticket-driven` and `linear-compatible`. Everything else preserved.
- **Workflow rule softened** with three explicit carve-outs that allow the agent to pause:
  - ticket-driven mode → post `linear_add_comment` and wait
  - `code_plan_create` returns `complexity: \"high\"` or non-empty `risks` → present to user
  - genuine ambiguity → ask the user
  Outside those, the \"complete the full sequence in one session\" rule still applies verbatim.
- **New section: Ticket-driven PR conventions** — placed after Branch safety rules. Tells the LLM to call `github_branch_name_from_ticket` first, pass `ticket_id` / `ticket_url` to `github_create_pr`, and post the PR URL back on the originating ticket using the `linear` skill (not in the PR itself).
- **New section: When working from a ticket** (under \"Branch safety rules\") — points the LLM at `github_branch_name_from_ticket` and explicitly forbids inventing branch names like `claude/fix-thing`.
- **`github_create_pr` docs** rebuilt as a proper input table with the two new rows and a one-line explainer of the auto-suffix/auto-footer behaviour. The previous one-line input bullet is unchanged in semantics.
- **New `## Tool: github_branch_name_from_ticket` section** placed after `github_checkout`.

## `github-create-pr.sh` changes

Extract `ticket_id` / `ticket_url`, then before the `gh pr create` invocation:

```bash
if [ -n \"\$TICKET_ID\" ]; then
  case \"\$TITLE\" in
    *\"[\$TICKET_ID]\"*) ;;
    *) TITLE=\"\$TITLE [\$TICKET_ID]\" ;;
  esac
  if [ -n \"\$TICKET_URL\" ]; then
    BODY=\"\$BODY\\n\\n---\\nTracks: [\$TICKET_ID](\$TICKET_URL)\"
  else
    BODY=\"\$BODY\\n\\n---\\nTracks: \$TICKET_ID\"
  fi
fi
```

The literal-bracket pattern (`*\"[\$TICKET_ID]\"*`) intentionally matches only the bracketed form, so a title like `\"ENG-123 hotfix\"` (no brackets) gets the suffix appended. This matches the documented convention.

## `github-branch-name-from-ticket.sh` (new)

- Validates `prefix` against `feat|fix|chore|docs|refactor`; falls back to `feat` for any other value.
- Lowercases ticket ID (`ENG-123` → `eng-123`).
- Slugifies: `tr [:upper:] → [:lower:]`, `sed -E 's/[^a-z0-9]+/-/g'`, strip leading/trailing `-`.
- Truncates to 60 chars; if a hyphen exists in the truncated string, cuts back to it via `\${SLUG%-*}` so we never emit a half-word.
- Returns `{\"branch\": \"<prefix>/<lower-id>-<slug>\"}`.

## Verification (verbatim from #70)

```
$ echo '{\"ticket_id\":\"ENG-123\",\"title\":\"Add invoice creation endpoint with validation\"}' | bash github-branch-name-from-ticket.sh
{\"branch\":\"feat/eng-123-add-invoice-creation-endpoint-with-validation\"}

$ echo '{\"ticket_id\":\"BUG-7\",\"title\":\"Fix: !!! Refresh token rejects 0-length string @@@\",\"prefix\":\"fix\"}' | bash github-branch-name-from-ticket.sh
{\"branch\":\"fix/bug-7-fix-refresh-token-rejects-0-length-string\"}
```

Both match the issue's expected outputs exactly. Additional edge cases tested locally:

| Input | Output |
|---|---|
| Invalid `prefix: \"wip\"` | Falls back to `feat` → `feat/x-1-hello` |
| Long title (130+ chars) | Cut at the last hyphen inside 60 chars: `feat/ops-999-this-is-a-really-really-really-really-really-really-long` |
| Missing `ticket_id` | `{\"error\":\"ticket_id is required\"}` on stderr, exit 1 |

## Test plan

- [x] `go test ./forge-skills/...` — all green (incl. `TestEmbeddedRegistry_GitHubDetails`, which counts on `gh`/`git`/`jq` + the egress domain set — none of which changed)
- [x] `go test ./forge-core/...` `./forge-cli/...` `./forge-plugins/...` — no regressions
- [x] `gofmt -w`, `golangci-lint run ./forge-skills/...` — 0 issues
- [x] `shellcheck` clean on `github-branch-name-from-ticket.sh`
- [x] Both verbatim smoke tests from #70 pass
- [x] Edge cases: invalid prefix → fallback, long title → hyphen-boundary truncation, missing required field → structured error
- [ ] Manual: against a sandbox repo with `GH_TOKEN`, verify the PR title ends with ` [ENG-DEMO-1]` and the body contains `Tracks: [ENG-DEMO-1](https://...)`

## Out of scope per #70

- No Linear / tracker API calls from github-skill scripts — the LLM does the post-PR ticket comment via the `linear` skill (PR #67)
- No hardcoded `linear.app` references — `ticket_url` is an opaque URL
- No `github_link_issue` / `github_close_issue_on_merge` — separate concern
- No new egress domains — `api.github.com` + `github.com` still the only allowed pair
- No changes to pagination contract or list-tool behaviour

## Pre-existing finding left untouched

`shellcheck github-create-pr.sh` reports SC2181 on line 88 (the `gh pr create` exit check uses `\$?` instead of `if !`). This exists verbatim on `main` and is not introduced by this PR — the issue's \"additive changes only\" rule covers existing style. Happy to fix in a follow-up.

## Relation to PRs #67 and #69

This PR is independent of:
- **#67** (linear skill) — provides the `linear_get_issue` / `linear_add_comment` tools the new system-prompt guidance references
- **#69** (code-plan skill) — provides `code_plan_create` whose `complexity: \"high\"` output is one of the workflow-pause carve-outs

The three together form the canonical ticket → plan → branch → commit → PR → comment flow. None of them touch the same files, so they can land in any order.