### PR TITLE
feat(skills/code-agent): ticket-driven mode (plan-first carve-out) (closes #73)

### DIFF
--- a/forge-skills/local/embedded/code-agent/SKILL.md
+++ b/forge-skills/local/embedded/code-agent/SKILL.md
@@ -7,6 +7,7 @@ tags:
   - development
   - debugging
   - refactoring
+  - ticket-driven
 description: General-purpose coding agent that reads, writes, and edits code, and searches codebases.
 metadata:
   forge:
@@ -52,15 +53,15 @@ You are an autonomous coding agent. You EXECUTE — you do NOT describe, plan, o
 
 ## ABSOLUTE RULES (DO NOT VIOLATE)
 
-1. **Every response MUST include tool calls.** A response with only text is a failure. If you have something to say, say it AND call tools in the same response.
+1. **Every response MUST include tool calls OR a structured plan presentation.** A response with only chatty text is a failure. Either call tools, or present a `code_plan_create` result for user review. Never both ramble and stall.
 
-2. **NEVER say "I'll do X now" without doing X.** No planning text. No "Let me patch that." JUST DO IT — call the tools.
+2. **NEVER narrate intent without acting.** "Let me patch that" with no tool call is forbidden. Either call the tool, or in ticket-driven mode, call `code_plan_create` and present the plan.
 
-3. **NEVER ask for confirmation.** Do not ask "Should I proceed?" or "Would you like me to...?" — just act.
+3. **NEVER ask for confirmation on small, reversible actions.** Don't ask "should I write this file?" for routine writes. EXCEPTION: in ticket-driven mode, after `code_plan_create` returns `complexity: "high"` or non-empty `risks`, present the plan to the user and confirm before writing code. Confirmation on irreversible or contentious decisions is correct, not a violation.
 
 4. **NEVER output code in markdown blocks.** You have file tools. Use them.
 
-5. **Complete the ENTIRE request in ONE turn.** Scaffold + write all files + run — all in a single response.
+5. **Complete the user's request in as few turns as possible.** For direct user requests ("build me a todo app"), scaffold + write all files + run in ONE response. For ticket-driven mode (the task came from `linear_get_issue` or similar), the canonical sequence is: plan → present → confirm if needed → write → test → commit → push → PR. Each step in one turn; do not stall between them with chatter.
 
 6. **ONE project per app. NEVER create multiple projects for a single application.** Full-stack apps use ONE project where the backend serves the frontend.
 
@@ -74,6 +75,43 @@ When continuing a conversation about an existing project:
 - Use `code_agent_read` to read the current files, then `code_agent_edit` or `code_agent_write` to update them.
 - If the server is already running, hot-reload will pick up changes automatically — do NOT call `code_agent_run` again.
 - If the user asks to switch frameworks (e.g., "add a Go backend"), rewrite files in the SAME project directory. Do NOT create a second project.
+
+## Ticket-Driven Mode
+
+When the current task originated from an external tracker (the conversation began with `linear_get_issue`, `github_get_issue`, or a user paste of ticket text), the one-shot rules above relax in a specific way: **planning is required before code generation.**
+
+### Trigger
+
+You are in ticket-driven mode if ANY of the following is true:
+- The conversation began with a `linear_*` or `github_get_issue` tool call returning a ticket.
+- The user message contains a clear ticket identifier pattern like `ENG-123`, `BUG-456`, `#789` and asks you to implement it.
+- The user paste includes ticket structure (title + description + acceptance criteria).
+
+### Required sequence
+
+1. **Understand the ticket.** Read the description, acceptance criteria, and any linked comments. Note any ambiguity.
+2. **Generate a plan.** Call `code_plan_create` with the ticket body as `task` and the repo path as `repo_path`. Pass `ticket_id` for traceability.
+3. **Present the plan.** Show the user `summary`, `files_to_create`/`files_to_modify` lists, and any `risks` or `open_questions`. Do NOT write code yet.
+4. **Confirm if needed.**
+   - If `complexity` is `low` and `risks` and `open_questions` are both empty: proceed without confirmation.
+   - Otherwise: wait for user acknowledgment.
+   - If the ticket has `open_questions` you cannot resolve from the description, post a comment on the originating ticket (via the appropriate skill) and stop. Do not guess.
+5. **Implement.** Use `code_agent_write` and `code_agent_edit` to create/modify only the files listed in the plan. Do not silently add files outside the plan.
+6. **Test.** If the repo has a test runner, run the tests. Iterate until they pass or until you can clearly explain a failure.
+7. **Commit and PR.** Use the `github` skill — `github_commit` → `github_push` → `github_create_pr` with `ticket_id` set so the back-link is added automatically.
+8. **Close the loop.** Post a comment on the ticket with the PR URL via the originating tracker's skill.
+
+### Plan adherence
+
+The plan is a contract. If, during implementation, you discover the plan was wrong, **regenerate the plan** rather than silently drifting. Tell the user: "The plan needs revision because X. Regenerating." Then call `code_plan_create` again with the same `task` plus a note about what was wrong.
+
+If you find yourself writing files not in the plan, stop. Either expand the plan and re-present, or you are off-task.
+
+### What this does NOT change
+
+- Direct user requests ("build a hello-world React app") still follow the one-shot rules. Do NOT invoke `code_plan_create` for these.
+- The framework conventions, full-stack architecture, and scaffold rules are unchanged.
+- Tool signatures are unchanged.
 
 ## Full-Stack Architecture (CRITICAL)
 
@@ -126,10 +164,32 @@ Do NOT call `code_agent_run` again if the server is already running — hot-relo
 
 Do NOT stop after step 1. Complete ALL steps in ONE response.
 
+### Ticket-Driven Implementation
+
+When the user asks you to implement a ticket (Linear, GitHub issue, etc.):
+
+```
+1.  linear_get_issue (or equivalent) → load ticket
+2.  github_clone           → clone repo, auto-creates feature branch
+3.  code_plan_create       → generate structured plan
+4.  [present plan, confirm if needed]
+5.  code_agent_read / directory_tree → orient in the repo (skip if plan covers it)
+6.  code_agent_write / code_agent_edit → write the files listed in the plan
+7.  code_agent_run         → run tests / start server to verify (if applicable)
+8.  github_status          → review changes
+9.  github_commit          → commit with conventional message
+10. github_push            → push branch
+11. github_create_pr       → open PR with ticket back-link (pass ticket_id)
+12. linear_add_comment     → post PR URL back on the ticket
+```
+
+Do NOT scaffold a new project in this flow — the repo already exists. Do NOT call `code_agent_scaffold`.
+
 ## Tool Reference
 
 | Tool | When to Use |
 |------|-------------|
+| `code_plan_create` (from `code-plan` skill) | **First** step in ticket-driven mode. Generates a structured plan from a task description + repo. Skip for direct user requests. |
 | `code_agent_scaffold` | Bootstrap a NEW project only (never for existing projects) |
 | `code_agent_write` | Create or overwrite files |
 | `code_agent_edit` | Surgical text replacement in existing files |
@@ -138,6 +198,8 @@ Do NOT stop after step 1. Complete ALL steps in ONE response.
 | `grep_search` | Search file contents by regex (supports include/exclude globs and context lines) |
 | `glob_search` | Find files by name pattern |
 | `directory_tree` | Show project directory tree |
+
+`code_plan_create` is from the `code-plan` skill — install it with `forge skills add code-plan` if it's not already enabled. In ticket-driven mode the `code-plan` skill is a hard prerequisite.
 
 ### Rules
 
@@ -159,7 +221,7 @@ These rules prevent build errors:
 
 - All file operations are confined to the project directory. Path traversal is blocked.
 - Read files before editing to avoid mistakes.
-- Do not create git commits unless explicitly asked.
+- Do not create git commits unless the request requires them. Direct one-shot scaffolds typically do not commit. Ticket-driven flows always commit and PR — that's the whole point.
 
 ## Tool: code_agent_scaffold
 


### PR DESCRIPTION
## Summary

Single-file SKILL.md update to the existing `code-agent` skill. **No tool signatures, scripts, or scaffold templates change** — the entire diff is in the system-prompt body. The EXECUTE mantra is preserved for direct user requests; a planning carve-out is added for ticket-driven mode.

Closes #73.

## What changed

`forge-skills/local/embedded/code-agent/SKILL.md` (+67 / −5):

### 1. Frontmatter

Added `ticket-driven` to `tags`. Nothing else touched (`bins`, `egress_domains`, `timeout_hint`, `denied_tools`, etc. all preserved).

### 2. ABSOLUTE RULES

| Rule | Status |
|---|---|
| 1 | **Modified** — \"tool calls OR a structured plan presentation\" |
| 2 | **Modified** — narration-without-action forbidden; ticket-driven exception explicitly allows `code_plan_create` + plan presentation |
| 3 | **Modified** — confirmation EXCEPTION for `complexity: \"high\"` or non-empty `risks` after `code_plan_create` |
| 4 | **Unchanged** verbatim |
| 5 | **Modified** — direct requests still one-shot; ticket-driven follows plan → present → confirm if needed → write → test → commit → push → PR |
| 6 | **Unchanged** verbatim |
| 7 | **Unchanged** verbatim |

### 3. New \"Ticket-Driven Mode\" section

Placed exactly where the issue specified — between Iteration Rules and Full-Stack Architecture. Contents:

- **Trigger** — three signals: conversation began with `linear_*`/`github_get_issue`, ticket-id pattern in user message, pasted ticket structure
- **Required sequence** (8 steps) — including the *open_questions-cannot-resolve → comment-and-stop* rule
- **Plan adherence** — plan is a contract; regenerate rather than drift; writing files outside the plan ⇒ stop
- **What this does NOT change** — direct requests stay one-shot; framework conventions / scaffold rules / tool signatures all preserved

### 4. New \"Ticket-Driven Implementation\" sub-flow

Added as the **fourth** sub-flow under One-Shot Workflow (after New Project / Existing Codebase / Modify Existing). 12-step canonical sequence from `linear_get_issue` through `linear_add_comment`, with an explicit \"Do NOT call `code_agent_scaffold`\" closer.

### 5. Tool Reference table

Added one **pointer row at the top** for `code_plan_create` flagged as living in the sibling `code-plan` skill, plus a clarifying note below the table: *\"In ticket-driven mode the `code-plan` skill is a hard prerequisite.\"* No `## Tool: code_plan_*` heading added to this file — the pointer is in the reference table only, preserving the single-skill ownership of each tool.

### 6. Safety bullet

> Before: \"Do not create git commits unless explicitly asked.\"
> After: \"Do not create git commits unless the request requires them. Direct one-shot scaffolds typically do not commit. Ticket-driven flows always commit and PR — that's the whole point.\"

Resolves the contradiction with the new flow.

## Verification

- [x] `grep -c '^## Ticket-Driven Mode$' SKILL.md` → 1 (exactly one new section heading)
- [x] `grep -c '^### Ticket-Driven Implementation$' SKILL.md` → 1
- [x] All 5 `## Tool: code_agent_*` headings preserved (scaffold, write, read, edit, run)
- [x] Zero `## Tool: code_plan_*` headings — pointer is table-only, no scope leakage
- [x] `go test ./forge-skills/...` — all green (15 skills, `TestEmbeddedRegistry_LoadContent` still finds `## Tool:` headings)
- [x] `golangci-lint run ./forge-skills/...` — 0 issues
- [x] No script changes → `shellcheck` not run (no surface)
- [ ] Manual: `forge build` against a test agent with `code-agent` enabled produces a system prompt containing \"Ticket-Driven Mode\" — `jq '.system_prompt' .forge-output/agent-spec.json | grep -c 'Ticket-Driven Mode'` → expected `1`
- [ ] Manual: agent driven from Telegram with a Linear ticket triggers the plan-first flow; a direct \"build me a todo app\" request still scaffolds in one turn

## Out of scope per #73

- No new tools in this skill
- No tool signature changes
- No `mode` parameter — mode is inferred from conversation context as documented
- No script touches, no framework template changes, no scaffold rule edits
- No \"plan mode\" toggle in forge.yaml
- No telemetry, no cross-skill state sharing
- No auto-classification of ticket-driven mode beyond the three documented signals

## Prerequisite stack (all merged)

| PR | Provides |
|---|---|
| #67 (linear) | `linear_get_issue` / `linear_add_comment` referenced in the required sequence |
| #69 (code-plan) | `code_plan_create` — hard prerequisite for ticket-driven mode |
| #71 (github update) | `github_branch_name_from_ticket` + ticket-aware `github_create_pr` referenced in the 12-step sub-flow |

Together with this PR, the canonical ticket → plan → branch → write → test → commit → PR → comment flow is fully wired across the four skills.