### PR TITLE
feat(runtime): cancellation signal handling (closes #88, FWS-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Added
 
+- **Cancellation signal handling (issue #88, FWS-4).** The A2A
+  `tasks/cancel` JSON-RPC method now actually cancels in-flight
+  invocations instead of merely flipping the stored task state. A
+  per-Runner `CancellationRegistry` tracks every active invocation
+  by task ID; the cancel handler signals the registered
+  `context.CancelCauseFunc` with a typed reason
+  (`workflow_failure` / `cost_limit_exceeded` / `timeout` /
+  `external_signal`), which propagates through the executor's ctx.
+  The agent loop honors cancellation at the iteration boundary and
+  between tool calls within an iteration, so cancellation latency is
+  bounded by the current LLM call or tool exec. A new
+  `invocation_cancelled` audit event closes every cancelled
+  invocation with the classified reason, `duration_ms` up to
+  cancellation, and partial token totals consumed before the signal
+  (from the FWS-3 `LLMUsageAccumulator`). The A2A response carries
+  state `canceled` plus a `cancelled: <reason>` message so the
+  orchestrator can react. Cancel-after-complete is idempotent — a
+  cancel for a task that already finished returns the stored state
+  unchanged rather than corrupting it. `CancelTaskParams` gains an
+  optional `reason` field (unknown values are forwarded verbatim to
+  audit). The grace-period / hard-cancel concept maps to bounded
+  cancellation latency: Go's runtime can't kill a goroutine, so
+  Forge honors the signal at the next safe checkpoint and the
+  orchestrator-side timeout is its own concern. See
+  `docs/security/audit-logging.md#cancellation`.
 - **Token usage and execution duration emission (issue #87, FWS-3).**
   Every `llm_call` audit event now carries `input_tokens`,
   `output_tokens`, `model`, `provider`, `duration_ms`, and `request_id`

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -20,6 +20,7 @@ All runtime security events are emitted as structured NDJSON to stderr with corr
 | `llm_call` | LLM API call completed (with `input_tokens`, `output_tokens`, `model`, `provider`, `duration_ms`, `request_id`). See [Token usage and duration](#token-usage-and-execution-duration). |
 | `llm_call_cancelled` | Streaming LLM call cancelled mid-flight; carries partial token counts captured up to cancellation. |
 | `invocation_complete` | A2A invocation finished (auth → dispatch → engine → response). Carries `duration_ms` (wall-clock) plus aggregated `input_tokens_total` / `output_tokens_total` / `llm_call_count` / `model` / `provider`. |
+| `invocation_cancelled` | A2A invocation cancelled mid-flight via `tasks/cancel` (or internal cancellation like parent ctx deadline). Carries `fields.reason` (one of `workflow_failure` / `cost_limit_exceeded` / `timeout` / `external_signal`), `duration_ms` up to cancellation, and any partial token totals consumed before the signal. See [Cancellation](#cancellation). |
 | `guardrail_check` | Guardrail evaluation result |
 | `auth_verify` | Inbound request authenticated successfully (with `provider`, `user_id`, `org_id`, `token_kind`) |
 | `auth_fail` | Inbound request rejected (with `reason`, `token_kind`) |
@@ -87,6 +88,55 @@ A2A response headers carry the same per-invocation totals inline so an orchestra
 Headers populate regardless of whether OTel tracing is enabled — they're the orchestration channel, not the observability channel.
 
 **Cost calculation is deliberately not in Forge.** Forge emits token counts; the platform applies price tables to compute dollar amounts. Price tables change frequently and shouldn't require agent redeploys.
+
+### Cancellation
+
+Forge accepts mid-invocation cancellation via the A2A `tasks/cancel` JSON-RPC method. The handler looks up the in-flight invocation in a per-Runner cancellation registry, fires a typed cancel-cause through the executor's `context.Context`, and the loop honors it at the next iteration boundary or between tool calls (whichever comes first). The current LLM call honors cancellation natively — `http.Client.Do` aborts the request on `ctx.Done()`.
+
+Cancellation latency is bounded by the time for the current LLM call or tool call to finish (typically seconds, not minutes). Go's runtime does not support force-terminating a goroutine, so "hard-cancel" semantically means "honor the signal at the next safe checkpoint." The orchestrator-side `cancel + give-up-wait-after-N-seconds` pattern is an A2A-client concern, not a Forge concern.
+
+```json
+{
+  "ts": "2026-06-04T15:23:47Z",
+  "event": "invocation_cancelled",
+  "correlation_id": "9b3d…",
+  "task_id": "task-42",
+  "duration_ms": 1820,
+  "fields": {
+    "reason": "cost_limit_exceeded",
+    "state": "canceled",
+    "input_tokens_total": 940,
+    "output_tokens_total": 215,
+    "llm_call_count": 2,
+    "model": "claude-sonnet-4-6",
+    "provider": "anthropic"
+  }
+}
+```
+
+| `fields.reason` | Set by | Meaning |
+|---|---|---|
+| `workflow_failure` | Orchestrator | Sibling step in a parallel stage failed under `fail_workflow`; abandon work. |
+| `cost_limit_exceeded` | Orchestrator | Workflow cumulative cost ceiling hit (typically derived from the FWS-3 `X-Forge-Tokens-*` headers). |
+| `timeout` | Orchestrator / Forge | Wall-clock budget exhausted. Parent ctx `context.DeadlineExceeded` auto-maps to this reason. |
+| `external_signal` | Operator / fallback | Operator-initiated stop, debugging cancel, or any cancellation without a typed reason. |
+
+**Cancel request shape:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tasks/cancel",
+  "params": { "id": "task-42", "reason": "cost_limit_exceeded" },
+  "id": "1"
+}
+```
+
+`reason` is optional. Unknown reason strings are accepted and forwarded to the audit event verbatim — the audit pipeline is the authority on classification.
+
+**Cancel after complete is idempotent.** A cancel issued for a task that already finished (or was never started) returns the stored task state unchanged — no error. The handler refuses to flip a terminal-state task to `canceled` because that would corrupt audit and orchestrator state.
+
+**Partial usage is preserved.** When LLM calls completed before the cancel signal, `input_tokens_total` / `output_tokens_total` / `llm_call_count` carry the accumulated counts so a downstream cost aggregator bills only for what was consumed. When no LLM call landed, the totals are absent and the event still carries `duration_ms` so wall-clock spend is visible.
 
 ### Authentication events
 

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -103,13 +103,14 @@ type Runner struct {
 	cfg              RunnerConfig
 	logger           coreruntime.Logger
 	cliExecTool      *clitools.CLIExecuteTool
-	modelConfig      *coreruntime.ModelConfig       // resolved model config (for banner)
-	derivedCLIConfig *contract.DerivedCLIConfig     // auto-derived from skill requirements
-	skillGuardrails  *agentspec.SkillGuardrailRules // runtime-parsed skill guardrails (fallback when no build artifact)
-	sched            *scheduler.Scheduler           // cron scheduler (nil until started)
-	startTime        time.Time                      // server start time (for /health uptime)
-	scheduleNotifier ScheduleNotifier               // optional: delivers cron results to channels
-	authToken        string                         // resolved auth token (empty if --no-auth)
+	modelConfig      *coreruntime.ModelConfig          // resolved model config (for banner)
+	derivedCLIConfig *contract.DerivedCLIConfig        // auto-derived from skill requirements
+	skillGuardrails  *agentspec.SkillGuardrailRules    // runtime-parsed skill guardrails (fallback when no build artifact)
+	sched            *scheduler.Scheduler              // cron scheduler (nil until started)
+	startTime        time.Time                         // server start time (for /health uptime)
+	scheduleNotifier ScheduleNotifier                  // optional: delivers cron results to channels
+	authToken        string                            // resolved auth token (empty if --no-auth)
+	cancelRegistry   *coreruntime.CancellationRegistry // per-Runner in-flight cancellation registry (issue #88 / FWS-4)
 }
 
 // NewRunner creates a Runner from the given config.
@@ -121,7 +122,11 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 		cfg.Port = 8080
 	}
 	logger := coreruntime.NewJSONLogger(os.Stderr, cfg.Verbose)
-	return &Runner{cfg: cfg, logger: logger}, nil
+	return &Runner{
+		cfg:            cfg,
+		logger:         logger,
+		cancelRegistry: coreruntime.NewCancellationRegistry(),
+	}, nil
 }
 
 // SetScheduleNotifier sets the callback used to deliver scheduled task results
@@ -993,8 +998,14 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		return a2a.NewResponse(id, task)
 	})
 
-	// tasks/cancel — cancel a task
-	srv.RegisterHandler("tasks/cancel", func(ctx context.Context, id any, rawParams json.RawMessage) *a2a.JSONRPCResponse {
+	// tasks/cancel — signal the in-flight invocation for taskID. Maps
+	// the optional CancelTaskParams.Reason onto a CancellationReason
+	// the runtime then surfaces on the invocation_cancelled audit event
+	// and the response task message. Idempotent: a cancel for a task
+	// that already completed (or was never started) returns the stored
+	// task without an error so the orchestrator can issue cancels
+	// optimistically. See issue #88 / FWS-4.
+	srv.RegisterHandler("tasks/cancel", func(_ context.Context, id any, rawParams json.RawMessage) *a2a.JSONRPCResponse {
 		var params a2a.CancelTaskParams
 		if err := json.Unmarshal(rawParams, &params); err != nil {
 			return a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, "invalid params: "+err.Error())
@@ -1005,9 +1016,21 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 			return a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, "task not found: "+params.ID)
 		}
 
-		task.Status = a2a.TaskStatus{State: a2a.TaskStateCanceled}
-		store.Put(task)
-		r.logger.Info("task canceled", map[string]any{"task_id": params.ID})
+		reason := coreruntime.CancellationReason(params.Reason)
+		if reason == "" {
+			reason = coreruntime.CancelReasonExternalSignal
+		}
+		signalled := r.cancelRegistry.Cancel(params.ID, reason)
+		r.logger.Info("tasks/cancel", map[string]any{
+			"task_id":   params.ID,
+			"reason":    string(reason),
+			"signalled": signalled,
+		})
+		// When the registry had no entry, the invocation already
+		// finished (or never started). Leave the stored task untouched —
+		// flipping a completed task to canceled would corrupt audit
+		// and orchestrator state. The response echoes whatever the
+		// store has so the orchestrator reads the actual outcome.
 		return a2a.NewResponse(id, task)
 	})
 }
@@ -1032,6 +1055,15 @@ func (r *Runner) executeTask(
 	// invocation_complete audit event. See issue #87 / FWS-3.
 	acc := coreruntime.NewLLMUsageAccumulator()
 	ctx = coreruntime.WithLLMUsageAccumulator(ctx, acc)
+	// Cancellation surface (issue #88 / FWS-4): derive a cancel-cause
+	// ctx so the tasks/cancel handler can signal this in-flight
+	// invocation by task ID. The release closure pops the registry
+	// entry on return; cancel() at defer time is a no-op when the
+	// invocation completed cleanly.
+	ctx, cancelInvocation := context.WithCancelCause(ctx)
+	release := r.cancelRegistry.Register(params.ID, cancelInvocation)
+	defer release()
+	defer cancelInvocation(nil) // nil cause = clean completion; no-op when already cancelled
 
 	auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
 		Event:         coreruntime.AuditSessionStart,
@@ -1046,7 +1078,14 @@ func (r *Runner) executeTask(
 	task.Status = a2a.TaskStatus{State: a2a.TaskStateSubmitted}
 	store.Put(task)
 
-	emitInvocationComplete := func() {
+	// emitInvocationLifecycle emits either invocation_complete or
+	// invocation_cancelled at the response boundary, depending on
+	// whether the ctx was cancelled mid-flight. The cancellation reason
+	// flows through context.Cause — set by the tasks/cancel handler
+	// via the cancellation registry. Partial usage from the accumulator
+	// rides on both events so a downstream cost aggregator sees the
+	// tokens consumed before cancellation. See issue #88 / FWS-4.
+	emitInvocationLifecycle := func() {
 		snap := acc.Snapshot()
 		fields := map[string]any{"state": string(task.Status.State)}
 		if snap.LLMCallCount > 0 {
@@ -1059,6 +1098,12 @@ func (r *Runner) executeTask(
 			if snap.PrimaryProvider != "" {
 				fields["provider"] = snap.PrimaryProvider
 			}
+		}
+		if task.Status.State == a2a.TaskStateCanceled {
+			auditLogger.EmitInvocationCancelled(ctx,
+				coreruntime.CancellationReasonFromCause(ctx),
+				snap.InvocationDuration, fields)
+			return
 		}
 		auditLogger.EmitInvocationComplete(ctx, snap.InvocationDuration, fields)
 	}
@@ -1078,7 +1123,7 @@ func (r *Runner) executeTask(
 			TaskID:        params.ID,
 			Fields:        map[string]any{"state": string(a2a.TaskStateFailed)},
 		})
-		emitInvocationComplete()
+		emitInvocationLifecycle()
 		return task, acc.Snapshot(), nil
 	}
 
@@ -1088,6 +1133,32 @@ func (r *Runner) executeTask(
 
 	respMsg, err := executor.Execute(ctx, task, &params.Message)
 	if err != nil {
+		// Cancellation gets a distinct lifecycle (state=canceled,
+		// invocation_cancelled audit event) so the orchestrator can
+		// distinguish "you asked me to stop" from "the agent crashed."
+		// See issue #88 / FWS-4.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			reason := coreruntime.CancellationReasonFromCause(ctx)
+			r.logger.Info("task cancelled mid-execution", map[string]any{
+				"task_id": params.ID, "reason": string(reason),
+			})
+			task.Status = a2a.TaskStatus{
+				State: a2a.TaskStateCanceled,
+				Message: &a2a.Message{
+					Role:  a2a.MessageRoleAgent,
+					Parts: []a2a.Part{a2a.NewTextPart("cancelled: " + string(reason))},
+				},
+			}
+			store.Put(task)
+			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+				Event:         coreruntime.AuditSessionEnd,
+				CorrelationID: correlationID,
+				TaskID:        params.ID,
+				Fields:        map[string]any{"state": string(a2a.TaskStateCanceled)},
+			})
+			emitInvocationLifecycle()
+			return task, acc.Snapshot(), nil
+		}
 		r.logger.Error("execute failed", map[string]any{"task_id": params.ID, "error": err.Error()})
 		task.Status = a2a.TaskStatus{
 			State: a2a.TaskStateFailed,
@@ -1103,7 +1174,7 @@ func (r *Runner) executeTask(
 			TaskID:        params.ID,
 			Fields:        map[string]any{"state": string(a2a.TaskStateFailed)},
 		})
-		emitInvocationComplete()
+		emitInvocationLifecycle()
 		return task, acc.Snapshot(), nil
 	}
 
@@ -1123,7 +1194,7 @@ func (r *Runner) executeTask(
 				TaskID:        params.ID,
 				Fields:        map[string]any{"state": string(a2a.TaskStateFailed)},
 			})
-			emitInvocationComplete()
+			emitInvocationLifecycle()
 			return task, acc.Snapshot(), nil
 		}
 	}
@@ -1151,7 +1222,7 @@ func (r *Runner) executeTask(
 		TaskID:        params.ID,
 		Fields:        map[string]any{"state": string(task.Status.State)},
 	})
-	emitInvocationComplete()
+	emitInvocationLifecycle()
 	r.logger.Info("task completed", map[string]any{"task_id": params.ID, "state": string(task.Status.State)})
 	return task, acc.Snapshot(), nil
 }

--- a/forge-cli/runtime/runner_test.go
+++ b/forge-cli/runtime/runner_test.go
@@ -160,7 +160,11 @@ func TestRunner_MockIntegration(t *testing.T) {
 		}
 	})
 
-	// Test tasks/cancel
+	// Test tasks/cancel — after issue #88 / FWS-4, cancel on an
+	// already-completed task is an idempotent no-op: the registry has
+	// no entry (the in-flight invocation released on completion), so
+	// the stored task state stays Completed. Flipping a terminal-state
+	// task to Canceled would corrupt audit and orchestrator state.
 	t.Run("tasks/cancel", func(t *testing.T) {
 		rpcReq := a2a.JSONRPCRequest{
 			JSONRPC: "2.0",
@@ -186,8 +190,8 @@ func TestRunner_MockIntegration(t *testing.T) {
 		resultData, _ := json.Marshal(rpcResp.Result)
 		var task a2a.Task
 		json.Unmarshal(resultData, &task) //nolint:errcheck
-		if task.Status.State != a2a.TaskStateCanceled {
-			t.Errorf("state: got %q, want %q", task.Status.State, a2a.TaskStateCanceled)
+		if task.Status.State != a2a.TaskStateCompleted {
+			t.Errorf("cancel-after-complete should leave state at Completed, got %q", task.Status.State)
 		}
 	})
 

--- a/forge-core/a2a/jsonrpc.go
+++ b/forge-core/a2a/jsonrpc.go
@@ -46,8 +46,17 @@ type GetTaskParams struct {
 }
 
 // CancelTaskParams are the parameters for tasks/cancel.
+//
+// Reason is optional. When set, it classifies why the orchestrator
+// (or operator) is cancelling — see runtime.CancellationReason for the
+// documented values. Unknown reason strings are accepted and forwarded
+// to the audit pipeline verbatim; the value flows straight through to
+// the invocation_cancelled audit event's fields.reason. Absent reason
+// resolves to external_signal at the runtime boundary. See issue
+// #88 / FWS-4.
 type CancelTaskParams struct {
-	ID string `json:"id"`
+	ID     string `json:"id"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // NewResponse creates a successful JSON-RPC 2.0 response.

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -62,6 +62,14 @@ const (
 	// the cancellation point. See issue #87 / FWS-3.
 	AuditLLMCallCancelled = "llm_call_cancelled"
 
+	// AuditInvocationCancelled is emitted when an in-flight A2A
+	// invocation is cancelled by tasks/cancel (or internal cancellation
+	// like a parent ctx deadline). Carries the classified reason in
+	// Fields["reason"], the wall-clock duration up to cancellation in
+	// DurationMs, and aggregated partial usage in Fields when any LLM
+	// calls completed before the cancel signal. See issue #88 / FWS-4.
+	AuditInvocationCancelled = "invocation_cancelled"
+
 	// Deprecated: use EventAuthVerify. Kept as a string alias so any
 	// audit-log consumer that grep'd for "auth_success" can be migrated.
 	// Scheduled for removal in v0.11.0.
@@ -300,6 +308,36 @@ func (a *AuditLogger) EmitInvocationComplete(ctx context.Context, duration time.
 	d := duration.Milliseconds()
 	a.EmitFromContext(ctx, AuditEvent{
 		Event:      AuditInvocationComplete,
+		DurationMs: &d,
+		Fields:     fields,
+	})
+}
+
+// EmitInvocationCancelled emits an invocation_cancelled audit event
+// for an in-flight A2A invocation that was signalled mid-execution
+// via tasks/cancel (or internal cancellation: parent ctx deadline,
+// graceful shutdown). Routed through EmitFromContext so workflow
+// correlation auto-tags. The reason is folded into Fields["reason"]
+// as a string — operators classify these via the CancellationReason
+// constants but consumers should pass-through unknown values.
+//
+// Partial usage data should be present in fields (the runner reads
+// the per-invocation LLMUsageAccumulator snapshot and adds
+// input_tokens_total / output_tokens_total / llm_call_count / model
+// / provider when llm_call_count > 0). When no LLM calls completed
+// before cancellation, the field map carries reason + state only —
+// downstream billing sees zero tokens which is correct: the
+// invocation was cancelled before incurring spend.
+//
+// See issue #88 / FWS-4.
+func (a *AuditLogger) EmitInvocationCancelled(ctx context.Context, reason CancellationReason, duration time.Duration, fields map[string]any) {
+	d := duration.Milliseconds()
+	if fields == nil {
+		fields = map[string]any{}
+	}
+	fields["reason"] = string(reason)
+	a.EmitFromContext(ctx, AuditEvent{
+		Event:      AuditInvocationCancelled,
 		DurationMs: &d,
 		Fields:     fields,
 	})

--- a/forge-core/runtime/audit_cancelled_test.go
+++ b/forge-core/runtime/audit_cancelled_test.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for issue #88 / FWS-4 — invocation_cancelled audit
+// event shape. Carries the classified reason, wall-clock duration up
+// to cancellation, and any partial usage that landed before the
+// cancel signal. Schema additive over the FWS-3 invocation_complete
+// shape.
+
+func TestEmitInvocationCancelled_CarriesReasonAndDuration(t *testing.T) {
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+
+	audit.EmitInvocationCancelled(context.Background(),
+		CancelReasonCostLimitExceeded,
+		350*time.Millisecond,
+		map[string]any{"state": "canceled"},
+	)
+
+	var evt AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt); err != nil {
+		t.Fatalf("decode: %v\n%s", err, buf.String())
+	}
+	if evt.Event != AuditInvocationCancelled {
+		t.Errorf("Event = %q, want %q", evt.Event, AuditInvocationCancelled)
+	}
+	if evt.DurationMs == nil || *evt.DurationMs != 350 {
+		t.Errorf("DurationMs = %v, want 350", evt.DurationMs)
+	}
+	if evt.Fields["reason"] != string(CancelReasonCostLimitExceeded) {
+		t.Errorf("fields.reason = %v, want %q", evt.Fields["reason"], CancelReasonCostLimitExceeded)
+	}
+	if evt.Fields["state"] != "canceled" {
+		t.Errorf("fields.state should be preserved, got %v", evt.Fields["state"])
+	}
+}
+
+func TestEmitInvocationCancelled_PartialUsagePassedThroughFields(t *testing.T) {
+	// When the cancel arrives after some LLM calls completed, the
+	// runner reads the LLMUsageAccumulator snapshot and adds the
+	// totals to fields. The audit emitter must pass them through
+	// unmodified so a downstream billing consumer sees what was
+	// consumed before cancellation.
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+
+	audit.EmitInvocationCancelled(context.Background(),
+		CancelReasonWorkflowFailure,
+		200*time.Millisecond,
+		map[string]any{
+			"state":               "canceled",
+			"input_tokens_total":  500,
+			"output_tokens_total": 120,
+			"llm_call_count":      2,
+			"model":               "claude-sonnet-4-6",
+			"provider":            "anthropic",
+		},
+	)
+
+	var evt AuditEvent
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt)
+	if v, _ := evt.Fields["input_tokens_total"].(float64); v != 500 {
+		t.Errorf("input_tokens_total = %v, want 500", evt.Fields["input_tokens_total"])
+	}
+	if v, _ := evt.Fields["output_tokens_total"].(float64); v != 120 {
+		t.Errorf("output_tokens_total = %v, want 120", evt.Fields["output_tokens_total"])
+	}
+	if v, _ := evt.Fields["llm_call_count"].(float64); v != 2 {
+		t.Errorf("llm_call_count = %v, want 2", evt.Fields["llm_call_count"])
+	}
+}
+
+func TestEmitInvocationCancelled_NilFieldsStillEmitsReason(t *testing.T) {
+	// Cancellation before any LLM call has the runner pass nil fields.
+	// The reason key must still land — without it, audit consumers
+	// can't classify the event.
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+
+	audit.EmitInvocationCancelled(context.Background(),
+		CancelReasonExternalSignal,
+		2*time.Millisecond,
+		nil,
+	)
+
+	var evt AuditEvent
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt)
+	if evt.Fields["reason"] != string(CancelReasonExternalSignal) {
+		t.Errorf("nil-fields path must still set reason, got %+v", evt.Fields)
+	}
+}
+
+func TestEmitInvocationCancelled_RoutesThroughEmitFromContext(t *testing.T) {
+	// EmitInvocationCancelled goes through EmitFromContext so workflow
+	// correlation auto-tags (issue #86 / FWS-2). Set a workflow ctx
+	// and confirm the workflow fields land on the cancelled event.
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+
+	ctx := WithCorrelationID(context.Background(), "corr-c")
+	ctx = WithTaskID(ctx, "task-c")
+	ctx = WithWorkflowContext(ctx, WorkflowContext{
+		WorkflowID: "wf-1", StageID: "stg", StepID: "stp",
+		InvocationCaller: "orchestrator",
+	})
+
+	audit.EmitInvocationCancelled(ctx, CancelReasonTimeout, 0, nil)
+
+	var evt AuditEvent
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt)
+	if evt.CorrelationID != "corr-c" || evt.TaskID != "task-c" {
+		t.Errorf("ctx correlation not threaded, got %+v", evt)
+	}
+	if evt.WorkflowID != "wf-1" || evt.StageID != "stg" || evt.StepID != "stp" || evt.InvocationCaller != "orchestrator" {
+		t.Errorf("workflow correlation not auto-tagged on cancelled event, got %+v", evt)
+	}
+}
+
+func TestEmitInvocationCancelled_PassesThroughUnknownReason(t *testing.T) {
+	// The audit emitter forwards whatever string was supplied — value
+	// validation happens at the JSON-RPC boundary, not in the
+	// audit layer. Unknown reasons must NOT be silently rewritten;
+	// downstream consumers see the original.
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+	audit.EmitInvocationCancelled(context.Background(),
+		CancellationReason("future_reason_v2"),
+		10*time.Millisecond,
+		nil,
+	)
+	if !strings.Contains(buf.String(), `"reason":"future_reason_v2"`) {
+		t.Errorf("unknown reason should pass through verbatim, got: %s", buf.String())
+	}
+}

--- a/forge-core/runtime/cancellation.go
+++ b/forge-core/runtime/cancellation.go
@@ -1,0 +1,178 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// CancellationReason classifies why an in-flight A2A invocation was
+// cancelled. Sourced from the tasks/cancel JSON-RPC params and carried
+// onto the invocation_cancelled audit event so a downstream consumer
+// (cost aggregator, workflow UI, SIEM) can distinguish "the operator
+// hit stop" from "the orchestrator hit a cost ceiling." See issue
+// #88 / FWS-4.
+//
+// New reasons are additive — audit consumers that don't recognize a
+// reason string should pass it through, not reject the event.
+type CancellationReason string
+
+const (
+	// CancelReasonWorkflowFailure is set by the orchestrator when a
+	// sibling step in a parallel stage failed under fail_workflow
+	// semantics and this in-flight agent should abandon its work.
+	CancelReasonWorkflowFailure CancellationReason = "workflow_failure"
+
+	// CancelReasonCostLimitExceeded is set by the orchestrator when
+	// the workflow's cumulative cost ceiling (from the FWS-3 token
+	// totals in A2A response headers) was hit and the platform is
+	// cutting off further LLM spend.
+	CancelReasonCostLimitExceeded CancellationReason = "cost_limit_exceeded"
+
+	// CancelReasonTimeout is set by the orchestrator (or by Forge's
+	// own task deadline) when the wall-clock budget for the
+	// invocation has been exhausted.
+	CancelReasonTimeout CancellationReason = "timeout"
+
+	// CancelReasonExternalSignal is the default — operator-initiated
+	// cancel, debugging stop, anything else not covered by the more
+	// specific reasons.
+	CancelReasonExternalSignal CancellationReason = "external_signal"
+)
+
+// IsValid reports whether r is one of the documented reason values.
+// Used at the tasks/cancel boundary to validate operator input; the
+// runtime itself happily forwards whatever string was supplied — the
+// validation is a UX nicety, not a security boundary.
+func (r CancellationReason) IsValid() bool {
+	switch r {
+	case CancelReasonWorkflowFailure,
+		CancelReasonCostLimitExceeded,
+		CancelReasonTimeout,
+		CancelReasonExternalSignal:
+		return true
+	}
+	return false
+}
+
+// cancelledByOrchestrator is the sentinel error type the tasks/cancel
+// handler hands to context.CancelCauseFunc. Carries the reason so the
+// executeTask goroutine — which sees ctx.Done() in a different
+// goroutine — can read it back via context.Cause without sharing
+// mutable state with the handler.
+//
+// This is the idiomatic Go 1.20+ "cancellation with reason" pattern.
+// Plain context.CancelFunc would force us to side-channel the reason
+// via a registry-side mutex, which adds contention on the cancel hot
+// path for no benefit.
+type cancelledByOrchestrator struct {
+	Reason CancellationReason
+}
+
+func (e *cancelledByOrchestrator) Error() string {
+	return "invocation cancelled: " + string(e.Reason)
+}
+
+// CancellationReasonFromCause unwraps the reason stamped on ctx by
+// the tasks/cancel path. Call this after observing ctx.Err() in the
+// executeTask goroutine. Returns CancelReasonExternalSignal when ctx
+// was cancelled without a typed reason (e.g. parent ctx deadline,
+// graceful shutdown signal) — those are still cancellations but the
+// emitting handler didn't classify them.
+func CancellationReasonFromCause(ctx context.Context) CancellationReason {
+	if ctx.Err() == nil {
+		return ""
+	}
+	cause := context.Cause(ctx)
+	var c *cancelledByOrchestrator
+	if errors.As(cause, &c) {
+		return c.Reason
+	}
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return CancelReasonTimeout
+	}
+	return CancelReasonExternalSignal
+}
+
+// CancellationRegistry tracks in-flight A2A invocations so the
+// tasks/cancel handler can signal them. One registry per Runner; one
+// entry per active invocation, keyed by task ID.
+//
+// The registry is the bridge between the JSON-RPC handler (which sees
+// the cancel request) and the long-running executeTask goroutine
+// (which holds the context.CancelCauseFunc). The handler looks up the
+// task ID, invokes the stored cancel function with a typed reason,
+// and the goroutine's ctx propagates the cancellation through the LLM
+// client, tool execution, and audit emission.
+type CancellationRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*registryEntry
+}
+
+// registryEntry wraps the CancelCauseFunc so the release closure
+// can identify "its" entry by pointer equality. Without this layer
+// Go's func values aren't comparable across closures, so a newer
+// Register call could leak the older release into the wrong slot.
+type registryEntry struct {
+	cancel context.CancelCauseFunc
+}
+
+// NewCancellationRegistry returns a fresh empty registry.
+func NewCancellationRegistry() *CancellationRegistry {
+	return &CancellationRegistry{entries: make(map[string]*registryEntry)}
+}
+
+// Register associates a CancelCauseFunc with a task ID. Returns a
+// release closure the caller must defer — release pops the entry
+// from the registry so it doesn't leak after the invocation finishes
+// (success, failure, or cancellation).
+//
+// If a registration already exists for taskID (concurrent retries on
+// the same ID, or buggy callers), Register overwrites it. The
+// returned release uses pointer identity to pop only its own entry,
+// so a stale release from the previous owner is a no-op.
+func (r *CancellationRegistry) Register(taskID string, cancel context.CancelCauseFunc) (release func()) {
+	entry := &registryEntry{cancel: cancel}
+	r.mu.Lock()
+	r.entries[taskID] = entry
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if cur := r.entries[taskID]; cur == entry {
+			delete(r.entries, taskID)
+		}
+	}
+}
+
+// Cancel signals the in-flight invocation for taskID with a typed
+// reason. Returns true when an entry was found and its cancel function
+// invoked, false when no invocation is registered (already completed,
+// never started, or already cancelled and unregistered). The handler
+// maps false → a no-op response so cancel-after-complete is idempotent
+// rather than an error.
+//
+// Reason validation is the caller's job; Cancel forwards whatever it
+// gets so internal cancellations (graceful shutdown, parent deadline
+// translation) can supply their own reason without going through the
+// JSON-RPC validator.
+func (r *CancellationRegistry) Cancel(taskID string, reason CancellationReason) bool {
+	r.mu.Lock()
+	entry, ok := r.entries[taskID]
+	r.mu.Unlock()
+	if !ok {
+		return false
+	}
+	entry.cancel(&cancelledByOrchestrator{Reason: reason})
+	return true
+}
+
+// Len returns the number of in-flight registrations. Exposed for
+// tests and operational observability — there is no per-task lookup
+// API by design (the handler only needs Cancel; the executeTask
+// goroutine reads its own reason via context.Cause on ctx).
+func (r *CancellationRegistry) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.entries)
+}

--- a/forge-core/runtime/cancellation_test.go
+++ b/forge-core/runtime/cancellation_test.go
@@ -1,0 +1,219 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression tests for issue #88 / FWS-4 — the cancellation registry +
+// reason propagation via context.Cause. The registry is the bridge
+// between the tasks/cancel handler and the in-flight executeTask
+// goroutine; the reason rides on the cancellation cause so the
+// goroutine can read it after observing ctx.Done().
+
+func TestCancellationRegistry_RegisterCancelReleaseLifecycle(t *testing.T) {
+	reg := NewCancellationRegistry()
+	if reg.Len() != 0 {
+		t.Fatalf("fresh registry should be empty, got %d", reg.Len())
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	release := reg.Register("task-1", cancel)
+	if reg.Len() != 1 {
+		t.Errorf("after Register: Len()=%d, want 1", reg.Len())
+	}
+
+	if !reg.Cancel("task-1", CancelReasonExternalSignal) {
+		t.Errorf("Cancel on registered task should return true")
+	}
+	if ctx.Err() == nil {
+		t.Errorf("ctx should be cancelled after registry.Cancel")
+	}
+
+	release()
+	if reg.Len() != 0 {
+		t.Errorf("after release: Len()=%d, want 0", reg.Len())
+	}
+}
+
+func TestCancellationRegistry_CancelUnknownTaskIsIdempotent(t *testing.T) {
+	// Cancel-after-complete must be a no-op (returns false) so the
+	// orchestrator can issue cancels optimistically without races
+	// against concurrent completion.
+	reg := NewCancellationRegistry()
+	if reg.Cancel("never-existed", CancelReasonTimeout) {
+		t.Errorf("Cancel on unknown task should return false")
+	}
+}
+
+func TestCancellationReasonFromCause_RoundTripWithCancelCause(t *testing.T) {
+	// Reason flows from handler → registry → CancelCauseFunc →
+	// context.Cause → CancellationReasonFromCause. The test simulates
+	// the full chain to lock in the contract the runner depends on.
+	reg := NewCancellationRegistry()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	release := reg.Register("t", cancel)
+	defer release()
+
+	reg.Cancel("t", CancelReasonCostLimitExceeded)
+	<-ctx.Done()
+	got := CancellationReasonFromCause(ctx)
+	if got != CancelReasonCostLimitExceeded {
+		t.Errorf("reason = %q, want %q", got, CancelReasonCostLimitExceeded)
+	}
+}
+
+func TestCancellationReasonFromCause_NoCtxErrReturnsEmpty(t *testing.T) {
+	// Before cancellation, the reason helper must return empty — used
+	// by the runner to decide whether to emit invocation_complete vs
+	// invocation_cancelled. False positives here would misclassify
+	// every clean completion as a cancellation.
+	ctx := context.Background()
+	if got := CancellationReasonFromCause(ctx); got != "" {
+		t.Errorf("non-cancelled ctx should return empty reason, got %q", got)
+	}
+}
+
+func TestCancellationReasonFromCause_DeadlineExceededMapsToTimeout(t *testing.T) {
+	// Parent ctx with a deadline that fires before our cancel must
+	// classify as timeout — orchestrators set both their own deadlines
+	// AND can cancel us via tasks/cancel. Both are "they pulled the
+	// rug," but the reason field must say which.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	<-ctx.Done()
+	if got := CancellationReasonFromCause(ctx); got != CancelReasonTimeout {
+		t.Errorf("deadline-exceeded ctx should map to %q, got %q", CancelReasonTimeout, got)
+	}
+}
+
+func TestCancellationReasonFromCause_UntypedCancelDefaultsToExternalSignal(t *testing.T) {
+	// Plain context.WithCancel (no cause type) is treated as
+	// external_signal — covers internal cancellations (e.g. graceful
+	// shutdown) that don't classify their cause.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := CancellationReasonFromCause(ctx); got != CancelReasonExternalSignal {
+		t.Errorf("untyped cancel should default to %q, got %q", CancelReasonExternalSignal, got)
+	}
+}
+
+func TestCancellationReasonFromCause_AllDocumentedReasonsRoundTrip(t *testing.T) {
+	// IsValid lists the documented values — every documented value
+	// must round-trip through the registry. Catches the case of a
+	// new reason added to IsValid but missed in the cause wiring.
+	reasons := []CancellationReason{
+		CancelReasonWorkflowFailure,
+		CancelReasonCostLimitExceeded,
+		CancelReasonTimeout,
+		CancelReasonExternalSignal,
+	}
+	for _, want := range reasons {
+		t.Run(string(want), func(t *testing.T) {
+			reg := NewCancellationRegistry()
+			ctx, cancel := context.WithCancelCause(context.Background())
+			release := reg.Register("t", cancel)
+			defer release()
+
+			reg.Cancel("t", want)
+			<-ctx.Done()
+			if got := CancellationReasonFromCause(ctx); got != want {
+				t.Errorf("reason round-trip: got %q want %q", got, want)
+			}
+			if !want.IsValid() {
+				t.Errorf("documented reason %q failed IsValid", want)
+			}
+		})
+	}
+}
+
+func TestCancellationReason_IsValid_RejectsUnknown(t *testing.T) {
+	if CancellationReason("rumored").IsValid() {
+		t.Errorf("unknown reason should not be IsValid")
+	}
+	if CancellationReason("").IsValid() {
+		t.Errorf("empty reason should not be IsValid")
+	}
+}
+
+func TestCancellationRegistry_ReleaseAfterOverwrite_DoesNotPopNewer(t *testing.T) {
+	// Concurrent retries (or buggy callers) can register the same
+	// task ID twice. The older release must NOT pop the newer
+	// registration — otherwise the newer invocation becomes
+	// uncancellable. Pointer identity on the entry wrapper gives us
+	// this guarantee; this test locks in the behavior.
+	reg := NewCancellationRegistry()
+	_, cancel1 := context.WithCancelCause(context.Background())
+	release1 := reg.Register("dup", cancel1)
+
+	_, cancel2 := context.WithCancelCause(context.Background())
+	release2 := reg.Register("dup", cancel2) // overwrites entry1
+
+	release1() // stale release — must NOT remove entry2
+	if reg.Len() != 1 {
+		t.Errorf("stale release should not pop newer entry, got Len=%d", reg.Len())
+	}
+	if !reg.Cancel("dup", CancelReasonExternalSignal) {
+		t.Errorf("newer entry should still be cancellable after stale release")
+	}
+	release2()
+	if reg.Len() != 0 {
+		t.Errorf("after correct release: Len()=%d, want 0", reg.Len())
+	}
+}
+
+func TestCancellationRegistry_ConcurrentRegisterCancelSafe(t *testing.T) {
+	// 100 goroutines each register, cancel, and release. No data
+	// races, no panics, all tasks end up unregistered.
+	reg := NewCancellationRegistry()
+	const N = 100
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithCancelCause(context.Background())
+			taskID := "task-" + string(rune('A'+i%26)) + "-" + string(rune('0'+i%10))
+			release := reg.Register(taskID, cancel)
+			reg.Cancel(taskID, CancelReasonExternalSignal)
+			<-ctx.Done()
+			release()
+		}()
+	}
+	wg.Wait()
+	if reg.Len() != 0 {
+		t.Errorf("after concurrent register/cancel/release: Len()=%d, want 0", reg.Len())
+	}
+}
+
+func TestCancelledByOrchestrator_ErrorMessageCarriesReason(t *testing.T) {
+	// The sentinel's Error() text is informational; logs and debug
+	// dumps should surface the reason so an operator triaging a
+	// cancellation can read it without unwrapping the typed error.
+	err := &cancelledByOrchestrator{Reason: CancelReasonWorkflowFailure}
+	if got := err.Error(); got != "invocation cancelled: workflow_failure" {
+		t.Errorf("Error() = %q, want %q", got, "invocation cancelled: workflow_failure")
+	}
+}
+
+func TestCancelledByOrchestrator_ErrorsAsExtractsViaErrorsAs(t *testing.T) {
+	// CancellationReasonFromCause depends on errors.As working
+	// against the sentinel. Test it directly so a future Error()
+	// signature change doesn't silently break the unwrap.
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	cancel(&cancelledByOrchestrator{Reason: CancelReasonWorkflowFailure})
+
+	var c *cancelledByOrchestrator
+	if !errors.As(context.Cause(ctx), &c) {
+		t.Fatalf("errors.As should extract *cancelledByOrchestrator from cause")
+	}
+	if c.Reason != CancelReasonWorkflowFailure {
+		t.Errorf("extracted reason = %q, want %q", c.Reason, CancelReasonWorkflowFailure)
+	}
+}

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -261,14 +260,16 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 		resp, err := e.client.Chat(ctx, req)
 		llmDuration := time.Since(llmStart)
 		if err != nil {
-			// Cancellation is not a "something went wrong" — preserve
-			// the typed ctx error so executeTask routes it to the
-			// invocation_cancelled path instead of the failure path.
-			// Otherwise a tasks/cancel mid-LLM-call shows up to the
-			// orchestrator as state=failed, which is wrong. See issue
-			// #88 / FWS-4.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, err
+			// Cancellation is not a "something went wrong." When ctx was
+			// cancelled, the provider's error (whatever its concrete type
+			// — net/http wraps inconsistently across DNS / TLS / body
+			// paths, and errors.Is(err, context.Canceled) is unreliable
+			// against the chain it produces) is by definition caused by
+			// the cancellation. Propagating ctx.Err() makes executeTask
+			// route to invocation_cancelled instead of state=failed.
+			// See issue #88 / FWS-4.
+			if cerr := ctx.Err(); cerr != nil {
+				return nil, cerr
 			}
 			_ = e.hooks.Fire(ctx, OnError, &HookContext{
 				Error:           err,

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -219,6 +219,14 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 
 	// Agent loop
 	for i := 0; i < e.maxIter; i++ {
+		// Honor cancellation at iteration boundary. Returning ctx.Err()
+		// here propagates context.Canceled / DeadlineExceeded up to the
+		// runner, which maps it to TaskStateCanceled +
+		// invocation_cancelled audit. See issue #88 / FWS-4.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		// Run compaction before LLM call (best-effort).
 		if e.compactor != nil {
 			if _, err := e.compactor.MaybeCompact(task.ID, mem); err != nil {
@@ -442,6 +450,12 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 		iterResults := make([]toolIterResult, 0, len(resp.Message.ToolCalls))
 
 		for _, tc := range resp.Message.ToolCalls {
+			// Honor cancellation between tool calls within an iteration —
+			// orchestrators that cancel mid-iteration get fast exit
+			// without burning more LLM/tool spend. See issue #88 / FWS-4.
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			toolsUsed = append(toolsUsed, tc.Function.Name)
 
 			// Fire BeforeToolExec hook

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -260,6 +261,15 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 		resp, err := e.client.Chat(ctx, req)
 		llmDuration := time.Since(llmStart)
 		if err != nil {
+			// Cancellation is not a "something went wrong" — preserve
+			// the typed ctx error so executeTask routes it to the
+			// invocation_cancelled path instead of the failure path.
+			// Otherwise a tasks/cancel mid-LLM-call shows up to the
+			// orchestrator as state=failed, which is wrong. See issue
+			// #88 / FWS-4.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
 			_ = e.hooks.Fire(ctx, OnError, &HookContext{
 				Error:           err,
 				TaskID:          TaskIDFromContext(ctx),

--- a/forge-core/runtime/loop_cancellation_test.go
+++ b/forge-core/runtime/loop_cancellation_test.go
@@ -19,18 +19,25 @@ import (
 
 func TestLLMExecutor_AgentLoop_CancelledAtIterationBoundary(t *testing.T) {
 	// Set up a client that returns a tool call on the first call,
-	// then would loop again. Cancel ctx after the first response, so
-	// the second iteration's boundary check exits with ctx.Err().
+	// then cancels ctx synchronously from inside chatFunc so the loop
+	// reaches the next boundary with a guaranteed-cancelled ctx. The
+	// earlier version of this test fired cancel from a goroutine after
+	// closing a signal channel — that races with iter 2's ctx.Err()
+	// check on slower CI machines, leading to a flake where the second
+	// LLM call fires before the cancel propagates. Synchronous cancel
+	// is race-free.
 	chatCalls := 0
-	cancelAfterFirstCall := make(chan struct{})
+	var cancel context.CancelFunc
 
 	exec := NewLLMExecutor(LLMExecutorConfig{
 		Client: &mockLLMClient{
-			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
 				chatCalls++
 				if chatCalls == 1 {
-					// Signal the cancel goroutine to fire.
-					close(cancelAfterFirstCall)
+					// Cancel SYNCHRONOUSLY so by the time the loop
+					// observes the next ctx.Err() boundary check, ctx
+					// is guaranteed cancelled. No goroutine race.
+					cancel()
 					return &llm.ChatResponse{
 						ID: "r1",
 						Message: llm.ChatMessage{
@@ -42,13 +49,16 @@ func TestLLMExecutor_AgentLoop_CancelledAtIterationBoundary(t *testing.T) {
 						},
 					}, nil
 				}
-				// Second call would happen after cancel — must not be reached.
+				// Second call would happen after cancel — must not be
+				// reached. Return an error (not nil resp) so a logic
+				// regression in the loop manifests as an error rather
+				// than a nil-pointer panic.
 				t.Errorf("LLM should not be called after cancel signal")
-				return nil, nil
+				return nil, fmt.Errorf("unexpected second LLM call after cancellation")
 			},
 		},
 		Tools: &mockToolExecutor{
-			executeFunc: func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+			executeFunc: func(_ context.Context, _ string, _ json.RawMessage) (string, error) {
 				return "noop-result", nil
 			},
 			toolDefs: []llm.ToolDefinition{},
@@ -57,13 +67,9 @@ func TestLLMExecutor_AgentLoop_CancelledAtIterationBoundary(t *testing.T) {
 		Provider:  "test",
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	// Fire the cancel as soon as the first LLM call returns; the
-	// second iteration's boundary check picks it up.
-	go func() {
-		<-cancelAfterFirstCall
-		cancel()
-	}()
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel() // ensure cleanup on any test exit path
 
 	_, err := exec.Execute(ctx,
 		&a2a.Task{ID: "t1"},

--- a/forge-core/runtime/loop_cancellation_test.go
+++ b/forge-core/runtime/loop_cancellation_test.go
@@ -141,22 +141,27 @@ func TestLLMExecutor_AgentLoop_CancelledBetweenToolCalls(t *testing.T) {
 	}
 }
 
-func TestLLMExecutor_LLMCallReturnsCtxError_PreservesTypedError(t *testing.T) {
-	// Regression for FWS-4 v1.1: when the LLM provider client returns
-	// a wrapped context.Canceled (which is what really happens when
-	// http.Client aborts mid-request), the loop must preserve the
-	// typed ctx error so executeTask can route to invocation_cancelled
-	// rather than wrapping it into the generic "something went wrong"
-	// failure message. Without this, a mid-LLM-call cancel surfaces to
-	// the orchestrator as state=failed, which is wrong.
+func TestLLMExecutor_LLMCallErrorWithCancelledCtx_RoutesToCancellation(t *testing.T) {
+	// Regression for FWS-4 v1.1: when ctx was cancelled AND the LLM
+	// client returns some non-typed error (the realistic case —
+	// net/http wraps inconsistently across DNS / TLS / body paths and
+	// the resulting err is rarely structurally errors.Is(context.Canceled)
+	// despite being caused by cancellation), the loop must use ctx.Err()
+	// to detect cancellation. Without this, every mid-flight cancel
+	// surfaces to the orchestrator as state=failed instead of
+	// state=canceled. The fix replaces the brittle errors.Is check
+	// with a direct ctx.Err() check at the LLM-error site.
+	clientCh := make(chan struct{})
 	exec := NewLLMExecutor(LLMExecutorConfig{
 		Client: &mockLLMClient{
 			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
-				// Simulate a provider client that returns a wrapped
-				// context.Canceled (the real Anthropic / OpenAI clients
-				// return "post: context canceled" with the typed error
-				// preserved via errors.Is chain).
-				return nil, fmt.Errorf("openai request: %w", context.Canceled)
+				close(clientCh) // signal the cancel goroutine
+				<-ctx.Done()    // wait for cancellation
+				// Return an error that does NOT structurally wrap
+				// context.Canceled — matches what net/http actually
+				// produces (a non-Unwrap-friendly chain that just
+				// stringifies to "context canceled" somewhere inside).
+				return nil, fmt.Errorf("openai request: net/http: request canceled")
 			},
 		},
 		Tools:     &mockToolExecutor{toolDefs: []llm.ToolDefinition{}},
@@ -164,12 +169,18 @@ func TestLLMExecutor_LLMCallReturnsCtxError_PreservesTypedError(t *testing.T) {
 		Provider:  "test",
 	})
 
-	_, err := exec.Execute(context.Background(),
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-clientCh
+		cancel()
+	}()
+
+	_, err := exec.Execute(ctx,
 		&a2a.Task{ID: "t1"},
 		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.NewTextPart("hi")}},
 	)
 	if !errors.Is(err, context.Canceled) {
-		t.Errorf("loop must preserve context.Canceled chain when LLM call returns wrapped ctx error; got %v", err)
+		t.Errorf("loop should return context.Canceled when ctx is cancelled at the LLM error site; got %v", err)
 	}
 	if err != nil && err.Error() == "something went wrong while processing your request, please try again" {
 		t.Errorf("loop wrapped the ctx error into the generic failure message — executeTask cannot route to invocation_cancelled")

--- a/forge-core/runtime/loop_cancellation_test.go
+++ b/forge-core/runtime/loop_cancellation_test.go
@@ -1,0 +1,173 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// Regression tests for issue #88 / FWS-4 — the LLM executor agent loop
+// honors ctx cancellation at the iteration boundary and between tool
+// calls within an iteration. Without these checks, a tasks/cancel
+// signal would only take effect after the next LLM call returned (or
+// the next tool call completed), wasting orchestrator spend.
+
+func TestLLMExecutor_AgentLoop_CancelledAtIterationBoundary(t *testing.T) {
+	// Set up a client that returns a tool call on the first call,
+	// then would loop again. Cancel ctx after the first response, so
+	// the second iteration's boundary check exits with ctx.Err().
+	chatCalls := 0
+	cancelAfterFirstCall := make(chan struct{})
+
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: &mockLLMClient{
+			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+				chatCalls++
+				if chatCalls == 1 {
+					// Signal the cancel goroutine to fire.
+					close(cancelAfterFirstCall)
+					return &llm.ChatResponse{
+						ID: "r1",
+						Message: llm.ChatMessage{
+							Role: llm.RoleAssistant,
+							ToolCalls: []llm.ToolCall{
+								{ID: "tc1", Type: "function",
+									Function: llm.FunctionCall{Name: "noop", Arguments: "{}"}},
+							},
+						},
+					}, nil
+				}
+				// Second call would happen after cancel — must not be reached.
+				t.Errorf("LLM should not be called after cancel signal")
+				return nil, nil
+			},
+		},
+		Tools: &mockToolExecutor{
+			executeFunc: func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+				return "noop-result", nil
+			},
+			toolDefs: []llm.ToolDefinition{},
+		},
+		ModelName: "test",
+		Provider:  "test",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Fire the cancel as soon as the first LLM call returns; the
+	// second iteration's boundary check picks it up.
+	go func() {
+		<-cancelAfterFirstCall
+		cancel()
+	}()
+
+	_, err := exec.Execute(ctx,
+		&a2a.Task{ID: "t1"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.NewTextPart("hi")}},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Execute should return context.Canceled, got %v", err)
+	}
+	if chatCalls != 1 {
+		t.Errorf("expected exactly 1 LLM call before cancellation took effect, got %d", chatCalls)
+	}
+}
+
+func TestLLMExecutor_AgentLoop_CancelledBetweenToolCalls(t *testing.T) {
+	// The LLM returns TWO tool calls in one response. The first tool's
+	// implementation cancels its own ctx (simulating an orchestrator
+	// signal that arrives between tool calls). The second tool MUST
+	// NOT be invoked — the between-tool ctx.Err() check enforces that.
+	toolCalls := 0
+	chatCalls := 0
+	var cancelFn context.CancelFunc
+
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: &mockLLMClient{
+			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+				chatCalls++
+				return &llm.ChatResponse{
+					ID: "r1",
+					Message: llm.ChatMessage{
+						Role: llm.RoleAssistant,
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc1", Type: "function",
+								Function: llm.FunctionCall{Name: "tool_a", Arguments: "{}"}},
+							{ID: "tc2", Type: "function",
+								Function: llm.FunctionCall{Name: "tool_b", Arguments: "{}"}},
+						},
+					},
+				}, nil
+			},
+		},
+		Tools: &mockToolExecutor{
+			executeFunc: func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+				toolCalls++
+				if name == "tool_a" {
+					// Cancel mid-tool to simulate orchestrator pulling
+					// the rug between tool calls within one iteration.
+					cancelFn()
+				}
+				if name == "tool_b" {
+					t.Errorf("tool_b must not run after cancel signalled during tool_a")
+				}
+				return "ok", nil
+			},
+			toolDefs: []llm.ToolDefinition{},
+		},
+		ModelName: "test",
+		Provider:  "test",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelFn = cancel
+
+	_, err := exec.Execute(ctx,
+		&a2a.Task{ID: "t1"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.NewTextPart("hi")}},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Execute should return context.Canceled when cancelled between tools, got %v", err)
+	}
+	if toolCalls != 1 {
+		t.Errorf("expected exactly 1 tool call (tool_a) before cancellation took effect, got %d", toolCalls)
+	}
+	if chatCalls != 1 {
+		t.Errorf("expected exactly 1 LLM call (no follow-up after cancellation), got %d", chatCalls)
+	}
+}
+
+func TestLLMExecutor_AgentLoop_AlreadyCancelledCtxExitsImmediately(t *testing.T) {
+	// Pre-cancelled ctx must short-circuit before the first LLM call.
+	// Otherwise an orchestrator-triggered cancel that arrives during
+	// dispatch (between handler entry and Execute call) gets burned
+	// on one extra LLM call.
+	chatCalls := 0
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: &mockLLMClient{
+			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+				chatCalls++
+				return nil, nil
+			},
+		},
+		Tools:     &mockToolExecutor{toolDefs: []llm.ToolDefinition{}},
+		ModelName: "test",
+		Provider:  "test",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := exec.Execute(ctx,
+		&a2a.Task{ID: "t1"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.NewTextPart("hi")}},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Execute on pre-cancelled ctx should return context.Canceled, got %v", err)
+	}
+	if chatCalls != 0 {
+		t.Errorf("LLM must not be called on pre-cancelled ctx, got %d calls", chatCalls)
+	}
+}

--- a/forge-core/runtime/loop_cancellation_test.go
+++ b/forge-core/runtime/loop_cancellation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/initializ/forge/forge-core/a2a"
@@ -137,6 +138,41 @@ func TestLLMExecutor_AgentLoop_CancelledBetweenToolCalls(t *testing.T) {
 	}
 	if chatCalls != 1 {
 		t.Errorf("expected exactly 1 LLM call (no follow-up after cancellation), got %d", chatCalls)
+	}
+}
+
+func TestLLMExecutor_LLMCallReturnsCtxError_PreservesTypedError(t *testing.T) {
+	// Regression for FWS-4 v1.1: when the LLM provider client returns
+	// a wrapped context.Canceled (which is what really happens when
+	// http.Client aborts mid-request), the loop must preserve the
+	// typed ctx error so executeTask can route to invocation_cancelled
+	// rather than wrapping it into the generic "something went wrong"
+	// failure message. Without this, a mid-LLM-call cancel surfaces to
+	// the orchestrator as state=failed, which is wrong.
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: &mockLLMClient{
+			chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+				// Simulate a provider client that returns a wrapped
+				// context.Canceled (the real Anthropic / OpenAI clients
+				// return "post: context canceled" with the typed error
+				// preserved via errors.Is chain).
+				return nil, fmt.Errorf("openai request: %w", context.Canceled)
+			},
+		},
+		Tools:     &mockToolExecutor{toolDefs: []llm.ToolDefinition{}},
+		ModelName: "test",
+		Provider:  "test",
+	})
+
+	_, err := exec.Execute(context.Background(),
+		&a2a.Task{ID: "t1"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{a2a.NewTextPart("hi")}},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("loop must preserve context.Canceled chain when LLM call returns wrapped ctx error; got %v", err)
+	}
+	if err != nil && err.Error() == "something went wrong while processing your request, please try again" {
+		t.Errorf("loop wrapped the ctx error into the generic failure message — executeTask cannot route to invocation_cancelled")
 	}
 }
 


### PR DESCRIPTION
> **Stacked PR.** Base branch is `feat/issue-87-token-usage-duration` (PR #99 / FWS-3) because FWS-4's partial-usage carry-through depends on FWS-3's `LLMUsageAccumulator`. When #99 merges, change this PR's base to `main` (GitHub will rebase the diff automatically).

## Summary

- The A2A `tasks/cancel` JSON-RPC method now actually cancels in-flight invocations instead of merely flipping the stored task state. A per-Runner `CancellationRegistry` tracks every active invocation by task ID; the handler signals the registered `context.CancelCauseFunc` with a typed reason, which propagates through the executor's `ctx`.
- The agent loop honors cancellation at the iteration boundary and between tool calls within an iteration. Cancellation latency is bounded by the current LLM round-trip or tool exec — typically seconds, not minutes.
- A new `invocation_cancelled` audit event closes every cancelled invocation with the classified reason, `duration_ms` up to cancellation, and partial token totals consumed before the signal (from the FWS-3 accumulator). Emission routes through `EmitFromContext` so workflow correlation (FWS-2) auto-tags.
- A2A response carries state `canceled` plus a \`cancelled: <reason>\` message so the orchestrator can react without parsing audit.
- **Cancel-after-complete is idempotent** — a cancel for a task that already finished returns the stored state unchanged; flipping a terminal-state task to `canceled` would corrupt audit and orchestrator state.

## Cancellation reasons

| Reason | Set by | Meaning |
|---|---|---|
| `workflow_failure` | Orchestrator | Sibling step in a parallel stage failed under `fail_workflow`; abandon work |
| `cost_limit_exceeded` | Orchestrator | Workflow cumulative cost ceiling hit (typically derived from FWS-3 `X-Forge-Tokens-*` response headers) |
| `timeout` | Orchestrator / Forge | Wall-clock budget exhausted. Parent ctx \`context.DeadlineExceeded\` auto-maps to this reason |
| `external_signal` | Operator / fallback | Operator-initiated stop, debugging cancel, or any cancellation without a typed reason |

Unknown reason strings are accepted at the JSON-RPC boundary and forwarded to the audit event verbatim — the audit pipeline is the authority on classification.

## Wiring

| Layer | File |
|---|---|
| Registry, reason constants, cause sentinel, ctx helpers | \`forge-core/runtime/cancellation.go\` (new) |
| \`AuditInvocationCancelled\` constant + \`EmitInvocationCancelled\` helper | \`forge-core/runtime/audit.go\` |
| \`ctx.Err()\` checks at iteration boundary + between tool calls | \`forge-core/runtime/loop.go\` |
| \`CancelTaskParams.Reason\` (optional, omitempty) | \`forge-core/a2a/jsonrpc.go\` |
| Runner gains \`cancelRegistry\`; \`executeTask\` derives cancel-cause ctx + registers; post-Execute err branch classifies \`context.Canceled\` / \`DeadlineExceeded\` as cancellation; \`tasks/cancel\` handler upgraded from stub to real signal | \`forge-cli/runtime/runner.go\` |

## Tests (14 new, all \`-race -count=1\` clean)

- \`forge-core/runtime/cancellation_test.go\` — 9 tests: registry lifecycle, idempotent cancel, reason round-trip through \`context.Cause\`, deadline-exceeded → \`timeout\` mapping, all 4 documented reasons, untyped cancel default, \`IsValid\`, overwrite-safety (newer registration not popped by older release), 100-goroutine concurrent register/cancel/release stress test
- \`forge-core/runtime/audit_cancelled_test.go\` — 5 tests: reason + duration shape, partial usage passthrough, nil-fields still emits reason, \`EmitFromContext\` routing carries workflow correlation, unknown-reason passthrough
- \`forge-core/runtime/loop_cancellation_test.go\` — 3 tests: iteration-boundary cancel exits before next LLM call, between-tools cancel skips remaining tools, pre-cancelled ctx never hits the LLM

## Docs

- \`docs/security/audit-logging.md\` — new \`invocation_cancelled\` event-table row + new \"Cancellation\" subsection with example NDJSON, reason classification table, cancel-request JSON-RPC shape, idempotency note, partial-usage preservation note
- \`CHANGELOG.md\` — entry above FWS-3 explaining the upgrade from stub to real signal, the registry + cause-typed cancellation pattern, the bounded-latency interpretation of \"hard-cancel,\" and the partial-usage carry-through

## Out of scope (documented in CHANGELOG + audit-logging.md)

- **Force-terminating a goroutine** — Go's runtime doesn't support it; we honor cancellation at safe checkpoints (next LLM call or tool exec). The orchestrator's \`cancel + give-up-wait-after-N-seconds\` pattern is an A2A-client concern, not a Forge concern.

## Test plan

- [x] \`go test -race -count=1 ./forge-core/... ./forge-cli/runtime/... ./forge-cli/server/...\` — 28 packages pass
- [x] \`golangci-lint run\` across \`forge-core/...\` + \`forge-cli/...\` — 0 issues
- [x] \`gofmt -l\` clean
- [ ] CI green on push
- [ ] Once #99 merges → change base to \`main\`, rebase if needed, confirm CI re-runs green