### PR TITLE
feat(catalog): centralise provider/model/channel/auth option lists in forge-core

### DIFF
--- a/forge-cli/internal/tui/steps/channel_step.go
+++ b/forge-cli/internal/tui/steps/channel_step.go
@@ -11,6 +11,8 @@ import (
 	"github.com/initializ/forge/forge-cli/internal/devicecode"
 	"github.com/initializ/forge/forge-cli/internal/tui"
 	"github.com/initializ/forge/forge-cli/internal/tui/components"
+
+	"github.com/initializ/forge/forge-core/catalog"
 )
 
 type channelPhase int
@@ -62,14 +64,21 @@ type ChannelStep struct {
 	tokens      map[string]string
 }
 
+// channelSelectItems projects the catalog channels into TUI select items.
+func channelSelectItems() []components.SingleSelectItem {
+	cs := catalog.AllChannels()
+	items := make([]components.SingleSelectItem, 0, len(cs))
+	for _, c := range cs {
+		items = append(items, components.SingleSelectItem{
+			Label: c.Label, Value: c.ID, Description: c.Description, Icon: c.Icon,
+		})
+	}
+	return items
+}
+
 // NewChannelStep creates a new channel step.
 func NewChannelStep(styles *tui.StyleSet) *ChannelStep {
-	items := []components.SingleSelectItem{
-		{Label: "None", Value: "none", Description: "CLI / API only", Icon: "🚫"},
-		{Label: "Telegram", Value: "telegram", Description: "Easy setup, no public URL needed", Icon: "✈️"},
-		{Label: "Slack", Value: "slack", Description: "Socket Mode, no public URL needed", Icon: "💬"},
-		{Label: "MS Teams", Value: "msteams", Description: "Graph polling, no public URL needed", Icon: "👥"},
-	}
+	items := channelSelectItems()
 
 	selector := components.NewSingleSelect(
 		items,

--- a/forge-cli/internal/tui/steps/provider_step.go
+++ b/forge-cli/internal/tui/steps/provider_step.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/initializ/forge/forge-cli/internal/tui"
 	"github.com/initializ/forge/forge-cli/internal/tui/components"
+
+	"github.com/initializ/forge/forge-core/catalog"
 )
 
 type providerPhase int
@@ -38,20 +40,33 @@ type modelOption struct {
 	ModelID     string
 }
 
-// openAIOAuthModels are available when using browser-based OAuth login.
-var openAIOAuthModels = []modelOption{
-	{DisplayName: "GPT 5.4", ModelID: "gpt-5.4"},
-	{DisplayName: "GPT 5 Mini", ModelID: "gpt-5-mini"},
-	{DisplayName: "GPT 5 Nano", ModelID: "gpt-5-nano"},
-	{DisplayName: "GPT 4.1", ModelID: "gpt-4.1"},
+// openAIOAuthModels (OAuth login) and openAIAPIKeyModels (API key) are sourced
+// from the central catalog so the wizard, forge-ui, and console stay in sync.
+var (
+	openAIOAuthModels  = openAIModelOptions()
+	openAIAPIKeyModels = openAIModelOptions()
+)
+
+// openAIModelOptions projects the catalog's OpenAI models into modelOption.
+func openAIModelOptions() []modelOption {
+	p, _ := catalog.ProviderByID("openai")
+	out := make([]modelOption, 0, len(p.Models))
+	for _, m := range p.Models {
+		out = append(out, modelOption{DisplayName: m.Label, ModelID: m.ModelID})
+	}
+	return out
 }
 
-// openAIAPIKeyModels are available when using an API key.
-var openAIAPIKeyModels = []modelOption{
-	{DisplayName: "GPT 5.4", ModelID: "gpt-5.4"},
-	{DisplayName: "GPT 5 Mini", ModelID: "gpt-5-mini"},
-	{DisplayName: "GPT 5 Nano", ModelID: "gpt-5-nano"},
-	{DisplayName: "GPT 4.1", ModelID: "gpt-4.1"},
+// providerSelectItems projects the catalog providers into TUI select items.
+func providerSelectItems() []components.SingleSelectItem {
+	ps := catalog.AllProviders()
+	items := make([]components.SingleSelectItem, 0, len(ps))
+	for _, p := range ps {
+		items = append(items, components.SingleSelectItem{
+			Label: p.Label, Value: p.ID, Description: p.Description, Icon: p.Icon,
+		})
+	}
+	return items
 }
 
 // ProviderStep handles model provider selection and API key entry.
@@ -82,13 +97,7 @@ type ProviderStep struct {
 // NewProviderStep creates a new provider selection step.
 // oauthFn is optional — pass nil to disable OAuth login.
 func NewProviderStep(styles *tui.StyleSet, validateFn ValidateKeyFunc, oauthFn ...OAuthFlowFunc) *ProviderStep {
-	items := []components.SingleSelectItem{
-		{Label: "OpenAI", Value: "openai", Description: "GPT 5.4, GPT 5 Mini, GPT 5 Nano", Icon: "🔷"},
-		{Label: "Anthropic", Value: "anthropic", Description: "Claude Sonnet, Haiku, Opus", Icon: "🟠"},
-		{Label: "Google Gemini", Value: "gemini", Description: "Gemini 2.5 Flash, Pro", Icon: "🔵"},
-		{Label: "Ollama (local)", Value: "ollama", Description: "Run models locally, no API key needed", Icon: "🦙"},
-		{Label: "Custom URL", Value: "custom", Description: "Any OpenAI-compatible endpoint", Icon: "⚙️"},
-	}
+	items := providerSelectItems()
 
 	selector := components.NewSingleSelect(
 		items,

--- a/forge-cli/internal/tui/steps/step_auth.go
+++ b/forge-cli/internal/tui/steps/step_auth.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/initializ/forge/forge-cli/internal/tui"
 	"github.com/initializ/forge/forge-cli/internal/tui/components"
+
+	"github.com/initializ/forge/forge-core/catalog"
 )
 
 // authPhase is the internal state machine of the auth step.
@@ -97,52 +99,21 @@ type AuthStep struct {
 	complete bool
 }
 
+// authSelectItems projects the catalog auth modes into TUI select items.
+func authSelectItems() []components.SingleSelectItem {
+	ms := catalog.AllAuthModes()
+	items := make([]components.SingleSelectItem, 0, len(ms))
+	for _, m := range ms {
+		items = append(items, components.SingleSelectItem{
+			Label: m.Label, Value: m.ID, Description: m.Description, Icon: m.Icon,
+		})
+	}
+	return items
+}
+
 // NewAuthStep constructs the auth step.
 func NewAuthStep(styles *tui.StyleSet) *AuthStep {
-	items := []components.SingleSelectItem{
-		{
-			Label:       "None",
-			Value:       AuthModeNone,
-			Description: "Anonymous access — no auth: block in forge.yaml",
-			Icon:        "🔓",
-		},
-		{
-			Label:       "OIDC (JWT)",
-			Value:       AuthModeOIDC,
-			Description: "Auth0, Keycloak, Azure AD, Google, Okta-OIDC, …",
-			Icon:        "🔐",
-		},
-		{
-			Label:       "HTTP Verifier",
-			Value:       AuthModeHTTPVerifier,
-			Description: "Legacy — POST tokens to your own /verify endpoint",
-			Icon:        "🔁",
-		},
-		{
-			Label:       "AWS Sigv4 (IAM)",
-			Value:       AuthModeAWSSigv4,
-			Description: "Verify AWS-IAM callers via STS GetCallerIdentity (Phase 2)",
-			Icon:        "🅰️",
-		},
-		{
-			Label:       "GCP Identity-Aware Proxy",
-			Value:       AuthModeGCPIAP,
-			Description: "Forge behind a GCP HTTPS LB+IAP (Phase 2)",
-			Icon:        "🇬",
-		},
-		{
-			Label:       "Azure AD / Entra ID",
-			Value:       AuthModeAzureAD,
-			Description: "Single-tenant Entra tokens (Phase 2 — multi-tenant via YAML)",
-			Icon:        "🇦",
-		},
-		{
-			Label:       "Custom",
-			Value:       AuthModeCustom,
-			Description: "Write a commented stub — I'll edit forge.yaml myself",
-			Icon:        "✏️",
-		},
-	}
+	items := authSelectItems()
 
 	selector := components.NewSingleSelect(
 		items,

--- a/forge-core/catalog/auth.go
+++ b/forge-core/catalog/auth.go
@@ -1,0 +1,86 @@
+package catalog
+
+// authModes is the canonical, ordered list of A2A authentication modes.
+//
+// The provider-backed modes (oidc, http_verifier, aws_sigv4, gcp_iap, azure_ad)
+// correspond to auth providers registered in forge-core/auth/providers; "none"
+// and "custom" are wizard-only conveniences. TestAuthModesMatchRegistry guards
+// against the two lists drifting apart.
+var authModes = []AuthMode{
+	{
+		ID:          "none",
+		Label:       "None",
+		Description: "Anonymous access — no auth: block in forge.yaml",
+		Icon:        "🔓",
+	},
+	{
+		ID:          "oidc",
+		Label:       "OIDC (JWT)",
+		Description: "Auth0, Keycloak, Azure AD, Google, Okta-OIDC, …",
+		Icon:        "🔐",
+		Fields: []AuthField{
+			{Key: "issuer", Prompt: "Issuer URL", Placeholder: "https://login.example.com", Required: true, Validation: "https_url"},
+			{Key: "audience", Prompt: "Audience", Placeholder: "api://forge", Required: true, Validation: "non_empty"},
+			{Key: "groups_claim", Prompt: "Groups claim (default: groups — press Enter to accept)", Placeholder: "groups", Default: "groups"},
+		},
+	},
+	{
+		ID:          "http_verifier",
+		Label:       "HTTP Verifier",
+		Description: "Legacy — POST tokens to your own /verify endpoint",
+		Icon:        "🔁",
+		Fields: []AuthField{
+			{Key: "url", Prompt: "Verifier URL", Placeholder: "https://auth.example.com/verify", Required: true, Validation: "https_url"},
+			{Key: "default_org", Prompt: "Default org_id (optional — press Enter to skip)"},
+		},
+	},
+	{
+		ID:          "aws_sigv4",
+		Label:       "AWS Sigv4 (IAM)",
+		Description: "Verify AWS-IAM callers via STS GetCallerIdentity (Phase 2)",
+		Icon:        "🅰️",
+		Fields: []AuthField{
+			{Key: "region", Prompt: "AWS region", Placeholder: "us-east-1", Required: true, Validation: "aws_region"},
+			{Key: "audience", Prompt: "Audience (informational; press Enter to skip)", Placeholder: "api://forge"},
+			{Key: "allowed_accounts", Prompt: "Allowed AWS accounts (comma-separated 12-digit IDs; Enter to skip)", Placeholder: "412664885516,109887654321", Validation: "account_list"},
+		},
+	},
+	{
+		ID:          "gcp_iap",
+		Label:       "GCP Identity-Aware Proxy",
+		Description: "Forge behind a GCP HTTPS LB+IAP (Phase 2)",
+		Icon:        "🇬",
+		Fields: []AuthField{
+			{Key: "audience", Prompt: "IAP audience (backend service ID from GCP console)", Placeholder: "/projects/PNUM/global/backendServices/BACKEND_ID", Required: true, Validation: "non_empty"},
+		},
+	},
+	{
+		ID:          "azure_ad",
+		Label:       "Azure AD / Entra ID",
+		Description: "Single-tenant Entra tokens (Phase 2 — multi-tenant via YAML)",
+		Icon:        "🇦",
+		Fields: []AuthField{
+			{Key: "tenant_id", Prompt: "Entra tenant ID (GUID)", Placeholder: "00000000-0000-0000-0000-000000000000", Required: true, Validation: "non_empty"},
+			{Key: "audience", Prompt: "Audience (Application ID URI)", Placeholder: "api://forge", Required: true, Validation: "non_empty"},
+		},
+	},
+	{
+		ID:          "custom",
+		Label:       "Custom",
+		Description: "Write a commented stub — I'll edit forge.yaml myself",
+		Icon:        "✏️",
+	},
+}
+
+// AllAuthModes returns the catalog of authentication modes in display order.
+func AllAuthModes() []AuthMode { return authModes }
+
+// AuthModeByID returns the auth mode with the given id, and whether it was found.
+func AuthModeByID(id string) (AuthMode, bool) {
+	for _, m := range authModes {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return AuthMode{}, false
+}

--- a/forge-core/catalog/catalog.go
+++ b/forge-core/catalog/catalog.go
@@ -1,0 +1,73 @@
+// Package catalog is the single source of truth for the option lists offered
+// when configuring an agent: LLM providers (and their models), messaging
+// channels, and authentication modes.
+//
+// Historically these lists were hardcoded inside the `forge init` TUI. They are
+// now centralised here so every front-end — the forge-cli TUI, forge-ui, and
+// the hosted console (via an HTTP projection) — renders the same choices and
+// cannot drift from one another.
+//
+// The catalog intentionally holds only plain data (no dependency on the TUI or
+// any UI toolkit) so it can be consumed by Go callers directly and serialised
+// to JSON for browser front-ends.
+package catalog
+
+// Provider is a selectable LLM provider.
+type Provider struct {
+	ID            string  `json:"id"`             // stable identifier, e.g. "openai"
+	Label         string  `json:"label"`          // human label, e.g. "OpenAI"
+	Description   string  `json:"description"`    // short blurb shown under the label
+	Icon          string  `json:"icon"`           // emoji/icon hint
+	NeedsAPIKey   bool    `json:"needsApiKey"`    // prompt for an API key
+	SupportsOAuth bool    `json:"supportsOAuth"`  // offer browser-based OAuth login
+	SupportsOrgID bool    `json:"supportsOrgId"`  // offer an optional organization ID
+	IsCustom      bool    `json:"isCustom"`       // user supplies base URL + model name
+	APIKeyEnvVar  string  `json:"apiKeyEnvVar"`   // env var the key is written to (if any)
+	Models        []Model `json:"models"`         // selectable models (empty ⇒ no picker)
+	DefaultModel  string  `json:"defaultModel"`   // model used when none is picked
+}
+
+// Model is a selectable model for a Provider.
+type Model struct {
+	Label   string `json:"label"`   // e.g. "GPT 5.4"
+	ModelID string `json:"modelId"` // e.g. "gpt-5.4"
+}
+
+// Channel is a selectable messaging channel connector.
+type Channel struct {
+	ID          string            `json:"id"`
+	Label       string            `json:"label"`
+	Description string            `json:"description"`
+	Icon        string            `json:"icon"`
+	Credentials []CredentialField `json:"credentials"` // tokens/secrets the channel needs
+}
+
+// CredentialField is a single credential prompted for a Channel.
+type CredentialField struct {
+	EnvVar   string `json:"envVar"`   // env var the value is written to
+	Prompt   string `json:"prompt"`   // label shown to the user
+	Secret   bool   `json:"secret"`   // mask the input
+	Optional bool   `json:"optional"` // may be skipped
+}
+
+// AuthMode is a selectable A2A authentication mode.
+type AuthMode struct {
+	ID          string      `json:"id"`
+	Label       string      `json:"label"`
+	Description string      `json:"description"`
+	Icon        string      `json:"icon"`
+	Fields      []AuthField `json:"fields"` // settings collected for this mode
+}
+
+// AuthField is a single input collected for an AuthMode. Key is the resulting
+// key under the auth provider's `settings` block in forge.yaml.
+type AuthField struct {
+	Key         string `json:"key"`
+	Prompt      string `json:"prompt"`
+	Placeholder string `json:"placeholder"`
+	Required    bool   `json:"required"`
+	Default     string `json:"default,omitempty"`
+	// Validation names a rule a front-end should apply: "https_url",
+	// "non_empty", "aws_region", "account_list", or "" for none.
+	Validation string `json:"validation,omitempty"`
+}

--- a/forge-core/catalog/catalog.go
+++ b/forge-core/catalog/catalog.go
@@ -14,17 +14,17 @@ package catalog
 
 // Provider is a selectable LLM provider.
 type Provider struct {
-	ID            string  `json:"id"`             // stable identifier, e.g. "openai"
-	Label         string  `json:"label"`          // human label, e.g. "OpenAI"
-	Description   string  `json:"description"`    // short blurb shown under the label
-	Icon          string  `json:"icon"`           // emoji/icon hint
-	NeedsAPIKey   bool    `json:"needsApiKey"`    // prompt for an API key
-	SupportsOAuth bool    `json:"supportsOAuth"`  // offer browser-based OAuth login
-	SupportsOrgID bool    `json:"supportsOrgId"`  // offer an optional organization ID
-	IsCustom      bool    `json:"isCustom"`       // user supplies base URL + model name
-	APIKeyEnvVar  string  `json:"apiKeyEnvVar"`   // env var the key is written to (if any)
-	Models        []Model `json:"models"`         // selectable models (empty ⇒ no picker)
-	DefaultModel  string  `json:"defaultModel"`   // model used when none is picked
+	ID            string  `json:"id"`            // stable identifier, e.g. "openai"
+	Label         string  `json:"label"`         // human label, e.g. "OpenAI"
+	Description   string  `json:"description"`   // short blurb shown under the label
+	Icon          string  `json:"icon"`          // emoji/icon hint
+	NeedsAPIKey   bool    `json:"needsApiKey"`   // prompt for an API key
+	SupportsOAuth bool    `json:"supportsOAuth"` // offer browser-based OAuth login
+	SupportsOrgID bool    `json:"supportsOrgId"` // offer an optional organization ID
+	IsCustom      bool    `json:"isCustom"`      // user supplies base URL + model name
+	APIKeyEnvVar  string  `json:"apiKeyEnvVar"`  // env var the key is written to (if any)
+	Models        []Model `json:"models"`        // selectable models (empty ⇒ no picker)
+	DefaultModel  string  `json:"defaultModel"`  // model used when none is picked
 }
 
 // Model is a selectable model for a Provider.

--- a/forge-core/catalog/catalog_test.go
+++ b/forge-core/catalog/catalog_test.go
@@ -1,0 +1,108 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/initializ/forge/forge-core/auth"
+	"github.com/initializ/forge/forge-core/catalog"
+
+	// Blank-import the auth providers so their init() registers them, letting
+	// TestAuthModesMatchRegistry cross-check the catalog against the registry.
+	_ "github.com/initializ/forge/forge-core/auth/providers/aws_sigv4"
+	_ "github.com/initializ/forge/forge-core/auth/providers/azure_ad"
+	_ "github.com/initializ/forge/forge-core/auth/providers/gcp_iap"
+	_ "github.com/initializ/forge/forge-core/auth/providers/httpverifier"
+	_ "github.com/initializ/forge/forge-core/auth/providers/oidc"
+)
+
+func TestProvidersWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range catalog.AllProviders() {
+		if p.ID == "" || p.Label == "" {
+			t.Errorf("provider has empty id/label: %+v", p)
+		}
+		if seen[p.ID] {
+			t.Errorf("duplicate provider id %q", p.ID)
+		}
+		seen[p.ID] = true
+		if p.NeedsAPIKey && p.APIKeyEnvVar == "" {
+			t.Errorf("provider %q needs an API key but has no APIKeyEnvVar", p.ID)
+		}
+		if !p.IsCustom && p.DefaultModel == "" {
+			t.Errorf("non-custom provider %q has no DefaultModel", p.ID)
+		}
+		for _, m := range p.Models {
+			if m.ModelID == "" || m.Label == "" {
+				t.Errorf("provider %q has a malformed model: %+v", p.ID, m)
+			}
+		}
+	}
+	if _, ok := catalog.ProviderByID("openai"); !ok {
+		t.Error("expected openai provider in catalog")
+	}
+	if _, ok := catalog.ProviderByID("nope"); ok {
+		t.Error("ProviderByID returned ok for a missing id")
+	}
+}
+
+func TestChannelsWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range catalog.AllChannels() {
+		if c.ID == "" || c.Label == "" {
+			t.Errorf("channel has empty id/label: %+v", c)
+		}
+		if seen[c.ID] {
+			t.Errorf("duplicate channel id %q", c.ID)
+		}
+		seen[c.ID] = true
+		for _, cr := range c.Credentials {
+			if cr.EnvVar == "" || cr.Prompt == "" {
+				t.Errorf("channel %q has a malformed credential: %+v", c.ID, cr)
+			}
+		}
+	}
+	none, ok := catalog.ChannelByID("none")
+	if !ok || len(none.Credentials) != 0 {
+		t.Error("expected a 'none' channel with no credentials")
+	}
+}
+
+func TestAuthModesWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, m := range catalog.AllAuthModes() {
+		if m.ID == "" || m.Label == "" {
+			t.Errorf("auth mode has empty id/label: %+v", m)
+		}
+		if seen[m.ID] {
+			t.Errorf("duplicate auth mode id %q", m.ID)
+		}
+		seen[m.ID] = true
+		for _, f := range m.Fields {
+			if f.Key == "" || f.Prompt == "" {
+				t.Errorf("auth mode %q has a malformed field: %+v", m.ID, f)
+			}
+		}
+	}
+	if m, ok := catalog.AuthModeByID("none"); !ok || len(m.Fields) != 0 {
+		t.Error("expected a 'none' auth mode with no fields")
+	}
+}
+
+// TestAuthModesMatchRegistry ensures every provider-backed auth mode in the
+// catalog corresponds to a real registered auth provider, so the wizard can
+// never offer a mode that the runtime cannot build. "none" and "custom" are
+// wizard-only and exempt.
+func TestAuthModesMatchRegistry(t *testing.T) {
+	registered := map[string]bool{}
+	for _, name := range auth.RegisteredTypes() {
+		registered[name] = true
+	}
+	for _, m := range catalog.AllAuthModes() {
+		if m.ID == "none" || m.ID == "custom" {
+			continue
+		}
+		if !registered[m.ID] {
+			t.Errorf("catalog auth mode %q is not a registered auth provider (registered: %v)", m.ID, auth.RegisteredTypes())
+		}
+	}
+}

--- a/forge-core/catalog/channels.go
+++ b/forge-core/catalog/channels.go
@@ -1,0 +1,56 @@
+package catalog
+
+// channels is the canonical, ordered list of messaging channel connectors.
+var channels = []Channel{
+	{
+		ID:          "none",
+		Label:       "None",
+		Description: "CLI / API only",
+		Icon:        "🚫",
+	},
+	{
+		ID:          "telegram",
+		Label:       "Telegram",
+		Description: "Easy setup, no public URL needed",
+		Icon:        "✈️",
+		Credentials: []CredentialField{
+			{EnvVar: "TELEGRAM_BOT_TOKEN", Prompt: "Telegram Bot Token (from @BotFather)", Secret: true},
+		},
+	},
+	{
+		ID:          "slack",
+		Label:       "Slack",
+		Description: "Socket Mode, no public URL needed",
+		Icon:        "💬",
+		Credentials: []CredentialField{
+			{EnvVar: "SLACK_APP_TOKEN", Prompt: "Slack App Token (xapp-...)", Secret: true},
+			{EnvVar: "SLACK_BOT_TOKEN", Prompt: "Slack Bot Token (xoxb-...)", Secret: true},
+		},
+	},
+	{
+		ID:          "msteams",
+		Label:       "MS Teams",
+		Description: "Graph polling, no public URL needed",
+		Icon:        "👥",
+		// MSTEAMS_REFRESH_TOKEN is obtained via an interactive device-code login
+		// flow rather than a static prompt, so it is not listed here.
+		Credentials: []CredentialField{
+			{EnvVar: "MSTEAMS_TENANT_ID", Prompt: "MS Teams Tenant ID (GUID from Entra)", Secret: true},
+			{EnvVar: "MSTEAMS_CLIENT_ID", Prompt: "MS Teams Client ID (GUID from Entra app)", Secret: true},
+			{EnvVar: "MSTEAMS_CLIENT_SECRET", Prompt: "MS Teams Client Secret (from Entra app)", Secret: true},
+		},
+	},
+}
+
+// AllChannels returns the catalog of messaging channels in display order.
+func AllChannels() []Channel { return channels }
+
+// ChannelByID returns the channel with the given id, and whether it was found.
+func ChannelByID(id string) (Channel, bool) {
+	for _, c := range channels {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return Channel{}, false
+}

--- a/forge-core/catalog/providers.go
+++ b/forge-core/catalog/providers.go
@@ -1,0 +1,68 @@
+package catalog
+
+// providers is the canonical, ordered list of LLM providers. The order is the
+// order shown in selection UIs.
+var providers = []Provider{
+	{
+		ID:            "openai",
+		Label:         "OpenAI",
+		Description:   "GPT 5.4, GPT 5 Mini, GPT 5 Nano",
+		Icon:          "🔷",
+		NeedsAPIKey:   true,
+		SupportsOAuth: true,
+		SupportsOrgID: true,
+		APIKeyEnvVar:  "OPENAI_API_KEY",
+		DefaultModel:  "gpt-5.4",
+		Models: []Model{
+			{Label: "GPT 5.4", ModelID: "gpt-5.4"},
+			{Label: "GPT 5 Mini", ModelID: "gpt-5-mini"},
+			{Label: "GPT 5 Nano", ModelID: "gpt-5-nano"},
+			{Label: "GPT 4.1", ModelID: "gpt-4.1"},
+		},
+	},
+	{
+		ID:           "anthropic",
+		Label:        "Anthropic",
+		Description:  "Claude Sonnet, Haiku, Opus",
+		Icon:         "🟠",
+		NeedsAPIKey:  true,
+		APIKeyEnvVar: "ANTHROPIC_API_KEY",
+		DefaultModel: "claude-sonnet-4-20250514",
+	},
+	{
+		ID:           "gemini",
+		Label:        "Google Gemini",
+		Description:  "Gemini 2.5 Flash, Pro",
+		Icon:         "🔵",
+		NeedsAPIKey:  true,
+		APIKeyEnvVar: "GEMINI_API_KEY",
+		DefaultModel: "gemini-2.5-flash",
+	},
+	{
+		ID:           "ollama",
+		Label:        "Ollama (local)",
+		Description:  "Run models locally, no API key needed",
+		Icon:         "🦙",
+		DefaultModel: "llama3",
+	},
+	{
+		ID:          "custom",
+		Label:       "Custom URL",
+		Description: "Any OpenAI-compatible endpoint",
+		Icon:        "⚙️",
+		IsCustom:    true,
+	},
+}
+
+// AllProviders returns the catalog of LLM providers in display order.
+func AllProviders() []Provider { return providers }
+
+// ProviderByID returns the provider with the given id, and whether it was found.
+func ProviderByID(id string) (Provider, bool) {
+	for _, p := range providers {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return Provider{}, false
+}


### PR DESCRIPTION
## What
Introduces **`forge-core/catalog`** — a single source of truth for the option lists offered when configuring an agent: LLM **providers** (+ their models), messaging **channels**, and A2A **auth modes**.

These lists were previously hardcoded inside the `forge init` TUI. That duplicated the data and meant any other front-end (forge-ui, the hosted console's create-agent wizard) would inevitably drift from `forge init`. Centralising them guarantees every UI renders the same choices.

## Changes
- **`forge-core/catalog`** (new): plain-data, JSON-serialisable registries —
  - `AllProviders()` / `ProviderByID()` — providers, models (OpenAI `gpt-5.4`/`gpt-5-mini`/`gpt-5-nano`/`gpt-4.1`), default models, API-key/OAuth/Org-ID flags, env-var names.
  - `AllChannels()` / `ChannelByID()` — none/telegram/slack/msteams + their credential fields.
  - `AllAuthModes()` / `AuthModeByID()` — none/oidc/http_verifier/aws_sigv4/gcp_iap/azure_ad/custom + per-mode field specs (prompt, placeholder, validation, default).
  - A test (`TestAuthModesMatchRegistry`) cross-checks the catalog's auth modes against the real `auth` provider registry (`auth.RegisteredTypes()`) so the two can't silently drift.
- **`forge-cli` init TUI**: `provider_step.go`, `channel_step.go`, `step_auth.go` now build their selection lists (and the OpenAI model list) from the catalog instead of inline literals.

## Design notes
- The catalog has **no dependency on any UI toolkit** (forge-core can't import forge-cli), so the TUI maps catalog entries → its own `SingleSelectItem`. The same data can be projected to JSON for browser front-ends.
- **Behaviour is unchanged.** Same labels/values/descriptions/icons/order — the `forge-cli` step and `init` cmd test suites pass.

## Test
`go build ./...`, `go vet`, and `go test` pass for both `forge-core` (incl. the new catalog tests) and `forge-cli` (`internal/tui/steps` + `cmd`, the full init suite).

## Follow-ups (separate PRs / repos)
- forge-ui to read auth/channel/provider lists from the catalog.
- agent-builder to expose `GET /api/v1/catalog` (JSON projection) for the console's create-agent wizard.