### PR TITLE
feat(security): three-layer platform policy + channel scope (closes #90, FWS-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@
 
 ### Added
 
+- **Three-layer platform policy + channel scope (issue #90, FWS-6).**
+  Forge now reads platform policy from three layers at startup
+  (`/etc/forge/policy.yaml`, `~/.forge/policy.yaml`, and the path at
+  `FORGE_PLATFORM_POLICY` — system, user, and workspace respectively).
+  The schema is unchanged from FWS-5 and applies identically at every
+  layer; resolution unions deny lists and takes the smallest non-zero
+  max-bound across layers ("most restrictive wins"). For audit
+  attribution, the first layer (in load order: system → user →
+  workspace) to contain an offending value takes credit so operators
+  grepping `layer=system` see every sysadmin-enforced violation
+  without false positives from per-user overrides. Every audit event
+  the policy subsystem emits (`policy_loaded`,
+  `policy_violation_at_build_time`, `channel_denied_by_policy`) now
+  carries `fields.layer` (`system` / `user` / `workspace`) and
+  `fields.source` (the on-disk path). Channel deny is now first-class:
+  `denied_channels` in any layer skips the named adapter at startup
+  with a `channel_denied_by_policy` event; `forge run --with` filters
+  and `forge channel serve` refuses to start a denied target outright.
+  Channel skip is non-fatal — the agent runs with the remaining
+  channels. New `forge channel disable <name>` and
+  `forge channel enable <name>` CLI subcommands edit
+  `~/.forge/policy.yaml` by default (the user layer); pass `--system`
+  to edit `/etc/forge/policy.yaml` instead (warns when not root). Both
+  are idempotent and remove the policy file entirely when the
+  resulting document is empty. New `GET /api/user-policy` and
+  `PUT /api/user-policy` endpoints in `forge ui` surface all three
+  layers (user editable, system + workspace read-only); the agent
+  card renders denied channels as locked / dimmed chips and clicking
+  an editable chip flips the entry in the user layer.
+  **Migration from FWS-6's first cut:** the `disabled_channels:`
+  field that briefly shipped in `forge.yaml` was rejected on review —
+  channel disable is laptop-level or workspace-level, never agent
+  declaration. Move any `disabled_channels:` block from `forge.yaml`
+  into `~/.forge/policy.yaml`'s `denied_channels:` (developer scope),
+  `/etc/forge/policy.yaml` (laptop-wide), or the workspace ConfigMap
+  (deployed-agent). `forge channel disable <name>` does this
+  automatically. The `channel_disabled_by_config` audit event was
+  retired in the same pass; `channel_denied_by_policy` (with layer
+  attribution) carries every skip. See
+  `docs/security/platform-policy.md` and
+  `examples/platform-policy.yaml`.
 - **Platform policy enforcement at runtime (issue #89, FWS-5).** Forge
   agents now accept a deploy-time policy file defining workspace-level
   upper bounds on egress destinations, registered tools, allowed

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -25,8 +25,9 @@ All runtime security events are emitted as structured NDJSON to stderr with corr
 | `auth_verify` | Inbound request authenticated successfully (with `provider`, `user_id`, `org_id`, `token_kind`) |
 | `auth_fail` | Inbound request rejected (with `reason`, `token_kind`) |
 | `agent_card_published` | Agent Card finalized at startup or hot-reload (with `name`, `version`, `protocol_version`, `url`, `skill_count`, `capabilities`, `security_schemes`, `card_size_bytes`, `card_sha256`). See [Agent Card reference](../reference/a2a-agent-card.md). |
-| `policy_loaded` | Emitted once at agent startup when a non-zero platform policy is active. Carries deny-list size counts + max bounds + source path. See [Platform Policy](platform-policy.md). |
-| `policy_violation_at_build_time` | One per violation when `forge.yaml` conflicts with the platform policy at startup. Agent refuses to start. Carries `fields.violation_kind` / `offending_value` / `forge_yaml_field`. See [Platform Policy](platform-policy.md). |
+| `policy_loaded` | One per non-empty policy layer at startup (system / user / workspace). Carries `fields.layer`, `source` (file path), deny-list size counts, and max bounds. See [Platform Policy](platform-policy.md). |
+| `policy_violation_at_build_time` | One per violation when `forge.yaml` conflicts with any policy layer. Agent refuses to start. Carries `fields.violation_kind` / `offending_value` / `forge_yaml_field` plus `layer` + `source` identifying the enforcing file. See [Platform Policy](platform-policy.md). |
+| `channel_denied_by_policy` | One per channel adapter skipped at startup because a policy layer's `denied_channels` list names it. Non-fatal; the agent runs with the remaining channels. Carries `fields.channel`, `layer` (`system` / `user` / `workspace`), and `source` (file path). See [Platform Policy — Channels](platform-policy.md#channels). |
 
 ### Example
 

--- a/docs/security/platform-policy.md
+++ b/docs/security/platform-policy.md
@@ -1,32 +1,50 @@
 ---
 title: "Platform Policy"
-description: "Workspace-level runtime safety net bounding what a forge.yaml is allowed to declare."
+description: "Three-layer policy that bounds what a forge.yaml is allowed to declare — system, user, and workspace files compose by union and most-restrictive."
 order: 8
 ---
 
 # Platform Policy
 
-Forge agents accept a deploy-time policy that defines workspace-level upper bounds on egress destinations, registered tools, allowed models, and configuration sizes. The agent's `forge.yaml` is what it claims to do; the platform policy is the ceiling — the agent refuses to start when its declaration exceeds the bound.
+Forge agents read a layered set of policy files at startup that bound what their `forge.yaml` is allowed to declare — egress destinations, registered tools, allowed models, channel adapters, and configuration sizes. The agent's `forge.yaml` is what it claims to do; the policy stack is the ceiling. The agent refuses to start when its declaration exceeds the bound (egress / tool / model / size) and skips individual channels when its channel declaration overlaps the deny list.
 
-This is the runtime safety net for the case where a developer pushes a `forge.yaml` that adds a forbidden domain or tool, intentionally or by mistake. PR-time linters help catch this at config time; the platform policy enforces it at startup regardless.
+This is the runtime safety net for the case where a developer's `forge.yaml` adds a forbidden domain or tool — intentionally or by mistake. PR-time linters help catch this at config time; the platform policy enforces it at startup regardless.
+
+## The three layers
+
+Three independent policy files are read at startup. Each is optional; an agent with none of them present runs exactly as it did pre-FWS-5.
+
+| Layer | Path | Set by | Scope |
+|---|---|---|---|
+| **system** | `/etc/forge/policy.yaml` (override: `FORGE_SYSTEM_POLICY` env) | Sysadmin (corporate-laptop image, MDM profile) | Every agent run by anyone on the machine |
+| **user** | `~/.forge/policy.yaml` | The developer themselves, via `forge channel disable` / the Web UI chip toggle / direct edit | Every agent run by that user on that machine |
+| **workspace** | path at `FORGE_PLATFORM_POLICY` env | Workspace operator (Initializ Command, custom controller, GitOps tooling) | The single deployed agent (unchanged from FWS-5) |
+
+All three layers share the same [schema](#schema). The loader silently skips an empty or absent file; a malformed file at any layer is an error that aborts startup.
+
+### Resolution semantics
+
+When the same value appears on multiple layers' deny lists, the **union** is enforced. When a max-bound (size cap) is set at multiple layers, the **smallest non-zero value wins** ("most restrictive across layers"). Both rules apply consistently to every field — egress, tools, models, channels, max counts.
+
+For audit attribution, the **first layer to deny in load order takes credit** (system → user → workspace). This means a `denied_egress` violation that's on the system layer's list will be attributed to `layer=system` in audit events even if the user layer also denied it — operators grepping for `layer=system` see every sysadmin-enforced violation without false positives from per-user overrides.
 
 ## When is a policy applied
 
-The agent reads `FORGE_PLATFORM_POLICY` at startup and loads the policy file at that path. Three outcomes:
+Per-layer behavior at startup:
 
 | Condition | Result |
 |---|---|
-| `FORGE_PLATFORM_POLICY` unset | No policy applied. Backward-compatible with pre-FWS-5 behavior. |
-| `FORGE_PLATFORM_POLICY` set, file missing | No policy applied (matches `forge package`'s `optional: true` ConfigMap mount). |
-| `FORGE_PLATFORM_POLICY` set, file malformed | Agent refuses to start. Malformed policy is an operator mistake that must fail loudly. |
-| `FORGE_PLATFORM_POLICY` set, file valid + `forge.yaml` conflict | Agent refuses to start with a multi-line error listing every violation; emits one `policy_violation_at_build_time` audit event per violation. |
-| `FORGE_PLATFORM_POLICY` set, file valid + no conflict | Agent starts; emits one `policy_loaded` audit event with a summary of the effective policy. |
+| All three layer files absent / empty | No policy applied. Backward-compatible with pre-FWS-5 / pre-FWS-6 behavior. |
+| Layer file present but malformed | Agent refuses to start. Operator / sysadmin / developer mistake that must fail loudly. |
+| Any layer denies a value `forge.yaml` declared (egress / tool / model / size) | Agent refuses to start with a multi-line error listing every violation; emits one `policy_violation_at_build_time` audit event per violation, each carrying the deciding layer + path. |
+| Any layer denies a channel `forge.yaml` declared | Agent starts without that channel adapter; emits one `channel_denied_by_policy` event per skip, carrying the deciding layer + path. (Channel deny is a scope-down, not a hard error.) |
+| All layers pass | Agent starts; emits one `policy_loaded` audit event per non-empty layer summarizing its contents. |
 
-Policy is read **once at startup**. Live reload is deliberately out of scope — policy changes require a pod restart. This keeps the running agent's state predictable and traceable to a specific policy file.
+Policy is read **once at startup**. Live reload is deliberately out of scope — policy changes require a pod restart (workspace) or process restart (system / user). This keeps the running agent's state predictable and traceable to a specific policy file snapshot.
 
-## How `forge package` wires this up
+## How `forge package` wires the workspace layer
 
-Every Deployment manifest generated by `forge package` is policy-ready by default:
+The workspace layer is the deploy-time slot. Every Deployment manifest generated by `forge package` is policy-ready by default:
 
 ```yaml
 containers:
@@ -59,9 +77,11 @@ kubectl create configmap forge-platform-policy \
 
 The Initializ Platform (or any custom controller / GitOps tooling) creates this ConfigMap from its own source of truth at deploy time.
 
+The **system** and **user** layers do not flow through `forge package` — they're laptop-local. Sysadmins drop `/etc/forge/policy.yaml` onto a corporate image via MDM / Ansible / the same channels they use to provision any other system config. Developers edit `~/.forge/policy.yaml` via the [CLI](#disabling-a-channel-from-the-cli) or the Web UI chip toggle (no manual YAML editing required).
+
 ## Schema
 
-See `examples/platform-policy.yaml` for a fully-commented working example.
+The same schema applies to all three layers. See `examples/platform-policy.yaml` for a fully-commented working example.
 
 ```yaml
 denied_egress_domains:
@@ -74,75 +94,147 @@ forbidden_models:
   - provider: anthropic
     name: claude-opus-4   # both fields required, no wildcards
 
+denied_channels:
+  - telegram              # registry name, case-sensitive
+
 max_egress_allowlist_size: 50   # 0 (or omitted) = no cap
 max_tool_count: 100             # 0 (or omitted) = no cap
-
-denied_channels:         # reserved for FWS-6 (#90); parsed but
-  - telegram             # not enforced in v1
 ```
 
 Decoding is strict — unknown fields are rejected so operator typos (`deinied_egress_domains:`) fail loudly instead of silently no-opping.
 
 | Field | Semantics |
 |---|---|
-| `denied_egress_domains` | Set-difference with `forge.yaml`'s `egress.allowed_domains`. Match is case-insensitive exact-host. Wildcard patterns belong in `forge.yaml` only; the platform deny list is operator-supplied and intentionally simple. |
-| `denied_tools` | Union with `forge.yaml`'s denied tools (typically from the derived CLI config). User-selected builtins survive `forge.yaml` denies but NOT platform-policy denies — workspace policy outranks per-agent declaration. |
+| `denied_egress_domains` | Set-difference with `forge.yaml`'s `egress.allowed_domains`. Match is case-insensitive exact-host. Wildcard patterns belong in `forge.yaml` only; the platform deny list is operator-supplied and intentionally simple. The union across all layers reaches the EgressEnforcer. |
+| `denied_tools` | Union across all layers with `forge.yaml`'s denied tools (typically from the derived CLI config). User-selected builtins survive `forge.yaml` denies but NOT policy denies — policy outranks per-agent declaration. |
 | `forbidden_models` | Applied to the primary model AND every fallback. Both `provider` and `name` are required to prevent loose patterns like "any anthropic model" that would silently let a new model in. |
-| `max_egress_allowlist_size` | Cap on the declared count (not the policy-filtered count). Defense against allowlist bloat. |
-| `max_tool_count` | Cap on the **effective** tool count (after policy strip). Stripping a denied tool must NOT cause a spurious bound violation. |
-| `denied_channels` | Reserved for FWS-6 (#90). Parsed but not enforced in v1. |
+| `denied_channels` | Per-layer channel deny list. Each entry is a channel adapter name (`slack`, `telegram`, `msteams`). At runtime: `forge run --with` skips denied channels (one `channel_denied_by_policy` audit event per skip); `forge channel serve` refuses to start outright when its target is denied. Match is case-sensitive. |
+| `max_egress_allowlist_size` | Cap on the declared count (not the policy-filtered count). Defense against allowlist bloat. Smallest non-zero value across layers wins. |
+| `max_tool_count` | Cap on the **effective** tool count (after policy strip). Stripping a denied tool must NOT cause a spurious bound violation. Smallest non-zero value across layers wins. |
 
 ## Conflict semantics
 
-When `forge.yaml` declares something the platform policy forbids, the runner:
+When `forge.yaml` declares an egress / tool / model / size value any layer forbids, the runner:
 
-1. Emits one `policy_violation_at_build_time` audit event per violation. The event carries `violation_kind`, `offending_value`, and `forge_yaml_field` so cost / compliance dashboards can group by kind and operator alerts can name the exact field to fix.
-2. Returns a multi-line error from `NewRunner` listing every violation. The developer sees every problem in one pass — fix the `forge.yaml` once and re-run, instead of ping-ponging through one error at a time.
+1. Emits one `policy_violation_at_build_time` audit event per violation. The event carries `violation_kind`, `offending_value`, `forge_yaml_field`, **`layer`** (which file decided), and **`source`** (the path to that file) so cost / compliance dashboards can group by kind or by enforcing authority.
+2. Returns a multi-line error from `NewRunner` listing every violation. The developer sees every problem in one pass — fix the `forge.yaml` once and re-run, instead of ping-ponging through one error at a time. Each error line names the deciding layer + path so they know which file owns the rule (and who to ask for an exception — sysadmin, themselves, or the platform operator).
+
+Channel violations are **non-fatal**: the agent starts without the named adapter and emits `channel_denied_by_policy`. See [Channels](#channels) below.
 
 Violation kinds:
 
 | `violation_kind` | What it means |
 |---|---|
-| `denied_egress` | `forge.yaml` `egress.allowed_domains` lists a domain on the policy deny list |
-| `denied_tool` | `forge.yaml` `tools[]` or `builtin_tools[]` lists a tool on the policy deny list |
-| `forbidden_model` | `forge.yaml` `model` or `model.fallbacks[]` uses a `(provider, name)` pair on the policy deny list |
-| `egress_bound_exceeded` | `len(forge.yaml.egress.allowed_domains)` exceeds `max_egress_allowlist_size` |
-| `tool_bound_exceeded` | Effective tool count (after policy strip) exceeds `max_tool_count` |
+| `denied_egress` | `forge.yaml` `egress.allowed_domains` lists a domain on a layer's deny list |
+| `denied_tool` | `forge.yaml` `tools[]` or `builtin_tools[]` lists a tool on a layer's deny list |
+| `forbidden_model` | `forge.yaml` `model` or `model.fallbacks[]` uses a `(provider, name)` pair on a layer's deny list |
+| `egress_bound_exceeded` | `len(forge.yaml.egress.allowed_domains)` exceeds the most-restrictive `max_egress_allowlist_size` across layers |
+| `tool_bound_exceeded` | Effective tool count (after policy strip) exceeds the most-restrictive `max_tool_count` across layers |
 
 ## Audit events
 
-Two events fire from this subsystem; both go through `AuditLogger.Emit` (no request ctx exists at startup, so the workflow / task correlation fields are absent).
+Three events fire from this subsystem; all go through `AuditLogger.Emit` (no request ctx exists at startup, so the workflow / task correlation fields are absent).
 
-**`policy_loaded`** — emitted once when a non-zero policy is loaded successfully. Fields summarize the policy without dumping its contents (which may contain internal infrastructure hints operators don't want in every audit stream):
+**`policy_loaded`** — one event per non-empty layer at startup. Fields summarize the layer's policy without dumping its contents (which may contain internal infrastructure hints operators don't want in every audit stream):
 
 ```json
 {
-  "ts": "2026-06-05T18:30:00Z",
+  "ts": "2026-06-06T18:30:00Z",
   "event": "policy_loaded",
   "fields": {
-    "source": "/etc/forge/policy/platform-policy.yaml",
+    "layer": "system",
+    "source": "/etc/forge/policy.yaml",
     "denied_egress_count": 2,
     "denied_tools_count": 1,
     "forbidden_models_count": 1,
+    "denied_channels_count": 1,
     "max_egress_allowlist": 50,
     "max_tool_count": 100
   }
 }
 ```
 
-**`policy_violation_at_build_time`** — one event per violation when `forge.yaml` conflicts with policy. Emitted before the runner aborts, so the audit pipeline captures the violation even though the agent never serves traffic:
+**`policy_violation_at_build_time`** — one event per violation when `forge.yaml` conflicts with any layer's policy. Emitted before the runner aborts, so the audit pipeline captures the violation even though the agent never serves traffic:
 
 ```json
 {
-  "ts": "2026-06-05T18:30:00Z",
+  "ts": "2026-06-06T18:30:00Z",
   "event": "policy_violation_at_build_time",
   "fields": {
     "violation_kind": "denied_egress",
     "offending_value": "api.slack.com",
-    "forge_yaml_field": "egress.allowed_domains"
+    "forge_yaml_field": "egress.allowed_domains",
+    "layer": "system",
+    "source": "/etc/forge/policy.yaml"
   }
 }
 ```
+
+**`channel_denied_by_policy`** — one event per channel skip at startup. The agent continues running with the remaining channels.
+
+```json
+{
+  "ts": "2026-06-06T18:30:00Z",
+  "event": "channel_denied_by_policy",
+  "fields": {
+    "channel": "slack",
+    "layer": "user",
+    "source": "/home/dev/.forge/policy.yaml"
+  }
+}
+```
+
+## Channels
+
+`denied_channels` is the same schema field at every layer. There is no per-agent `disabled_channels` in `forge.yaml` — channel disable is always a property of the machine (sysadmin policy or developer preference), never of the agent declaration itself. The reasoning: a developer who wants Telegram off in dev is making a laptop-level statement, not modifying the agent's published capability set.
+
+When `forge.yaml` declares `channels: [slack, telegram]` and any layer's `denied_channels` contains `telegram`, the runner:
+
+- Starts `slack` normally.
+- Skips `telegram` and emits `channel_denied_by_policy` attributed to the first layer that denied it.
+- Continues. Channel deny is a scope-down, not a hard error.
+
+### Disabling a channel from the CLI
+
+```bash
+forge channel disable slack             # edits ~/.forge/policy.yaml (user layer)
+forge channel enable slack              # ditto
+
+forge channel disable slack --system    # edits /etc/forge/policy.yaml (system layer)
+forge channel enable slack --system     # ditto
+```
+
+Both subcommands are idempotent — disabling an already-denied channel reports "already denied" and returns 0. They edit the resolved policy file in place, adding or removing the entry from `denied_channels`. When the resulting policy is empty (every field zero), the file is removed entirely so a "no policy" state has no on-disk noise.
+
+The `--system` flag writes to the system path. The CLI prints a warning if the effective uid is not root, since `/etc/forge/policy.yaml` typically requires elevated permissions to write — the warning surfaces the failure mode before `os.WriteFile` returns `EACCES`.
+
+### Disabling a channel from the Web UI
+
+`forge ui` renders each declared channel on the agent card as a chip. Channels denied by any layer are shown locked / dimmed with a tooltip naming the deciding layer. Clicking an editable chip toggles the channel in the user layer (`~/.forge/policy.yaml`); the system and workspace layers are display-only.
+
+REST shape (`GET/PUT /api/user-policy`):
+
+```bash
+# Read all three layers — user is editable, system + workspace are read-only.
+GET /api/user-policy
+    → {
+        "path": "/home/dev/.forge/policy.yaml",
+        "user": { "denied_channels": ["telegram"], "denied_tools": [] },
+        "system": { "denied_channels": ["msteams"] },
+        "system_path": "/etc/forge/policy.yaml",
+        "workspace": { "denied_egress_domains": ["api.notion.com"] },
+        "workspace_path": "/run/forge/workspace.yaml"
+      }
+
+# Write the user layer only. Body is the full PlatformPolicy doc.
+PUT /api/user-policy
+    ← { "user": { "denied_channels": ["slack", "telegram"] } }
+    → 200 + the same shape as GET, refreshed.
+```
+
+When the submitted user policy is the zero value (every field empty), the on-disk file is removed so a "no policy" state has no on-disk noise. The frontend renders chips by checking `denied_channels` from any layer; clicking an editable chip flips the entry in the `user` block and PUTs it back.
+
+**Important**: enabling a channel only undoes a deny on the layer being edited. It does NOT override a deny on a higher-precedence layer — if a sysadmin has denied a channel in `/etc/forge/policy.yaml`, no `forge channel enable slack` (without `--system`, which would require root) can lift it. The chip stays locked.
 
 ## Validating a policy file standalone
 
@@ -150,17 +242,18 @@ Two events fire from this subsystem; both go through `AuditLogger.Emit` (no requ
 forge validate --platform-policy=path/to/policy.yaml
 ```
 
-Schema-only lint. Returns non-zero on parse errors, unknown fields, or invalid values. Use this as a CI gate before `kubectl apply` of the ConfigMap.
+Schema-only lint. Returns non-zero on parse errors, unknown fields, or invalid values. Use this as a CI gate before `kubectl apply` of the workspace ConfigMap, before pushing a system policy to a corporate-laptop image, or before committing a `~/.forge/policy.yaml` to dotfiles.
 
 ## What's deliberately NOT in v1
 
-- **Live policy reload.** Policy changes require a pod restart. Simpler and more predictable trust boundary.
+- **Live policy reload.** Policy changes require a process restart. Simpler and more predictable trust boundary.
 - **Computed allow / deny lists in the audit summary.** The `policy_loaded` event reports counts, not contents. Operators can read the source file via the `source` field if they need the full policy.
+- **Per-agent disable in `forge.yaml`.** Channel disable is always laptop-level, never declared in agent source. (Removed in FWS-6 after FWS-5's prototype shipped a `disabled_channels:` field — see CHANGELOG.)
 - **Platform policy applied to non-Forge agents.** Out of scope here. The orchestrator enforces platform policy at the orchestration boundary for non-Forge agents (e.g., refuses to invoke if their declared capabilities violate policy).
 
 ## Cross-references
 
-- **Issue #89 / FWS-5** — this feature
-- **Issue #90 / FWS-6** — channel-policy enforcement; will populate the reserved `denied_channels` slot
+- **Issue #89 / FWS-5** — single-layer (workspace) policy enforcement, original design
+- **Issue #90 / FWS-6** — three-layer redesign + channel-policy enforcement (this doc)
 - **Issue #31** — Forge's per-IP rate limiter, the original deployment-time bound
-- **FWS-3 / FWS-4 audit events** — `invocation_complete`, `invocation_cancelled`, `policy_loaded`, and `policy_violation_at_build_time` are all on the same audit stream
+- **FWS-3 / FWS-4 audit events** — `invocation_complete`, `invocation_cancelled`, `policy_loaded`, `policy_violation_at_build_time`, and `channel_denied_by_policy` are all on the same audit stream

--- a/examples/platform-policy.yaml
+++ b/examples/platform-policy.yaml
@@ -1,15 +1,36 @@
-# Forge platform policy — workspace-level runtime safety net.
+# Forge platform policy — three-layer runtime safety net.
 #
-# This file documents the schema operators write when injecting a
-# platform-level policy into a Forge deployment. The agent reads this
-# document at startup (via the FORGE_PLATFORM_POLICY env var, which
-# `forge package` pre-wires into the generated Deployment manifest)
-# and refuses to start when forge.yaml's declaration exceeds the bound
-# set here.
+# This file documents the schema that applies, identically, at every
+# one of the three layers Forge reads at startup:
 #
-# Workflow:
-#   1. Operator (or platform deployer like initializ Command, custom
-#      controller, GitOps tooling) writes a policy YAML based on this
+#   system    /etc/forge/policy.yaml          # sysadmin (corporate
+#                                             # laptop image, MDM)
+#                                             # FORGE_SYSTEM_POLICY env
+#                                             # overrides path for tests
+#                                             # / non-root installs.
+#
+#   user      ~/.forge/policy.yaml            # the developer themselves,
+#                                             # via `forge channel disable`
+#                                             # or the Web UI chip toggle.
+#                                             # Applies to every agent
+#                                             # this user runs on this
+#                                             # machine.
+#
+#   workspace path at FORGE_PLATFORM_POLICY   # operator (Initializ
+#                                             # Command, custom controller,
+#                                             # GitOps tooling). `forge
+#                                             # package` pre-wires this env
+#                                             # into generated Deployment
+#                                             # manifests. Applies to the
+#                                             # one deployed agent.
+#
+# Resolution: deny lists union across layers; max-bound caps use the
+# smallest non-zero value across layers ("most restrictive wins").
+# Audit attribution credits the first layer (in load order: system →
+# user → workspace) that contains the offending value.
+#
+# Workspace-layer rollout via Kubernetes:
+#   1. Operator (or platform deployer) writes a policy YAML based on this
 #      example.
 #   2. Operator validates it: `forge validate --platform-policy=<file>`.
 #   3. Operator creates the ConfigMap:
@@ -18,17 +39,23 @@
 #   4. Every agent deployment in that namespace reads the policy on
 #      next pod restart.
 #
-# Absence of a policy ConfigMap is the normal case — the Deployment's
-# volume mount has `optional: true`, so an agent without a policy
-# starts with no constraints (pre-FWS-5 behavior).
+# System-layer rollout (sysadmin): drop the file at /etc/forge/policy.yaml
+# via your usual machine-provisioning channels (MDM / Ansible / etc).
+#
+# User-layer rollout (developer): no manual editing required — `forge
+# channel disable <name>` and the Web UI chip toggle both update
+# ~/.forge/policy.yaml in place.
+#
+# Absence of all three layers is the normal case and behaves like
+# pre-FWS-5 (no constraints).
 #
 # See docs/security/platform-policy.md for the full reference.
 
-# Workspace-level egress deny list. Each entry is matched
-# case-insensitively against the entries in forge.yaml's
-# `egress.allowed_domains`. If a forge.yaml lists any domain here, the
-# agent refuses to start and emits a `policy_violation_at_build_time`
-# audit event naming the offending entry and the forge.yaml field.
+# Egress deny list. Each entry is matched case-insensitively against
+# the entries in forge.yaml's `egress.allowed_domains`. If a forge.yaml
+# lists any domain denied by ANY layer, the agent refuses to start and
+# emits a `policy_violation_at_build_time` audit event naming the
+# offending entry, the forge.yaml field, and the deciding layer + path.
 #
 # Example use case: a workspace forbids agents from calling Slack
 # directly even if a developer adds api.slack.com to their forge.yaml.
@@ -36,21 +63,21 @@ denied_egress_domains:
   - api.slack.com
   - hooks.slack.com
 
-# Workspace-level tool deny list. Each entry is a tool registry name
-# (case-sensitive — matches the name as it appears in the agent's
-# registered tools). Union semantics: forge.yaml's own deny list plus
-# this list are stripped from the agent's registry at startup.
-# Platform denies take precedence over user-selected builtins.
+# Tool deny list. Each entry is a tool registry name (case-sensitive —
+# matches the name as it appears in the agent's registered tools).
+# Union semantics: every layer's deny list plus forge.yaml's own deny
+# list are stripped from the agent's registry at startup.
 #
-# Example use case: a workspace bans `cli_execute` across all agents
-# because the security team hasn't approved arbitrary shell exec yet.
+# Example use case: a sysadmin bans `cli_execute` across all agents on
+# a corporate laptop because the security team hasn't approved arbitrary
+# shell exec yet.
 denied_tools:
   - cli_execute
   - http_request
 
-# Workspace-level model deny list. Each entry is a (provider, name)
-# pair — both fields are required (no wildcards). Applies to BOTH
-# the primary model and every fallback in forge.yaml.
+# Model deny list. Each entry is a (provider, name) pair — both fields
+# are required (no wildcards). Applies to BOTH the primary model and
+# every fallback in forge.yaml.
 #
 # Example use cases:
 #   - cost-ceiling enforcement ("no Opus in this workspace")
@@ -62,22 +89,29 @@ forbidden_models:
   - provider: openai
     name: gpt-4-32k
 
+# Channel deny list. Each entry is a channel adapter name
+# (case-sensitive — e.g. "slack", "telegram", "msteams"). At runtime,
+# `forge run --with` skips any channel denied by any layer (one
+# `channel_denied_by_policy` audit event per skip) and `forge channel
+# serve` refuses to start outright when its target is denied. Channel
+# skip is non-fatal — unlike egress / tool / model violations, the
+# agent runs with the remaining channels rather than aborting.
+#
+# This is the same field at every layer. There is no per-agent
+# `disabled_channels` in forge.yaml — channel disable is laptop-level
+# (user policy) or fleet-level (system / workspace policy), never agent
+# declaration. Developers toggle their user layer via the CLI
+# (`forge channel disable <name>`) or the Web UI chip — no manual YAML
+# editing required.
+denied_channels:
+  - telegram
+
 # Defense against allowlist bloat. Hard caps on what forge.yaml may
-# declare. Zero (or omitted) means no cap.
+# declare. Zero (or omitted) means no cap. When multiple layers set a
+# non-zero cap, the smallest wins ("most restrictive across layers").
 #
 # Rationale: a developer adding 200 third-party domains to their
 # egress allow list is almost certainly doing something they shouldn't.
-# A workspace policy can prevent this without naming every domain
-# individually.
+# A policy can prevent this without naming every domain individually.
 max_egress_allowlist_size: 50
 max_tool_count: 100
-
-# Workspace-level channel deny list. Reserved for the FWS-6
-# (issue #90) channel-policy work. Operators may already write this
-# field today — the schema parses it — but v1 of the runtime does
-# NOT enforce channel denies. The slot exists so operators write one
-# policy document instead of two.
-#
-# Will be enforced when FWS-6 ships.
-denied_channels:
-  - telegram

--- a/forge-cli/cmd/channel.go
+++ b/forge-cli/cmd/channel.go
@@ -13,6 +13,8 @@ import (
 	"github.com/initializ/forge/forge-cli/templates"
 	"github.com/initializ/forge/forge-core/auth"
 	corechannels "github.com/initializ/forge/forge-core/channels"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-plugins/channels/msteams"
 	"github.com/initializ/forge/forge-plugins/channels/slack"
 	"github.com/initializ/forge/forge-plugins/channels/telegram"
@@ -42,9 +44,65 @@ var channelServeCmd = &cobra.Command{
 	RunE:      runChannelServe,
 }
 
+// channelDisableCmd adds a channel name to the user (or system)
+// policy file's denied_channels list. The denial applies to every
+// agent the user runs on this machine — not just the agent in the
+// current working directory. Mirrors the GUI chip toggle.
+// See issue #90 / FWS-6 (three-layer model).
+var channelDisableCmd = &cobra.Command{
+	Use:   "disable <name>",
+	Short: "Disable a channel via the user (or system) policy file",
+	Long: `Disable a channel adapter by adding it to a policy file's denied_channels list.
+
+By default edits ~/.forge/policy.yaml (user-layer policy: applies to every agent
+this user runs on this machine). Pass --system to edit /etc/forge/policy.yaml
+(system-layer policy: applies to every user on this machine — sysadmin scope,
+warns if not run as root).
+
+Idempotent — disabling an already-denied channel is a no-op. The disable
+does NOT modify any agent's forge.yaml; policy lives separately from agent
+declaration.`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runChannelDisable,
+	Aliases: []string{"off"},
+}
+
+// channelEnableCmd removes a channel name from the user (or system)
+// policy file's denied_channels list. Idempotent. Important: this
+// only undoes a disable in the SAME layer — a user-layer enable does
+// not lift a system-layer or workspace-layer deny.
+var channelEnableCmd = &cobra.Command{
+	Use:   "enable <name>",
+	Short: "Re-enable a previously disabled channel",
+	Long: `Remove a channel adapter from a policy file's denied_channels list.
+
+By default edits ~/.forge/policy.yaml. Pass --system to edit /etc/forge/policy.yaml
+(warns if not root).
+
+Idempotent — enabling a channel that isn't denied in the target layer is a
+no-op. Important: enabling at the user layer does NOT override a system-layer
+or workspace-layer deny. If a sysadmin has denied a channel in
+/etc/forge/policy.yaml, no per-user enable can lift it.`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runChannelEnable,
+	Aliases: []string{"on"},
+}
+
+// channelSystemFlag selects the system policy file (/etc/forge/policy.yaml)
+// for the disable/enable subcommands. Default false → user layer
+// (~/.forge/policy.yaml).
+var channelSystemFlag bool
+
+func init() {
+	channelDisableCmd.Flags().BoolVar(&channelSystemFlag, "system", false, "edit /etc/forge/policy.yaml (system policy) instead of ~/.forge/policy.yaml (user policy); requires write access (typically root)")
+	channelEnableCmd.Flags().BoolVar(&channelSystemFlag, "system", false, "edit /etc/forge/policy.yaml (system policy) instead of ~/.forge/policy.yaml (user policy); requires write access (typically root)")
+}
+
 func init() {
 	channelCmd.AddCommand(channelAddCmd)
 	channelCmd.AddCommand(channelServeCmd)
+	channelCmd.AddCommand(channelDisableCmd)
+	channelCmd.AddCommand(channelEnableCmd)
 }
 
 func runChannelAdd(cmd *cobra.Command, args []string) error {
@@ -104,6 +162,22 @@ func runChannelServe(cmd *cobra.Command, args []string) error {
 	adapter := args[0]
 	if adapter != "slack" && adapter != "telegram" && adapter != "msteams" {
 		return fmt.Errorf("unsupported adapter: %s (supported: slack, telegram, msteams)", adapter)
+	}
+
+	// Honor every layer's denied_channels list (issue #90 / FWS-6
+	// three-layer). Standalone serve typically runs one container per
+	// channel under docker-compose / k8s; each container loads the
+	// same policy layers (system from /etc/forge, user from $HOME,
+	// workspace from FORGE_PLATFORM_POLICY) and refuses to start if
+	// its target is denied at any layer.
+	layers, layerErr := security.LoadAllPolicyLayers()
+	if layerErr != nil {
+		return fmt.Errorf("loading platform policy layers: %w", layerErr)
+	}
+	if src := security.FirstLayerDenyingChannel(layers, adapter); src != nil {
+		audit := coreruntime.NewAuditLogger(os.Stderr)
+		audit.EmitChannelDeniedByPolicy(adapter, src.Source, src.Path)
+		return fmt.Errorf("channel %q denied by %s policy (%s) — refusing to start", adapter, src.Source, src.Path)
 	}
 
 	// Load channel config
@@ -397,4 +471,162 @@ func printSetupInstructions(adapter string) {
 	fmt.Println(strings.Repeat("─", 40))
 	fmt.Printf("Config: %s-config.yaml\n", adapter)
 	fmt.Printf("Test:   forge run --with %s\n", adapter)
+}
+
+// runChannelDisable handles `forge channel disable <name>`. Adds the
+// name to the target policy file's denied_channels list. Default
+// target is ~/.forge/policy.yaml (user layer); --system targets
+// /etc/forge/policy.yaml (sysadmin layer). Idempotent — disabling an
+// already-denied channel reports "already disabled" and returns 0.
+// See issue #90 / FWS-6.
+func runChannelDisable(_ *cobra.Command, args []string) error {
+	name := args[0]
+	path, layerLabel, err := resolveChannelPolicyTarget()
+	if err != nil {
+		return err
+	}
+	added, err := mutateDeniedChannelsInPolicy(path, name, true)
+	if err != nil {
+		return err
+	}
+	if !added {
+		fmt.Printf("Channel %q is already denied in %s policy (%s).\n", name, layerLabel, path)
+		return nil
+	}
+	fmt.Printf("Disabled channel %q via %s policy (%s). The adapter is skipped on next 'forge run'.\n", name, layerLabel, path)
+	return nil
+}
+
+// runChannelEnable handles `forge channel enable <name>`. Removes the
+// name from the target policy file's denied_channels list.
+// Idempotent. Important: a user-layer enable does NOT override a
+// system-layer or workspace-layer deny — the runtime unions all
+// loaded layers, so the channel stays denied if any other layer
+// names it.
+func runChannelEnable(_ *cobra.Command, args []string) error {
+	name := args[0]
+	path, layerLabel, err := resolveChannelPolicyTarget()
+	if err != nil {
+		return err
+	}
+	removed, err := mutateDeniedChannelsInPolicy(path, name, false)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		fmt.Printf("Channel %q is not in %s policy denied_channels (%s) — nothing to enable.\n", name, layerLabel, path)
+		fmt.Printf("If it's still denied at runtime, check the other policy layers (system / workspace).\n")
+		return nil
+	}
+	fmt.Printf("Enabled channel %q in %s policy (%s). Adapter starts on next 'forge run' (subject to other layers).\n", name, layerLabel, path)
+	return nil
+}
+
+// resolveChannelPolicyTarget returns the policy file path + label
+// based on the --system flag. For the system path it warns when
+// euid != 0 (the write will likely fail without root); doesn't refuse
+// outright because /etc/forge/policy.yaml may be writable by a
+// dedicated group on some sysadmin setups.
+func resolveChannelPolicyTarget() (path, label string, err error) {
+	if channelSystemFlag {
+		path = security.SystemPolicyPath()
+		label = "system"
+		if os.Geteuid() != 0 {
+			fmt.Fprintf(os.Stderr, "Note: editing system policy at %s without root — write may fail. Use sudo or omit --system to edit the user policy at ~/.forge/policy.yaml.\n", path)
+		}
+		return path, label, nil
+	}
+	path = security.UserPolicyPath()
+	if path == "" {
+		return "", "", fmt.Errorf("could not determine user home directory; cannot edit user policy. Use --system or set $HOME")
+	}
+	return path, "user", nil
+}
+
+// mutateDeniedChannelsInPolicy reads the policy file (treating
+// missing as empty), adds OR removes `name` from denied_channels, and
+// writes the file back. Returns true when a change was applied;
+// false when the file already reflected the requested state.
+//
+// Creates the parent directory if missing (~/.forge/ may not exist
+// on first use). Uses yaml round-trip via map[string]any so the
+// runtime's strict-decoder (KnownFields(true)) still loads the file
+// after the mutation.
+func mutateDeniedChannelsInPolicy(path, name string, add bool) (bool, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	var doc map[string]any
+	if data, err := os.ReadFile(path); err == nil {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return false, fmt.Errorf("parsing %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+
+	var list []string
+	if existing, ok := doc["denied_channels"]; ok {
+		if arr, ok := existing.([]any); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					list = append(list, s)
+				}
+			}
+		}
+	}
+
+	idx := -1
+	for i, c := range list {
+		if c == name {
+			idx = i
+			break
+		}
+	}
+	if add {
+		if idx >= 0 {
+			return false, nil
+		}
+		list = append(list, name)
+	} else {
+		if idx < 0 {
+			return false, nil
+		}
+		list = append(list[:idx], list[idx+1:]...)
+	}
+
+	if len(list) == 0 {
+		delete(doc, "denied_channels")
+	} else {
+		out := make([]any, len(list))
+		for i, s := range list {
+			out[i] = s
+		}
+		doc["denied_channels"] = out
+	}
+
+	// If the document is now empty (no other policy fields), remove
+	// the file entirely so a "clean" enable-everything state has no
+	// on-disk noise. Operators inspecting ~/.forge can tell at a
+	// glance whether any user policy is set.
+	if len(doc) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("removing empty policy %s: %w", path, err)
+		}
+		return true, nil
+	}
+
+	marshalled, err := yaml.Marshal(doc)
+	if err != nil {
+		return false, fmt.Errorf("marshalling policy: %w", err)
+	}
+	if err := os.WriteFile(path, marshalled, 0o644); err != nil {
+		return false, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return true, nil
 }

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -14,6 +14,8 @@ import (
 	"github.com/initializ/forge/forge-cli/runtime"
 	"github.com/initializ/forge/forge-core/a2a"
 	corechannels "github.com/initializ/forge/forge-core/channels"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/spf13/cobra"
 )
 
@@ -131,13 +133,30 @@ func runRun(cmd *cobra.Command, args []string) error {
 		// Collect initialized plugins so the scheduler can deliver results.
 		activePlugins := make(map[string]corechannels.ChannelPlugin)
 
-		names := strings.Split(runWithChannels, ",")
-		for _, name := range names {
-			name = strings.TrimSpace(name)
-			if name == "" {
-				continue
+		// Apply channel filtering (issue #90 / FWS-6 three-layer):
+		// each declared channel runs through the union of system / user
+		// / workspace policy denies. One channel_denied_by_policy
+		// audit event per skip (carrying the deciding layer). Effective
+		// list goes on to start adapters.
+		channelLayers, channelLayerErr := security.LoadAllPolicyLayers()
+		if channelLayerErr != nil {
+			return fmt.Errorf("loading policy layers for channel filter: %w", channelLayerErr)
+		}
+		requested := strings.Split(runWithChannels, ",")
+		var trimmed []string
+		for _, n := range requested {
+			if n = strings.TrimSpace(n); n != "" {
+				trimmed = append(trimmed, n)
 			}
+		}
+		effective, skipped := security.EffectiveChannels(trimmed, channelLayers)
+		channelAudit := coreruntime.NewAuditLogger(os.Stderr)
+		for _, s := range skipped {
+			channelAudit.EmitChannelDeniedByPolicy(s.Channel, s.Layer, s.LayerPath)
+			fmt.Fprintf(os.Stderr, "  Channel:    %s skipped (denied by %s policy)\n", s.Channel, s.Layer)
+		}
 
+		for _, name := range effective {
 			plugin := registry.Get(name)
 			if plugin == nil {
 				return fmt.Errorf("unknown channel adapter: %s", name)

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -258,45 +258,49 @@ func (r *Runner) Run(ctx context.Context) error {
 	// 4. Create audit logger (used by hooks and handlers)
 	auditLogger := coreruntime.NewAuditLogger(os.Stderr)
 
-	// 4a. Load + enforce platform policy (issue #89 / FWS-5). The
-	// platform-level workspace policy is the upper bound — forge.yaml
-	// is what the agent claims to do, the platform policy is what the
-	// workspace allows. If forge.yaml exceeds the bound, refuse to
-	// start with a clear error and emit policy_violation_at_build_time
-	// to audit so the violation lands in the operator's pipeline even
-	// though the agent never serves traffic.
+	// 4a. Load + enforce platform policy across three layers
+	// (issue #90 / FWS-6, building on FWS-5):
 	//
-	// Absence of FORGE_PLATFORM_POLICY (or missing file) → zero policy
-	// → no constraints → backward compat with pre-FWS-5 behavior.
-	platformPolicy, policyErr := security.LoadPlatformPolicy(os.Getenv("FORGE_PLATFORM_POLICY"))
+	//   - system    → /etc/forge/policy.yaml  (sysadmin-managed)
+	//   - user      → ~/.forge/policy.yaml    (developer-managed via
+	//                                          TUI/GUI)
+	//   - workspace → FORGE_PLATFORM_POLICY   (operator-managed at
+	//                                          deploy)
+	//
+	// Each layer is optional. The runtime unions the deny lists and
+	// takes the most-restrictive max bound across all loaded layers.
+	// A malformed file at any layer aborts startup (silently treating
+	// a broken policy as "no policy" defeats the safety net).
+	platformLayers, policyErr := security.LoadAllPolicyLayers()
 	if policyErr != nil {
-		// Malformed policy is an operator mistake that must abort —
-		// silently treating a broken policy as "no policy" defeats the
-		// safety net.
-		return fmt.Errorf("loading platform policy: %w", policyErr)
+		return fmt.Errorf("loading platform policy layers: %w", policyErr)
 	}
-	if !platformPolicy.IsZero() {
+	for _, layer := range platformLayers {
 		auditLogger.EmitPolicyLoaded(map[string]any{
-			"source":                 os.Getenv("FORGE_PLATFORM_POLICY"),
-			"denied_egress_count":    len(platformPolicy.DeniedEgressDomains),
-			"denied_tools_count":     len(platformPolicy.DeniedTools),
-			"forbidden_models_count": len(platformPolicy.ForbiddenModels),
-			"max_egress_allowlist":   platformPolicy.MaxEgressAllowlistSize,
-			"max_tool_count":         platformPolicy.MaxToolCount,
+			"layer":                  layer.Source,
+			"source":                 layer.Path,
+			"denied_egress_count":    len(layer.Policy.DeniedEgressDomains),
+			"denied_tools_count":     len(layer.Policy.DeniedTools),
+			"forbidden_models_count": len(layer.Policy.ForbiddenModels),
+			"denied_channels_count":  len(layer.Policy.DeniedChannels),
+			"max_egress_allowlist":   layer.Policy.MaxEgressAllowlistSize,
+			"max_tool_count":         layer.Policy.MaxToolCount,
 		})
-		if violations := security.EnforcePolicy(r.cfg.Config, platformPolicy); len(violations) > 0 {
-			// Emit one audit event per violation so cost / compliance
-			// dashboards can group by kind. Then abort with a combined
-			// developer-facing error listing every offence.
-			for _, v := range violations {
-				auditLogger.EmitPolicyViolationAtBuildTime(map[string]any{
-					"violation_kind":   string(v.Kind),
-					"offending_value":  v.OffendingValue,
-					"forge_yaml_field": v.ForgeYAMLField,
-				})
-			}
-			return fmt.Errorf("%s", security.FormatViolations(violations))
+	}
+	if violations := security.EnforcePolicy(r.cfg.Config, platformLayers); len(violations) > 0 {
+		// One audit event per violation so cost / compliance dashboards
+		// can group by kind AND by deciding layer; then abort with a
+		// combined developer-facing error listing every offence.
+		for _, v := range violations {
+			auditLogger.EmitPolicyViolationAtBuildTime(map[string]any{
+				"violation_kind":   string(v.Kind),
+				"offending_value":  v.OffendingValue,
+				"forge_yaml_field": v.ForgeYAMLField,
+				"layer":            v.Layer,
+				"source":           v.LayerPath,
+			})
 		}
+		return fmt.Errorf("%s", security.FormatViolations(violations))
 	}
 
 	// 4b. Resolve egress config and start proxy (if not in container)
@@ -317,7 +321,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// startup on a declared-but-denied entry; this filter is the
 	// belt-and-suspenders defence-in-depth pass — any new code path
 	// that injects egress entries can call it independently.
-	declaredAllowed := security.EffectiveEgressAllowlist(r.cfg.Config, platformPolicy)
+	declaredAllowed := security.EffectiveEgressAllowlist(r.cfg.Config, platformLayers)
 	var egressDomains []string
 	for _, d := range declaredAllowed {
 		egressDomains = append(egressDomains, expandEgressDomains(d, envVars)...)
@@ -528,15 +532,21 @@ func (r *Runner) Run(ctx context.Context) error {
 			if r.derivedCLIConfig != nil {
 				forgeDenied = r.derivedCLIConfig.DeniedTools
 			}
-			effectiveDenied := security.EffectiveDeniedTools(forgeDenied, platformPolicy)
+			effectiveDenied := security.EffectiveDeniedTools(forgeDenied, platformLayers)
 			if len(effectiveDenied) > 0 {
 				userSelected := make(map[string]bool, len(r.cfg.Config.BuiltinTools))
 				for _, name := range r.cfg.Config.BuiltinTools {
 					userSelected[name] = true
 				}
-				policyDenied := make(map[string]bool, len(platformPolicy.DeniedTools))
-				for _, name := range platformPolicy.DeniedTools {
-					policyDenied[name] = true
+				// Union every policy layer's tool denies. A user-selected
+				// builtin survives forge.yaml-only denies but NOT any
+				// policy-layer deny (system/user/workspace all outrank
+				// per-agent selection).
+				policyDenied := make(map[string]bool)
+				for _, l := range platformLayers {
+					for _, name := range l.Policy.DeniedTools {
+						policyDenied[name] = true
+					}
 				}
 
 				var removed []string

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -80,6 +80,24 @@ const (
 	// See issue #89 / FWS-5.
 	AuditPolicyViolationAtBuildTime = "policy_violation_at_build_time"
 
+	// AuditChannelDeniedByPolicy is emitted at agent startup when a
+	// channel adapter would have been started but a policy layer
+	// (system / user / workspace) names it on its denied_channels
+	// list. The channel is NOT started; the runner continues with
+	// the remaining channels rather than aborting — unlike the
+	// egress/tool/model violations, channel deny is treated as a
+	// scope-down, not as a forge.yaml conflict.
+	//
+	// Carries fields.channel (registry name), fields.layer
+	// ("system" / "user" / "workspace") identifying which file
+	// enforced, and fields.source (path to that file). When the
+	// channel is denied by multiple layers, the first-match wins
+	// for attribution (system > user > workspace precedence; the
+	// most restrictive layer takes credit).
+	//
+	// See issue #90 / FWS-6.
+	AuditChannelDeniedByPolicy = "channel_denied_by_policy"
+
 	// AuditInvocationCancelled is emitted when an in-flight A2A
 	// invocation is cancelled by tasks/cancel (or internal cancellation
 	// like a parent ctx deadline). Carries the classified reason in
@@ -393,6 +411,25 @@ func (a *AuditLogger) EmitPolicyViolationAtBuildTime(fields map[string]any) {
 	a.Emit(AuditEvent{
 		Event:  AuditPolicyViolationAtBuildTime,
 		Fields: fields,
+	})
+}
+
+// EmitChannelDeniedByPolicy records that a channel adapter was skipped
+// at startup because a policy layer's denied_channels list named it.
+// `layer` identifies which file enforced ("system" / "user" /
+// "workspace"); `source` is that file's path. Unlike egress/tool/model
+// violations, channel deny does NOT abort startup — the agent runs
+// without the denied channel. Operators see the skip in their audit
+// pipeline and group by layer to understand which policy file owns
+// the decision. See issue #90 / FWS-6.
+func (a *AuditLogger) EmitChannelDeniedByPolicy(channel, layer, source string) {
+	a.Emit(AuditEvent{
+		Event: AuditChannelDeniedByPolicy,
+		Fields: map[string]any{
+			"channel": channel,
+			"layer":   layer,
+			"source":  source,
+		},
 	})
 }
 

--- a/forge-core/runtime/audit_channels_test.go
+++ b/forge-core/runtime/audit_channels_test.go
@@ -1,0 +1,70 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// Regression tests for issue #90 / FWS-6 — channel deny audit events.
+// After the three-layer redesign the only emitter is
+// EmitChannelDeniedByPolicy; it carries channel + layer ("system" /
+// "user" / "workspace") + source (the path of the deciding file).
+// EmitChannelDisabledByConfig was removed when per-agent disable was
+// ripped out of forge.yaml.
+
+func TestEmitChannelDeniedByPolicy_Shape(t *testing.T) {
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+	audit.EmitChannelDeniedByPolicy("slack", "system", "/etc/forge/policy.yaml")
+
+	var evt AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt); err != nil {
+		t.Fatalf("decode: %v\n%s", err, buf.String())
+	}
+	if evt.Event != AuditChannelDeniedByPolicy {
+		t.Errorf("Event = %q, want %q", evt.Event, AuditChannelDeniedByPolicy)
+	}
+	if evt.Fields["channel"] != "slack" {
+		t.Errorf("channel field: %+v", evt.Fields)
+	}
+	if evt.Fields["layer"] != "system" {
+		t.Errorf("layer field: %+v", evt.Fields)
+	}
+	if evt.Fields["source"] != "/etc/forge/policy.yaml" {
+		t.Errorf("source field: %+v", evt.Fields)
+	}
+}
+
+// TestEmitChannelDeniedByPolicy_LayerAttribution locks in that each of
+// the three layer values reaches the audit consumer verbatim. Audit
+// pipelines group by layer to answer "which file is enforcing this?",
+// so the values must pass through without case-folding or normalization.
+func TestEmitChannelDeniedByPolicy_LayerAttribution(t *testing.T) {
+	cases := []struct {
+		layer string
+		path  string
+	}{
+		{"system", "/etc/forge/policy.yaml"},
+		{"user", "/home/dev/.forge/policy.yaml"},
+		{"workspace", "/run/forge/workspace-policy.yaml"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.layer, func(t *testing.T) {
+			var buf bytes.Buffer
+			audit := NewAuditLogger(&buf)
+			audit.EmitChannelDeniedByPolicy("telegram", tc.layer, tc.path)
+
+			var evt AuditEvent
+			if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &evt); err != nil {
+				t.Fatalf("decode: %v\n%s", err, buf.String())
+			}
+			if evt.Fields["layer"] != tc.layer {
+				t.Errorf("layer = %v, want %q", evt.Fields["layer"], tc.layer)
+			}
+			if evt.Fields["source"] != tc.path {
+				t.Errorf("source = %v, want %q", evt.Fields["source"], tc.path)
+			}
+		})
+	}
+}

--- a/forge-core/security/platform_policy.go
+++ b/forge-core/security/platform_policy.go
@@ -42,38 +42,38 @@ type PlatformPolicy struct {
 	// Domain matching is exact-host (no wildcards in this list).
 	// Wildcard semantics belong in forge.yaml; the platform deny list
 	// is operator-supplied and intentionally simple.
-	DeniedEgressDomains []string `yaml:"denied_egress_domains,omitempty"`
+	DeniedEgressDomains []string `yaml:"denied_egress_domains,omitempty" json:"denied_egress_domains,omitempty"`
 
 	// DeniedTools is the union with forge.yaml's denied tools. Tool
 	// names match the registry name (e.g. "cli_execute", "http_request",
 	// MCP-namespaced "linear__create_issue"). A tool denied here is
 	// stripped from the agent's registry at startup — same code path
 	// as forge.yaml's deny list.
-	DeniedTools []string `yaml:"denied_tools,omitempty"`
+	DeniedTools []string `yaml:"denied_tools,omitempty" json:"denied_tools,omitempty"`
 
 	// ForbiddenModels lists provider/name pairs the agent must NOT
 	// use. If forge.yaml's model OR any model in model.fallbacks
 	// matches an entry here, the agent refuses to start. Use cases:
 	// cost ceilings ("no Opus in this workspace"), data-residency
 	// requirements ("no third-party providers for tenant X").
-	ForbiddenModels []ModelMatcher `yaml:"forbidden_models,omitempty"`
+	ForbiddenModels []ModelMatcher `yaml:"forbidden_models,omitempty" json:"forbidden_models,omitempty"`
 
 	// MaxEgressAllowlistSize caps the number of entries forge.yaml's
 	// egress.allowed_domains may declare. Defense against allowlist
 	// bloat — a developer adding 200 third-party domains to their
 	// allowlist is almost certainly doing something they shouldn't.
 	// Zero means no cap (today's behavior).
-	MaxEgressAllowlistSize int `yaml:"max_egress_allowlist_size,omitempty"`
+	MaxEgressAllowlistSize int `yaml:"max_egress_allowlist_size,omitempty" json:"max_egress_allowlist_size,omitempty"`
 
 	// MaxToolCount caps the number of tools the agent may register
 	// (after intersection/union math). Same rationale as
 	// MaxEgressAllowlistSize. Zero means no cap.
-	MaxToolCount int `yaml:"max_tool_count,omitempty"`
+	MaxToolCount int `yaml:"max_tool_count,omitempty" json:"max_tool_count,omitempty"`
 
 	// DeniedChannels reserved for FWS-6 (#90) — channel-policy
 	// injection. Not consumed by the runtime in v1; the field is on
 	// the schema so operators write one policy document, not two.
-	DeniedChannels []string `yaml:"denied_channels,omitempty"`
+	DeniedChannels []string `yaml:"denied_channels,omitempty" json:"denied_channels,omitempty"`
 }
 
 // ModelMatcher identifies one forbidden model. Both fields are
@@ -82,8 +82,8 @@ type PlatformPolicy struct {
 // patterns ("anthropic/*") are a footgun (provider adds a new model,
 // nobody updates the policy, model leaks through).
 type ModelMatcher struct {
-	Provider string `yaml:"provider"`
-	Name     string `yaml:"name"`
+	Provider string `yaml:"provider" json:"provider"`
+	Name     string `yaml:"name" json:"name"`
 }
 
 // String returns "provider/name" for log + error message use.
@@ -213,6 +213,21 @@ func (p PlatformPolicy) ToolDenied(name string) bool {
 func (p PlatformPolicy) ModelForbidden(provider, name string) bool {
 	for _, m := range p.ForbiddenModels {
 		if m.Provider == provider && m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ChannelDenied reports whether the given channel name is on the
+// platform deny list. Match is case-sensitive — channel names are
+// registry identifiers (e.g. "slack", "telegram", "msteams"), same
+// convention as tool names. Used by the runtime at channel adapter
+// init to skip denied channels and emit a channel_denied_by_policy
+// audit event. See issue #90 / FWS-6.
+func (p PlatformPolicy) ChannelDenied(name string) bool {
+	for _, c := range p.DeniedChannels {
+		if c == name {
 			return true
 		}
 	}

--- a/forge-core/security/platform_policy_channels_test.go
+++ b/forge-core/security/platform_policy_channels_test.go
@@ -1,0 +1,116 @@
+package security
+
+import (
+	"testing"
+)
+
+// Regression tests for issue #90 / FWS-6 — three-layer channel
+// filtering. EffectiveChannels now takes []PolicyLayer; deny lives in
+// system / user / workspace policy files (not in forge.yaml). First-
+// match-wins gives attribution to the most-restrictive layer.
+
+func TestPlatformPolicy_ChannelDenied_BasicMatch(t *testing.T) {
+	p := PlatformPolicy{DeniedChannels: []string{"slack", "msteams"}}
+	if !p.ChannelDenied("slack") {
+		t.Errorf("slack should be denied")
+	}
+	if p.ChannelDenied("telegram") {
+		t.Errorf("telegram should NOT be denied")
+	}
+	if p.ChannelDenied("Slack") {
+		t.Errorf("channel match must be case-sensitive")
+	}
+}
+
+func TestEffectiveChannels_NoLayers_PassThrough(t *testing.T) {
+	// Backward-compat: no policy files at all → declared list passes
+	// through unchanged, zero skips. Matches pre-FWS-6 behavior.
+	declared := []string{"slack", "telegram"}
+	effective, skipped := EffectiveChannels(declared, nil)
+	if len(effective) != 2 || effective[0] != "slack" || effective[1] != "telegram" {
+		t.Errorf("no layers must pass declared through, got %+v", effective)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("no layers must produce no skips, got %+v", skipped)
+	}
+}
+
+func TestEffectiveChannels_UserLayerOnly(t *testing.T) {
+	// Most common case: the developer disabled a channel via the TUI.
+	// No system or workspace layer present.
+	layers := []PolicyLayer{
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"telegram"}}},
+	}
+	effective, skipped := EffectiveChannels([]string{"slack", "telegram"}, layers)
+	if len(effective) != 1 || effective[0] != "slack" {
+		t.Errorf("slack should remain, got %+v", effective)
+	}
+	if len(skipped) != 1 || skipped[0].Channel != "telegram" {
+		t.Fatalf("telegram should be skipped, got %+v", skipped)
+	}
+	if skipped[0].Layer != LayerUser {
+		t.Errorf("attribution should be user, got %q", skipped[0].Layer)
+	}
+	if skipped[0].LayerPath != "/home/dev/.forge/policy.yaml" {
+		t.Errorf("LayerPath = %q, want user policy path", skipped[0].LayerPath)
+	}
+}
+
+func TestEffectiveChannels_SystemBeatsUserBeatsWorkspace(t *testing.T) {
+	// When multiple layers deny the same channel, attribution goes to
+	// the FIRST loaded layer (system → user → workspace order). The
+	// system layer is most-restrictive and the most visible in the
+	// operator's audit pipeline.
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"telegram"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"telegram"}}},
+		{Source: LayerWorkspace, Path: "/etc/forge/workspace.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"telegram"}}},
+	}
+	_, skipped := EffectiveChannels([]string{"telegram"}, layers)
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skip, got %+v", skipped)
+	}
+	if skipped[0].Layer != LayerSystem {
+		t.Errorf("system layer should win attribution, got %q", skipped[0].Layer)
+	}
+}
+
+func TestEffectiveChannels_DifferentLayersDifferentDenies(t *testing.T) {
+	// System denies one channel, user denies another. Both get
+	// skipped, each attributed to its own layer.
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"slack"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedChannels: []string{"telegram"}}},
+	}
+	_, skipped := EffectiveChannels([]string{"slack", "telegram", "msteams"}, layers)
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skips, got %+v", skipped)
+	}
+	got := map[string]string{}
+	for _, s := range skipped {
+		got[s.Channel] = s.Layer
+	}
+	if got["slack"] != LayerSystem {
+		t.Errorf("slack attribution: got %q want %q", got["slack"], LayerSystem)
+	}
+	if got["telegram"] != LayerUser {
+		t.Errorf("telegram attribution: got %q want %q", got["telegram"], LayerUser)
+	}
+}
+
+func TestEffectiveChannels_DeclaredOrderPreserved(t *testing.T) {
+	layers := []PolicyLayer{
+		{Source: LayerUser, Path: "/x", Policy: PlatformPolicy{DeniedChannels: []string{"slack"}}},
+	}
+	declared := []string{"telegram", "slack", "msteams"}
+	effective, _ := EffectiveChannels(declared, layers)
+	if len(effective) != 2 || effective[0] != "telegram" || effective[1] != "msteams" {
+		t.Errorf("declared order not preserved, got %+v", effective)
+	}
+}

--- a/forge-core/security/platform_policy_enforce.go
+++ b/forge-core/security/platform_policy_enforce.go
@@ -8,10 +8,10 @@ import (
 )
 
 // PolicyViolation describes a single conflict between forge.yaml's
-// declaration and the platform policy. Multiple violations may be
-// reported from one enforcement pass — the runner emits all of them
-// to audit, then aborts with a single combined error so the developer
-// sees every problem in one go instead of fixing them one at a time.
+// declaration and a policy layer. Multiple violations may be reported
+// from one enforcement pass — the runner emits all of them to audit,
+// then aborts with a single combined error so the developer sees
+// every problem in one go instead of fixing them one at a time.
 type PolicyViolation struct {
 	// Kind classifies the violation. The runner audit emitter uses
 	// this as the violation_kind field; consumers (cost / compliance
@@ -28,6 +28,19 @@ type PolicyViolation struct {
 	// "model.name"). Lets the developer's error message point at the
 	// exact field to edit.
 	ForgeYAMLField string
+
+	// Layer is the policy source that enforced this rule
+	// ("system" / "user" / "workspace"). System-layer violations
+	// signal a sysadmin-set bound; user-layer signals the local
+	// developer's own policy; workspace signals the deploy-time
+	// operator policy. See issue #90 / FWS-6.
+	Layer string
+
+	// LayerPath is the on-disk location of the enforcing policy file.
+	// Surfaced in audit events so consumers can fetch the document
+	// directly and in the formatted error so developers know which
+	// file to look at.
+	LayerPath string
 }
 
 // PolicyViolationKind enumerates the conflict categories. New values
@@ -58,89 +71,97 @@ const (
 // "policy-forbidden-value" from "policy-over-budget" — they need
 // different operator responses.
 //
-// See issue #89 / FWS-5.
-func EnforcePolicy(cfg *types.ForgeConfig, policy PlatformPolicy) []PolicyViolation {
-	if policy.IsZero() {
+// See issue #89 / FWS-5, issue #90 / FWS-6.
+func EnforcePolicy(cfg *types.ForgeConfig, layers []PolicyLayer) []PolicyViolation {
+	if len(layers) == 0 {
 		return nil
 	}
 	var violations []PolicyViolation
 
-	// Egress: each domain in forge.yaml that's on the policy deny
-	// list is a violation. Reported individually so the developer's
-	// error message can name every offending entry.
+	// Egress: each declared domain that any layer denies is a
+	// violation; first layer to deny takes attribution credit.
 	for _, d := range cfg.Egress.AllowedDomains {
-		if policy.EgressDomainDenied(d) {
+		if src := FirstLayerDenyingEgress(layers, d); src != nil {
 			violations = append(violations, PolicyViolation{
 				Kind:           ViolationDeniedEgress,
 				OffendingValue: d,
 				ForgeYAMLField: "egress.allowed_domains",
+				Layer:          src.Source,
+				LayerPath:      src.Path,
 			})
 		}
 	}
 
-	// Tools: per-tool union (forge.yaml's denies are added to the
-	// policy denies; a tool ON the policy deny list that forge.yaml
-	// ALSO declares is just stripped, not a violation). Violation
-	// only fires when the developer is trying to DECLARE a denied
-	// tool — i.e. it's in cfg.Tools AND in policy.DeniedTools.
+	// Tools: declared tools (cfg.Tools[].Name) or builtin_tools[]
+	// matched against the union of layer deny lists.
 	for _, t := range cfg.Tools {
-		if policy.ToolDenied(t.Name) {
+		if src := FirstLayerDenyingTool(layers, t.Name); src != nil {
 			violations = append(violations, PolicyViolation{
 				Kind:           ViolationDeniedTool,
 				OffendingValue: t.Name,
 				ForgeYAMLField: "tools",
+				Layer:          src.Source,
+				LayerPath:      src.Path,
 			})
 		}
 	}
 	for _, t := range cfg.BuiltinTools {
-		if policy.ToolDenied(t) {
+		if src := FirstLayerDenyingTool(layers, t); src != nil {
 			violations = append(violations, PolicyViolation{
 				Kind:           ViolationDeniedTool,
 				OffendingValue: t,
 				ForgeYAMLField: "builtin_tools",
+				Layer:          src.Source,
+				LayerPath:      src.Path,
 			})
 		}
 	}
 
-	// Model: primary + every fallback.
-	if cfg.Model.Provider != "" && policy.ModelForbidden(cfg.Model.Provider, cfg.Model.Name) {
-		violations = append(violations, PolicyViolation{
-			Kind:           ViolationForbiddenModel,
-			OffendingValue: cfg.Model.Provider + "/" + cfg.Model.Name,
-			ForgeYAMLField: "model",
-		})
+	// Model: primary + every fallback. Each match attributed to the
+	// most-restrictive layer (first deny wins).
+	if cfg.Model.Provider != "" {
+		if src := FirstLayerForbiddingModel(layers, cfg.Model.Provider, cfg.Model.Name); src != nil {
+			violations = append(violations, PolicyViolation{
+				Kind:           ViolationForbiddenModel,
+				OffendingValue: cfg.Model.Provider + "/" + cfg.Model.Name,
+				ForgeYAMLField: "model",
+				Layer:          src.Source,
+				LayerPath:      src.Path,
+			})
+		}
 	}
 	for i, fb := range cfg.Model.Fallbacks {
-		if policy.ModelForbidden(fb.Provider, fb.Name) {
+		if src := FirstLayerForbiddingModel(layers, fb.Provider, fb.Name); src != nil {
 			violations = append(violations, PolicyViolation{
 				Kind:           ViolationForbiddenModel,
 				OffendingValue: fb.Provider + "/" + fb.Name,
 				ForgeYAMLField: fmt.Sprintf("model.fallbacks[%d]", i),
+				Layer:          src.Source,
+				LayerPath:      src.Path,
 			})
 		}
 	}
 
-	// Size bounds: the count must NOT exceed the cap (zero cap = no
-	// limit). Reported once with the count itself as the offending
-	// value so the developer's error reads "egress allow-list size
-	// 73 exceeds policy max 50."
-	if policy.MaxEgressAllowlistSize > 0 && len(cfg.Egress.AllowedDomains) > policy.MaxEgressAllowlistSize {
+	// Size bounds use the MOST RESTRICTIVE non-zero value across all
+	// layers ("most restrictive wins"); the layer whose bound was
+	// effective takes attribution.
+	if max, src := MostRestrictiveEgressMax(layers); max > 0 && len(cfg.Egress.AllowedDomains) > max {
 		violations = append(violations, PolicyViolation{
 			Kind:           ViolationEgressBoundExceeded,
-			OffendingValue: fmt.Sprintf("%d (max %d)", len(cfg.Egress.AllowedDomains), policy.MaxEgressAllowlistSize),
+			OffendingValue: fmt.Sprintf("%d (max %d)", len(cfg.Egress.AllowedDomains), max),
 			ForgeYAMLField: "egress.allowed_domains",
+			Layer:          src.Source,
+			LayerPath:      src.Path,
 		})
 	}
-	// Tool count is checked AFTER the policy strip: the bound applies
-	// to the effective tool count, not the declared one (otherwise
-	// stripping a denied tool would cause a spurious bound violation
-	// on a forge.yaml that's actually under the limit).
-	effective := EffectiveToolCount(cfg, policy)
-	if policy.MaxToolCount > 0 && effective > policy.MaxToolCount {
+	effective := EffectiveToolCount(cfg, layers)
+	if max, src := MostRestrictiveToolMax(layers); max > 0 && effective > max {
 		violations = append(violations, PolicyViolation{
 			Kind:           ViolationToolBoundExceeded,
-			OffendingValue: fmt.Sprintf("%d (max %d)", effective, policy.MaxToolCount),
+			OffendingValue: fmt.Sprintf("%d (max %d)", effective, max),
 			ForgeYAMLField: "tools+builtin_tools",
+			Layer:          src.Source,
+			LayerPath:      src.Path,
 		})
 	}
 
@@ -148,19 +169,17 @@ func EnforcePolicy(cfg *types.ForgeConfig, policy PlatformPolicy) []PolicyViolat
 }
 
 // EffectiveEgressAllowlist returns forge.yaml's allowed_domains with
-// any entries on the policy deny list removed. Used by the runner's
-// security wiring to construct the actual EgressEnforcer config —
-// the developer's forge.yaml declaration is filtered through the
-// policy before it reaches the enforcer.
+// any entry denied by ANY layer removed. The unioned deny list is
+// what reaches the EgressEnforcer.
 //
-// Returns the input unchanged when the policy is zero.
-func EffectiveEgressAllowlist(cfg *types.ForgeConfig, policy PlatformPolicy) []string {
-	if policy.IsZero() || len(policy.DeniedEgressDomains) == 0 {
+// Returns the input unchanged when no layers are loaded.
+func EffectiveEgressAllowlist(cfg *types.ForgeConfig, layers []PolicyLayer) []string {
+	if len(layers) == 0 {
 		return cfg.Egress.AllowedDomains
 	}
 	out := make([]string, 0, len(cfg.Egress.AllowedDomains))
 	for _, d := range cfg.Egress.AllowedDomains {
-		if !policy.EgressDomainDenied(d) {
+		if FirstLayerDenyingEgress(layers, d) == nil {
 			out = append(out, d)
 		}
 	}
@@ -168,50 +187,94 @@ func EffectiveEgressAllowlist(cfg *types.ForgeConfig, policy PlatformPolicy) []s
 }
 
 // EffectiveDeniedTools returns the union of forge.yaml's declared
-// deny list (from the derived CLI config — empty here, the runner
-// passes its own existing list) and the platform policy's denies.
+// deny list (from the derived CLI config) and every layer's tool deny.
 // Used by the runner to strip tools from the registry at startup.
-//
-// Caller passes the existing forge.yaml-derived deny list (typically
-// runner.derivedCLIConfig.DeniedTools); this function adds the
-// policy denies on top.
-func EffectiveDeniedTools(forgeDenied []string, policy PlatformPolicy) []string {
-	if policy.IsZero() || len(policy.DeniedTools) == 0 {
+// Dedupes; preserves forge.yaml ordering first, then appends each
+// layer's denies in load order.
+func EffectiveDeniedTools(forgeDenied []string, layers []PolicyLayer) []string {
+	if len(layers) == 0 {
 		return forgeDenied
 	}
-	seen := make(map[string]struct{}, len(forgeDenied)+len(policy.DeniedTools))
-	out := make([]string, 0, len(forgeDenied)+len(policy.DeniedTools))
-	for _, t := range forgeDenied {
-		if _, dup := seen[t]; !dup {
-			seen[t] = struct{}{}
-			out = append(out, t)
-		}
+	totalCap := len(forgeDenied)
+	for _, l := range layers {
+		totalCap += len(l.Policy.DeniedTools)
 	}
-	for _, t := range policy.DeniedTools {
-		if _, dup := seen[t]; !dup {
-			seen[t] = struct{}{}
-			out = append(out, t)
+	seen := make(map[string]struct{}, totalCap)
+	out := make([]string, 0, totalCap)
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for _, t := range forgeDenied {
+		add(t)
+	}
+	for _, l := range layers {
+		for _, t := range l.Policy.DeniedTools {
+			add(t)
 		}
 	}
 	return out
 }
 
-// EffectiveToolCount returns the count of tools forge.yaml would
-// register after the policy strip. Used by both the bound check in
-// EnforcePolicy and (eventually) by the runner's logging.
-func EffectiveToolCount(cfg *types.ForgeConfig, policy PlatformPolicy) int {
+// EffectiveToolCount returns how many tools the agent would register
+// after every layer's deny strip. Used by the bound check above and
+// the runner's startup log.
+func EffectiveToolCount(cfg *types.ForgeConfig, layers []PolicyLayer) int {
 	count := 0
 	for _, t := range cfg.Tools {
-		if !policy.ToolDenied(t.Name) {
+		if FirstLayerDenyingTool(layers, t.Name) == nil {
 			count++
 		}
 	}
 	for _, t := range cfg.BuiltinTools {
-		if !policy.ToolDenied(t) {
+		if FirstLayerDenyingTool(layers, t) == nil {
 			count++
 		}
 	}
 	return count
+}
+
+// ChannelSkip records a channel that was skipped at startup and which
+// layer's deny list named it. The runner emits one
+// channel_denied_by_policy audit event per skip with the layer name
+// attached. The security package stays free of the runtime
+// dependency (audit lives in forge-core/runtime); the caller walks
+// the slice and emits.
+//
+// See issue #90 / FWS-6.
+type ChannelSkip struct {
+	Channel   string
+	Layer     string // "system" / "user" / "workspace"
+	LayerPath string // on-disk path for fields.source
+}
+
+// EffectiveChannels returns the channel list that should actually be
+// started (after policy filtering) along with one ChannelSkip per
+// filtered entry. The caller iterates the effective list to start
+// adapters and the skip list to emit audit events.
+//
+// Attribution: when a channel is denied by multiple layers, the
+// system layer wins (first match in layer load order: system → user
+// → workspace). System-layer denies are the most visible in the
+// audit pipeline.
+//
+// See issue #90 / FWS-6.
+func EffectiveChannels(declared []string, layers []PolicyLayer) (effective []string, skipped []ChannelSkip) {
+	effective = make([]string, 0, len(declared))
+	for _, c := range declared {
+		if src := FirstLayerDenyingChannel(layers, c); src != nil {
+			skipped = append(skipped, ChannelSkip{Channel: c, Layer: src.Source, LayerPath: src.Path})
+			continue
+		}
+		effective = append(effective, c)
+	}
+	return effective, skipped
 }
 
 // FormatViolations returns a multi-line, developer-friendly error
@@ -227,11 +290,21 @@ func FormatViolations(violations []PolicyViolation) string {
 	var b strings.Builder
 	b.WriteString("platform policy violations:\n")
 	for _, v := range violations {
-		fmt.Fprintf(&b, "  - %s: %s at forge.yaml field %s\n",
-			v.Kind, v.OffendingValue, v.ForgeYAMLField)
+		// Include the deciding layer + path so the developer knows
+		// which policy file owns the rule (and who to ask for an
+		// exception — sysadmin for system, themselves for user,
+		// platform operator for workspace).
+		if v.Layer != "" {
+			fmt.Fprintf(&b, "  - %s: %s at forge.yaml field %s (enforced by %s policy: %s)\n",
+				v.Kind, v.OffendingValue, v.ForgeYAMLField, v.Layer, v.LayerPath)
+		} else {
+			fmt.Fprintf(&b, "  - %s: %s at forge.yaml field %s\n",
+				v.Kind, v.OffendingValue, v.ForgeYAMLField)
+		}
 	}
-	b.WriteString("\nThe deployed platform policy forbids this configuration. " +
-		"Either update forge.yaml to comply, or request a policy change from " +
-		"the platform operator. See docs/security/platform-policy.md.")
+	b.WriteString("\nThis configuration is forbidden by one or more policy layers " +
+		"(system / user / workspace). Either update forge.yaml to comply, edit " +
+		"the user policy at ~/.forge/policy.yaml, or contact the policy owner. " +
+		"See docs/security/platform-policy.md.")
 	return b.String()
 }

--- a/forge-core/security/platform_policy_enforce_test.go
+++ b/forge-core/security/platform_policy_enforce_test.go
@@ -7,20 +7,30 @@ import (
 	"github.com/initializ/forge/forge-core/types"
 )
 
-// Regression tests for issue #89 / FWS-5 — the policy enforcement
-// engine. The pure-function shape (config + policy → []violation) lets
-// us exhaustively cover every conflict category without spinning a
-// runner. The runner-level integration is tested separately.
+// Regression tests for the policy enforcement engine. Issue #89 / FWS-5
+// introduced the single-layer EnforcePolicy(cfg, PlatformPolicy);
+// issue #90 / FWS-6 broadened it to EnforcePolicy(cfg, []PolicyLayer)
+// so a system / user / workspace stack can compose. The pure-function
+// shape (config + layers → []violation) lets us exhaustively cover
+// every conflict category without spinning a runner.
 
-func TestEnforcePolicy_ZeroPolicy_NoViolations(t *testing.T) {
-	// The common pre-FWS-5 case: no platform policy → no constraints.
-	// Backward-compat guarantee.
+// wrap is a tiny helper that turns a single PlatformPolicy into a
+// one-element []PolicyLayer attributed to the system layer. The pre-
+// FWS-6 single-policy cases convert cleanly via this wrapper.
+func wrap(p PlatformPolicy) []PolicyLayer {
+	return []PolicyLayer{{Source: LayerSystem, Path: "/etc/forge/policy.yaml", Policy: p}}
+}
+
+func TestEnforcePolicy_NoLayers_NoViolations(t *testing.T) {
+	// Backward-compat: no policy files at all → no constraints. The
+	// runner used to call this with PlatformPolicy{}; the layered API
+	// expresses the same thing as a nil slice.
 	cfg := &types.ForgeConfig{
 		Egress: types.EgressRef{AllowedDomains: []string{"api.openai.com", "api.slack.com"}},
 		Tools:  []types.ToolRef{{Name: "cli_execute"}},
 	}
-	if v := EnforcePolicy(cfg, PlatformPolicy{}); len(v) != 0 {
-		t.Errorf("zero policy must report no violations, got %+v", v)
+	if v := EnforcePolicy(cfg, nil); len(v) != 0 {
+		t.Errorf("no layers must report no violations, got %+v", v)
 	}
 }
 
@@ -33,10 +43,10 @@ func TestEnforcePolicy_DeniedEgressDomain_OneViolationPerDomain(t *testing.T) {
 			"api.openai.com", "api.slack.com", "hooks.slack.com",
 		}},
 	}
-	policy := PlatformPolicy{
+	layers := wrap(PlatformPolicy{
 		DeniedEgressDomains: []string{"api.slack.com", "hooks.slack.com"},
-	}
-	violations := EnforcePolicy(cfg, policy)
+	})
+	violations := EnforcePolicy(cfg, layers)
 	if len(violations) != 2 {
 		t.Fatalf("expected 2 violations (one per offending domain), got %d: %+v", len(violations), violations)
 	}
@@ -46,6 +56,12 @@ func TestEnforcePolicy_DeniedEgressDomain_OneViolationPerDomain(t *testing.T) {
 		}
 		if v.ForgeYAMLField != "egress.allowed_domains" {
 			t.Errorf("wrong field path: %+v", v)
+		}
+		if v.Layer != LayerSystem {
+			t.Errorf("layer attribution: got %q, want %q", v.Layer, LayerSystem)
+		}
+		if v.LayerPath != "/etc/forge/policy.yaml" {
+			t.Errorf("layer path: got %q", v.LayerPath)
 		}
 	}
 }
@@ -58,10 +74,10 @@ func TestEnforcePolicy_DeniedTool_BothListsScanned(t *testing.T) {
 		Tools:        []types.ToolRef{{Name: "http_request"}, {Name: "allowed_tool"}},
 		BuiltinTools: []string{"cli_execute", "datetime_now"},
 	}
-	policy := PlatformPolicy{
+	layers := wrap(PlatformPolicy{
 		DeniedTools: []string{"http_request", "cli_execute"},
-	}
-	violations := EnforcePolicy(cfg, policy)
+	})
+	violations := EnforcePolicy(cfg, layers)
 	if len(violations) != 2 {
 		t.Fatalf("expected 2 violations, got %+v", violations)
 	}
@@ -88,12 +104,12 @@ func TestEnforcePolicy_ForbiddenModel_PrimaryAndFallbacks(t *testing.T) {
 			},
 		},
 	}
-	policy := PlatformPolicy{
+	layers := wrap(PlatformPolicy{
 		ForbiddenModels: []ModelMatcher{
 			{Provider: "anthropic", Name: "claude-opus-4"},
 		},
-	}
-	violations := EnforcePolicy(cfg, policy)
+	})
+	violations := EnforcePolicy(cfg, layers)
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %+v", violations)
 	}
@@ -116,8 +132,8 @@ func TestEnforcePolicy_EgressBoundExceeded(t *testing.T) {
 			AllowedDomains: []string{"a", "b", "c", "d", "e"},
 		},
 	}
-	policy := PlatformPolicy{MaxEgressAllowlistSize: 3}
-	violations := EnforcePolicy(cfg, policy)
+	layers := wrap(PlatformPolicy{MaxEgressAllowlistSize: 3})
+	violations := EnforcePolicy(cfg, layers)
 	if len(violations) != 1 || violations[0].Kind != ViolationEgressBoundExceeded {
 		t.Fatalf("expected egress_bound_exceeded violation, got %+v", violations)
 	}
@@ -134,14 +150,14 @@ func TestEnforcePolicy_ToolBoundExceeded_AppliesToEffectiveCount(t *testing.T) {
 	cfg := &types.ForgeConfig{
 		BuiltinTools: []string{"a", "b", "c", "denied_tool"},
 	}
-	policy := PlatformPolicy{
+	layers := wrap(PlatformPolicy{
 		DeniedTools:  []string{"denied_tool"},
 		MaxToolCount: 3,
-	}
+	})
 	// Declared count = 4 (would exceed), effective count = 3 (under
 	// limit). NO bound violation expected — but the declaration of
 	// "denied_tool" itself IS a tool-denied violation.
-	violations := EnforcePolicy(cfg, policy)
+	violations := EnforcePolicy(cfg, layers)
 	for _, v := range violations {
 		if v.Kind == ViolationToolBoundExceeded {
 			t.Errorf("effective count is under limit, should not report bound violation: %+v", v)
@@ -158,17 +174,107 @@ func TestEnforcePolicy_MultipleViolationsAllReported(t *testing.T) {
 		Tools:  []types.ToolRef{{Name: "http_request"}},
 		Model:  types.ModelRef{Provider: "anthropic", Name: "claude-opus-4"},
 	}
-	policy := PlatformPolicy{
+	layers := wrap(PlatformPolicy{
 		DeniedEgressDomains:    []string{"api.slack.com"},
 		DeniedTools:            []string{"http_request"},
 		ForbiddenModels:        []ModelMatcher{{Provider: "anthropic", Name: "claude-opus-4"}},
 		MaxEgressAllowlistSize: 2,
-	}
-	violations := EnforcePolicy(cfg, policy)
+	})
+	violations := EnforcePolicy(cfg, layers)
 	if len(violations) < 4 {
 		t.Errorf("expected at least 4 violations (egress, tool, model, bound), got %d: %+v", len(violations), violations)
 	}
 }
+
+// --- FWS-6 multi-layer behavior ---------------------------------------
+
+func TestEnforcePolicy_MultiLayer_SystemBeatsUserBeatsWorkspace(t *testing.T) {
+	// When the same offending value is on multiple layers' deny
+	// lists, attribution goes to the FIRST loaded layer (system →
+	// user → workspace). Locks the audit-attribution contract:
+	// system-layer denies are the most visible in the audit pipeline
+	// so consumers can grep "layer=system" to find sysadmin policy
+	// hits without false positives from user / workspace overrides.
+	cfg := &types.ForgeConfig{
+		Egress: types.EgressRef{AllowedDomains: []string{"api.slack.com"}},
+	}
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}},
+		{Source: LayerWorkspace, Path: "/run/forge/workspace.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}},
+	}
+	violations := EnforcePolicy(cfg, layers)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation (one per offending value across layers), got %+v", violations)
+	}
+	if violations[0].Layer != LayerSystem {
+		t.Errorf("system should win attribution, got %q", violations[0].Layer)
+	}
+	if violations[0].LayerPath != "/etc/forge/policy.yaml" {
+		t.Errorf("layer path: got %q", violations[0].LayerPath)
+	}
+}
+
+func TestEnforcePolicy_MultiLayer_DifferentLayersDifferentDenies(t *testing.T) {
+	// Two layers each denying a distinct value: each violation is
+	// attributed to the layer that actually denies that value, NOT
+	// to the load order.
+	cfg := &types.ForgeConfig{
+		Egress: types.EgressRef{AllowedDomains: []string{"api.slack.com", "api.notion.com"}},
+	}
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.notion.com"}}},
+	}
+	violations := EnforcePolicy(cfg, layers)
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %+v", violations)
+	}
+	got := map[string]string{}
+	for _, v := range violations {
+		got[v.OffendingValue] = v.Layer
+	}
+	if got["api.slack.com"] != LayerSystem {
+		t.Errorf("slack should be system-attributed, got %q", got["api.slack.com"])
+	}
+	if got["api.notion.com"] != LayerUser {
+		t.Errorf("notion should be user-attributed, got %q", got["api.notion.com"])
+	}
+}
+
+func TestEnforcePolicy_MultiLayer_MostRestrictiveBoundWins(t *testing.T) {
+	// Bound bounds resolve via min-non-zero across layers. The layer
+	// whose bound was effective takes attribution credit so operators
+	// know which file to edit if they need an exception.
+	cfg := &types.ForgeConfig{
+		Egress: types.EgressRef{AllowedDomains: []string{"a", "b", "c", "d"}},
+	}
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{MaxEgressAllowlistSize: 10}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{MaxEgressAllowlistSize: 3}}, // most restrictive
+		{Source: LayerWorkspace, Path: "/run/forge/workspace.yaml",
+			Policy: PlatformPolicy{MaxEgressAllowlistSize: 5}},
+	}
+	violations := EnforcePolicy(cfg, layers)
+	if len(violations) != 1 || violations[0].Kind != ViolationEgressBoundExceeded {
+		t.Fatalf("expected egress_bound_exceeded, got %+v", violations)
+	}
+	if violations[0].Layer != LayerUser {
+		t.Errorf("user (lowest non-zero max) should win attribution, got %q", violations[0].Layer)
+	}
+	if !strings.Contains(violations[0].OffendingValue, "max 3") {
+		t.Errorf("offending value should report the winning max, got %q", violations[0].OffendingValue)
+	}
+}
+
+// --- Effective views ---------------------------------------------------
 
 func TestEffectiveEgressAllowlist_FiltersDeniedEntries(t *testing.T) {
 	cfg := &types.ForgeConfig{
@@ -176,31 +282,56 @@ func TestEffectiveEgressAllowlist_FiltersDeniedEntries(t *testing.T) {
 			"api.openai.com", "api.slack.com", "api.notion.com",
 		}},
 	}
-	policy := PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}
-	got := EffectiveEgressAllowlist(cfg, policy)
+	layers := wrap(PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}})
+	got := EffectiveEgressAllowlist(cfg, layers)
 	if len(got) != 2 || got[0] != "api.openai.com" || got[1] != "api.notion.com" {
 		t.Errorf("filter did not strip denied entry, got %+v", got)
 	}
 }
 
-func TestEffectiveEgressAllowlist_ZeroPolicyPassesThrough(t *testing.T) {
+func TestEffectiveEgressAllowlist_NoLayersPassesThrough(t *testing.T) {
 	cfg := &types.ForgeConfig{
 		Egress: types.EgressRef{AllowedDomains: []string{"x", "y"}},
 	}
-	got := EffectiveEgressAllowlist(cfg, PlatformPolicy{})
+	got := EffectiveEgressAllowlist(cfg, nil)
 	if len(got) != 2 {
-		t.Errorf("zero policy must not modify allowlist, got %+v", got)
+		t.Errorf("no layers must not modify allowlist, got %+v", got)
+	}
+}
+
+func TestEffectiveEgressAllowlist_UnionAcrossLayers(t *testing.T) {
+	// System denies one domain, user denies another → both stripped.
+	// Locks the union semantics for deny lists across layers.
+	cfg := &types.ForgeConfig{
+		Egress: types.EgressRef{AllowedDomains: []string{
+			"api.openai.com", "api.slack.com", "api.notion.com",
+		}},
+	}
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.slack.com"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedEgressDomains: []string{"api.notion.com"}}},
+	}
+	got := EffectiveEgressAllowlist(cfg, layers)
+	if len(got) != 1 || got[0] != "api.openai.com" {
+		t.Errorf("union of layer denies should strip both, got %+v", got)
 	}
 }
 
 func TestEffectiveDeniedTools_UnionPreservesOrderAndDedupes(t *testing.T) {
 	// forge.yaml's deny list comes first (preserves the developer's
-	// ordering for debug-printable output), policy denies are
-	// appended, duplicates collapsed.
+	// ordering for debug-printable output), then each layer's denies
+	// in load order, duplicates collapsed.
 	forgeDenied := []string{"web_search", "http_request"}
-	policy := PlatformPolicy{DeniedTools: []string{"http_request", "cli_execute"}}
-	got := EffectiveDeniedTools(forgeDenied, policy)
-	want := []string{"web_search", "http_request", "cli_execute"}
+	layers := []PolicyLayer{
+		{Source: LayerSystem, Path: "/etc/forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedTools: []string{"http_request", "cli_execute"}}},
+		{Source: LayerUser, Path: "/home/dev/.forge/policy.yaml",
+			Policy: PlatformPolicy{DeniedTools: []string{"cli_execute", "datetime_now"}}},
+	}
+	got := EffectiveDeniedTools(forgeDenied, layers)
+	want := []string{"web_search", "http_request", "cli_execute", "datetime_now"}
 	if len(got) != len(want) {
 		t.Fatalf("union size = %d, want %d: got %+v", len(got), len(want), got)
 	}
@@ -211,11 +342,11 @@ func TestEffectiveDeniedTools_UnionPreservesOrderAndDedupes(t *testing.T) {
 	}
 }
 
-func TestEffectiveDeniedTools_ZeroPolicyReturnsForgeListUnchanged(t *testing.T) {
+func TestEffectiveDeniedTools_NoLayersReturnsForgeListUnchanged(t *testing.T) {
 	forgeDenied := []string{"web_search"}
-	got := EffectiveDeniedTools(forgeDenied, PlatformPolicy{})
+	got := EffectiveDeniedTools(forgeDenied, nil)
 	if len(got) != 1 || got[0] != "web_search" {
-		t.Errorf("zero policy must pass-through, got %+v", got)
+		t.Errorf("no layers must pass-through, got %+v", got)
 	}
 }
 
@@ -224,12 +355,14 @@ func TestEffectiveToolCount_AppliesPolicyDeny(t *testing.T) {
 		Tools:        []types.ToolRef{{Name: "a"}, {Name: "denied_tool"}},
 		BuiltinTools: []string{"b", "denied_tool"},
 	}
-	policy := PlatformPolicy{DeniedTools: []string{"denied_tool"}}
+	layers := wrap(PlatformPolicy{DeniedTools: []string{"denied_tool"}})
 	// denied_tool appears in both lists; both occurrences stripped.
-	if got := EffectiveToolCount(cfg, policy); got != 2 {
+	if got := EffectiveToolCount(cfg, layers); got != 2 {
 		t.Errorf("effective count = %d, want 2", got)
 	}
 }
+
+// --- Error formatting --------------------------------------------------
 
 func TestFormatViolations_EmptyReturnsEmptyString(t *testing.T) {
 	if got := FormatViolations(nil); got != "" {
@@ -240,16 +373,21 @@ func TestFormatViolations_EmptyReturnsEmptyString(t *testing.T) {
 func TestFormatViolations_DeveloperFriendlyMultiLine(t *testing.T) {
 	// Lock the error format — developers will be looking at this in
 	// their terminal when startup aborts. Each violation on its own
-	// indented line, with kind + offending value + forge.yaml field.
+	// indented line, with kind + offending value + forge.yaml field +
+	// the deciding layer's name and path.
 	violations := []PolicyViolation{
-		{Kind: ViolationDeniedEgress, OffendingValue: "api.slack.com", ForgeYAMLField: "egress.allowed_domains"},
-		{Kind: ViolationForbiddenModel, OffendingValue: "anthropic/claude-opus-4", ForgeYAMLField: "model"},
+		{Kind: ViolationDeniedEgress, OffendingValue: "api.slack.com", ForgeYAMLField: "egress.allowed_domains",
+			Layer: LayerSystem, LayerPath: "/etc/forge/policy.yaml"},
+		{Kind: ViolationForbiddenModel, OffendingValue: "anthropic/claude-opus-4", ForgeYAMLField: "model",
+			Layer: LayerUser, LayerPath: "/home/dev/.forge/policy.yaml"},
 	}
 	out := FormatViolations(violations)
 	for _, want := range []string{
 		"platform policy violations:",
 		"denied_egress: api.slack.com at forge.yaml field egress.allowed_domains",
+		"enforced by system policy: /etc/forge/policy.yaml",
 		"forbidden_model: anthropic/claude-opus-4 at forge.yaml field model",
+		"enforced by user policy: /home/dev/.forge/policy.yaml",
 		"docs/security/platform-policy.md",
 	} {
 		if !strings.Contains(out, want) {

--- a/forge-core/security/platform_policy_layers.go
+++ b/forge-core/security/platform_policy_layers.go
@@ -1,0 +1,212 @@
+package security
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PolicyLayer is one of the three sources the runtime reads
+// PlatformPolicy from. Each layer's policy is loaded independently;
+// at enforcement time the runner walks all loaded layers and unions
+// their denies (for *_egress_domains / _tools / _channels /
+// forbidden_models) or takes the most restrictive max value (for
+// bound caps).
+//
+// Layers, in order of broadening scope:
+//
+//   - LayerSystem: /etc/forge/policy.yaml (or FORGE_SYSTEM_POLICY).
+//     Set by a sysadmin pushing corporate-laptop policy. Most users
+//     can't write to this path; the runtime simply reads it (root
+//     not required to read a world-readable policy file).
+//
+//   - LayerUser: ~/.forge/policy.yaml. Set by the developer via
+//     `forge channel disable …` or the GUI's chip toggle. Applies to
+//     every agent this user runs on this machine.
+//
+//   - LayerWorkspace: file at FORGE_PLATFORM_POLICY env var.
+//     Set by the workspace operator (initializ Command, custom
+//     controller, GitOps tooling) at deploy time. Applies to the
+//     specific deployed agent. Unchanged from FWS-5.
+//
+// See issue #90 / FWS-6.
+type PolicyLayer struct {
+	// Source is the layer identifier ("system" / "user" / "workspace").
+	// Audit events use this verbatim as the fields.layer value.
+	Source string
+	// Path is the on-disk location of the policy file. Audit events
+	// use this as fields.source so a downstream consumer can fetch the
+	// document directly.
+	Path string
+	// Policy is the parsed policy. Zero policy means the layer's file
+	// was absent or empty — the loader includes only non-zero layers
+	// in the returned slice, so callers don't need to check IsZero.
+	Policy PlatformPolicy
+}
+
+const (
+	LayerSystem    = "system"
+	LayerUser      = "user"
+	LayerWorkspace = "workspace"
+
+	// DefaultSystemPolicyPath is /etc/forge/policy.yaml. Override via
+	// FORGE_SYSTEM_POLICY (test isolation; non-root install paths).
+	DefaultSystemPolicyPath = "/etc/forge/policy.yaml"
+)
+
+// SystemPolicyPath returns the on-disk system policy path with env
+// override taken into account. Exposed so the CLI's --system flag
+// writes to the same path the runtime reads from.
+func SystemPolicyPath() string {
+	if p := os.Getenv("FORGE_SYSTEM_POLICY"); p != "" {
+		return p
+	}
+	return DefaultSystemPolicyPath
+}
+
+// UserPolicyPath returns ~/.forge/policy.yaml. Empty when the user
+// has no home directory (rare; typically a chroot or test sandbox);
+// callers treat empty as "no user layer."
+func UserPolicyPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".forge", "policy.yaml")
+}
+
+// WorkspacePolicyPath returns the path from FORGE_PLATFORM_POLICY
+// (the FWS-5 env var, unchanged). Empty when not set — runtime treats
+// empty as "no workspace layer."
+func WorkspacePolicyPath() string {
+	return os.Getenv("FORGE_PLATFORM_POLICY")
+}
+
+// LoadAllPolicyLayers reads each of the three layers and returns the
+// non-zero ones in source order (system, then user, then workspace).
+// Each absent or empty layer is silently omitted; this is the
+// backward-compat path for pre-FWS-6 deployments that had only the
+// FORGE_PLATFORM_POLICY env (or none of the three).
+//
+// A malformed policy at ANY layer is an error — operator (or
+// sysadmin, or developer) mistake that must fail loudly. Silently
+// dropping a broken layer would let a typo bypass intended bounds.
+//
+// Layer-ordering rule for audit attribution: when an offending value
+// (e.g. a denied domain) is on multiple layers' deny lists, the FIRST
+// loaded layer that contains it takes credit. The load order is
+// system → user → workspace, so a system-layer deny "wins"
+// attribution over a user-layer or workspace-layer deny on the same
+// value. This makes the most-restrictive layer the most visible in
+// the audit pipeline.
+func LoadAllPolicyLayers() ([]PolicyLayer, error) {
+	var out []PolicyLayer
+	if p, err := loadLayerIfPresent(SystemPolicyPath()); err != nil {
+		return nil, fmt.Errorf("loading system policy: %w", err)
+	} else if !p.IsZero() {
+		out = append(out, PolicyLayer{Source: LayerSystem, Path: SystemPolicyPath(), Policy: p})
+	}
+	if up := UserPolicyPath(); up != "" {
+		if p, err := loadLayerIfPresent(up); err != nil {
+			return nil, fmt.Errorf("loading user policy: %w", err)
+		} else if !p.IsZero() {
+			out = append(out, PolicyLayer{Source: LayerUser, Path: up, Policy: p})
+		}
+	}
+	if wp := WorkspacePolicyPath(); wp != "" {
+		if p, err := loadLayerIfPresent(wp); err != nil {
+			return nil, fmt.Errorf("loading workspace policy: %w", err)
+		} else if !p.IsZero() {
+			out = append(out, PolicyLayer{Source: LayerWorkspace, Path: wp, Policy: p})
+		}
+	}
+	return out, nil
+}
+
+// loadLayerIfPresent delegates to LoadPlatformPolicy. The file-not-
+// found path returns zero policy without error (matches the
+// optional:true ConfigMap mount semantics from FWS-5); other errors
+// (parse, unknown fields, validation) propagate.
+func loadLayerIfPresent(path string) (PlatformPolicy, error) {
+	return LoadPlatformPolicy(path)
+}
+
+// FirstLayerDenyingEgress returns the first layer whose deny list
+// contains the given domain (system → user → workspace order).
+// Returns nil when no layer denies. Used by the runner to attribute
+// a policy_violation_at_build_time audit event to the deciding layer.
+func FirstLayerDenyingEgress(layers []PolicyLayer, domain string) *PolicyLayer {
+	for i := range layers {
+		if layers[i].Policy.EgressDomainDenied(domain) {
+			return &layers[i]
+		}
+	}
+	return nil
+}
+
+// FirstLayerDenyingTool — see FirstLayerDenyingEgress.
+func FirstLayerDenyingTool(layers []PolicyLayer, name string) *PolicyLayer {
+	for i := range layers {
+		if layers[i].Policy.ToolDenied(name) {
+			return &layers[i]
+		}
+	}
+	return nil
+}
+
+// FirstLayerForbiddingModel — see FirstLayerDenyingEgress.
+func FirstLayerForbiddingModel(layers []PolicyLayer, provider, name string) *PolicyLayer {
+	for i := range layers {
+		if layers[i].Policy.ModelForbidden(provider, name) {
+			return &layers[i]
+		}
+	}
+	return nil
+}
+
+// FirstLayerDenyingChannel — see FirstLayerDenyingEgress.
+func FirstLayerDenyingChannel(layers []PolicyLayer, name string) *PolicyLayer {
+	for i := range layers {
+		if layers[i].Policy.ChannelDenied(name) {
+			return &layers[i]
+		}
+	}
+	return nil
+}
+
+// MostRestrictiveEgressMax walks the layers and returns the smallest
+// non-zero MaxEgressAllowlistSize plus the layer it came from. When
+// no layer sets a non-zero max, returns 0 and nil — caller treats as
+// "no cap." See issue #90 / FWS-6.
+func MostRestrictiveEgressMax(layers []PolicyLayer) (int, *PolicyLayer) {
+	var max int
+	var src *PolicyLayer
+	for i := range layers {
+		v := layers[i].Policy.MaxEgressAllowlistSize
+		if v <= 0 {
+			continue
+		}
+		if max == 0 || v < max {
+			max = v
+			src = &layers[i]
+		}
+	}
+	return max, src
+}
+
+// MostRestrictiveToolMax — see MostRestrictiveEgressMax.
+func MostRestrictiveToolMax(layers []PolicyLayer) (int, *PolicyLayer) {
+	var max int
+	var src *PolicyLayer
+	for i := range layers {
+		v := layers[i].Policy.MaxToolCount
+		if v <= 0 {
+			continue
+		}
+		if max == 0 || v < max {
+			max = v
+			src = &layers[i]
+		}
+	}
+	return max, src
+}

--- a/forge-ui/discovery.go
+++ b/forge-ui/discovery.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/types"
 	"github.com/initializ/forge/forge-core/util/process"
 )
@@ -86,6 +87,27 @@ func (s *Scanner) scanDir(dir string) (*AgentInfo, error) {
 
 	skillCount := countSkills(dir)
 
+	// Compute the effective denied_channels set across system + user +
+	// workspace policy layers (issue #90 / FWS-6). The frontend uses
+	// this to render denied channels as locked/dimmed chips. Best-
+	// effort — load failure (e.g. malformed system file the user
+	// can't edit) is logged on the runtime path but treated as zero
+	// here so a broken file doesn't blank out the agent card.
+	var deniedChannels []string
+	if layers, err := security.LoadAllPolicyLayers(); err == nil {
+		seen := make(map[string]struct{})
+		for _, ch := range cfg.Channels {
+			if security.FirstLayerDenyingChannel(layers, ch) == nil {
+				continue
+			}
+			if _, dup := seen[ch]; dup {
+				continue
+			}
+			seen[ch] = struct{}{}
+			deniedChannels = append(deniedChannels, ch)
+		}
+	}
+
 	info := &AgentInfo{
 		ID:        cfg.AgentID,
 		Version:   cfg.Version,
@@ -96,6 +118,7 @@ func (s *Scanner) scanDir(dir string) (*AgentInfo, error) {
 		},
 		Tools:           toolNames,
 		Channels:        cfg.Channels,
+		DeniedChannels:  deniedChannels,
 		Skills:          skillCount,
 		Directory:       dir,
 		Status:          StateStopped,

--- a/forge-ui/handlers_user_policy.go
+++ b/forge-ui/handlers_user_policy.go
@@ -1,0 +1,125 @@
+package forgeui
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/initializ/forge/forge-core/security"
+	"gopkg.in/yaml.v3"
+)
+
+// userPolicyResponse is the GET payload describing the user policy
+// (~/.forge/policy.yaml) and the read-only state of the other two
+// layers. The frontend renders the user policy as editable form
+// fields; system and workspace layers are display-only (with a
+// "denied by system / workspace policy" badge on channel chips that
+// are blocked higher up).
+//
+// See issue #90 / FWS-6 (three-layer policy resolution).
+type userPolicyResponse struct {
+	// Path is the on-disk location of the user policy file (typically
+	// ~/.forge/policy.yaml). Empty when the runtime can't determine a
+	// home directory.
+	Path string `json:"path"`
+	// User is the parsed user policy. May be the zero value when no
+	// user policy file exists yet.
+	User security.PlatformPolicy `json:"user"`
+	// System is the parsed system policy (read-only from the UI's
+	// perspective). Surfaced so the frontend can render
+	// system-denied channels as locked toggles.
+	System security.PlatformPolicy `json:"system,omitempty"`
+	// SystemPath is the on-disk location of the system policy.
+	SystemPath string `json:"system_path,omitempty"`
+	// Workspace is the parsed workspace policy (read-only — set by
+	// the operator at deploy time via FORGE_PLATFORM_POLICY).
+	Workspace security.PlatformPolicy `json:"workspace,omitempty"`
+	// WorkspacePath is the on-disk location of the workspace policy.
+	WorkspacePath string `json:"workspace_path,omitempty"`
+}
+
+// userPolicyUpdateRequest is the PUT body. Only the User field is
+// writable — system + workspace are operator-controlled and not
+// editable via the UI.
+type userPolicyUpdateRequest struct {
+	User security.PlatformPolicy `json:"user"`
+}
+
+// handleGetUserPolicy returns the current user policy plus a snapshot
+// of the system + workspace layers so the frontend can render the
+// effective state (a channel chip greyed out + locked = denied by a
+// higher layer, not editable). All three reads are best-effort —
+// missing files return zero policy without erroring (matches the
+// runtime's optional-mount semantics from FWS-5).
+func (s *UIServer) handleGetUserPolicy(w http.ResponseWriter, _ *http.Request) {
+	resp := userPolicyResponse{
+		Path:          security.UserPolicyPath(),
+		SystemPath:    security.SystemPolicyPath(),
+		WorkspacePath: security.WorkspacePolicyPath(),
+	}
+	if p, err := security.LoadPlatformPolicy(resp.Path); err == nil {
+		resp.User = p
+	}
+	if p, err := security.LoadPlatformPolicy(resp.SystemPath); err == nil {
+		resp.System = p
+	}
+	if resp.WorkspacePath != "" {
+		if p, err := security.LoadPlatformPolicy(resp.WorkspacePath); err == nil {
+			resp.Workspace = p
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handlePutUserPolicy writes the user policy YAML. The body is the
+// full PlatformPolicy doc; the handler replaces the on-disk file
+// rather than merging because the runtime treats the file as a
+// complete document. Creates ~/.forge if missing.
+//
+// When the submitted policy is the zero value (every field empty),
+// the file is removed from disk so a "no policy" state has no
+// on-disk noise.
+func (s *UIServer) handlePutUserPolicy(w http.ResponseWriter, r *http.Request) {
+	var req userPolicyUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if err := req.User.Validate(); err != nil {
+		writeError(w, http.StatusBadRequest, "policy validation failed: "+err.Error())
+		return
+	}
+	path := security.UserPolicyPath()
+	if path == "" {
+		writeError(w, http.StatusInternalServerError, "cannot determine user home directory")
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		writeError(w, http.StatusInternalServerError, "creating policy dir: "+err.Error())
+		return
+	}
+
+	if req.User.IsZero() {
+		// Empty policy → remove the file. Same on-disk shape as a
+		// fresh install.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			writeError(w, http.StatusInternalServerError, "removing empty policy: "+err.Error())
+			return
+		}
+	} else {
+		data, err := yaml.Marshal(req.User)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "marshalling policy: "+err.Error())
+			return
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			writeError(w, http.StatusInternalServerError, "writing policy: "+err.Error())
+			return
+		}
+	}
+
+	// Echo back the resulting state so the frontend can refresh
+	// without a second GET.
+	s.handleGetUserPolicy(w, r)
+}

--- a/forge-ui/server.go
+++ b/forge-ui/server.go
@@ -87,6 +87,13 @@ func (s *UIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /api/agents/{id}/config", s.handleGetConfig)
 	mux.HandleFunc("PUT /api/agents/{id}/config", s.handleUpdateConfig)
 	mux.HandleFunc("POST /api/agents/{id}/config/validate", s.handleValidateConfig)
+	// User-policy surface (issue #90 / FWS-6 three-layer). Read /
+	// write the user-level ~/.forge/policy.yaml that bounds every
+	// agent the user runs locally. System and workspace layers are
+	// not editable via the UI — sysadmins push the system file, and
+	// workspace policy is the operator's ConfigMap.
+	mux.HandleFunc("GET /api/user-policy", s.handleGetUserPolicy)
+	mux.HandleFunc("PUT /api/user-policy", s.handlePutUserPolicy)
 	mux.HandleFunc("GET /api/skills", s.handleListSkills)
 	mux.HandleFunc("GET /api/skills/{name}/content", s.handleGetSkillContent)
 	mux.HandleFunc("GET /api/tools", s.handleListBuiltinTools)

--- a/forge-ui/static/app.js
+++ b/forge-ui/static/app.js
@@ -659,9 +659,13 @@ function StatusDot({ status }) {
   return html`<span class="status-dot ${status}" />`;
 }
 
-function AgentCard({ agent, onStart, onStop }) {
+function AgentCard({ agent, onStart, onStop, onChannelsChanged }) {
   const isActive = agent.status === 'running' || agent.status === 'starting';
   const isBusy = agent.status === 'starting' || agent.status === 'stopping';
+  // Optimistic chip state — flipped immediately on click so the UI
+  // reflects intent before /api/user-policy responds. Cleared back to
+  // the authoritative agent.denied_channels on every render.
+  const [pendingChannel, setPendingChannel] = useState(null);
 
   return html`
     <div class="agent-card" onClick=${() => isActive && navigate('agent/' + agent.id)}>
@@ -705,7 +709,57 @@ function AgentCard({ agent, onStart, onStop }) {
         ${(agent.channels?.length > 0) && html`
           <span class="agent-card-tag">
             <span class="tag-label">channels</span>
-            ${agent.channels.join(', ')}
+            <span class="channel-chip-group">
+              ${agent.channels.map(ch => {
+                // denied_channels is the EFFECTIVE deny set across
+                // system + user + workspace layers (server computes
+                // it). Click toggles the user-layer entry in
+                // ~/.forge/policy.yaml.
+                const denied = new Set(agent.denied_channels || []);
+                const lockedBy = agent.denied_channels_locked?.[ch];
+                const isDenied = pendingChannel === ch ? !denied.has(ch) : denied.has(ch);
+                const isSaving = pendingChannel === ch;
+                const isLocked = !!lockedBy && lockedBy !== 'user';
+                const title = isLocked
+                  ? `Denied by ${lockedBy} policy (read-only — edit the policy file directly)`
+                  : `Click to ${isDenied ? 'enable' : 'disable'} ${ch} (edits ~/.forge/policy.yaml)`;
+                const flip = async (e) => {
+                  e.stopPropagation();
+                  if (isLocked || isSaving) return;
+                  setPendingChannel(ch);
+                  try {
+                    const cur = await fetch('/api/user-policy').then(r => r.json());
+                    const user = cur.user || {};
+                    const userDenies = user.denied_channels || [];
+                    const userDenied = userDenies.includes(ch);
+                    const next = userDenied
+                      ? userDenies.filter(c => c !== ch)
+                      : [...userDenies, ch];
+                    const updatedUser = { ...user, denied_channels: next };
+                    const res = await fetch('/api/user-policy', {
+                      method: 'PUT',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ user: updatedUser }),
+                    });
+                    if (!res.ok) throw new Error('PUT /api/user-policy failed');
+                    if (onChannelsChanged) await onChannelsChanged();
+                  } catch (err) {
+                    console.error('channel toggle failed', err);
+                  } finally {
+                    setPendingChannel(null);
+                  }
+                };
+                const klass = ['channel-chip',
+                  isDenied ? 'disabled' : '',
+                  isSaving ? 'saving' : '',
+                  isLocked ? 'locked' : ''].filter(Boolean).join(' ');
+                return html`
+                  <span class=${klass} title=${title} onClick=${flip}>
+                    ${ch}
+                  </span>
+                `;
+              })}
+            </span>
           </span>
         `}
         ${agent.port > 0 && html`
@@ -719,6 +773,23 @@ function AgentCard({ agent, onStart, onStop }) {
       ${agent.error && html`
         <div class="agent-card-error">${agent.error}</div>
       `}
+
+      ${!isActive && agent.channels?.length > 0 && (() => {
+        // Pre-launch hint: what `forge serve start --with …` will
+        // actually bring up (declared channels minus policy denies).
+        // Single-line, ellipsis on overflow, full list in tooltip.
+        const denied = new Set(agent.denied_channels || []);
+        const effective = agent.channels.filter(c => !denied.has(c));
+        const text = effective.length === 0
+          ? 'no channels (all denied by policy)'
+          : effective.join(', ');
+        return html`
+          <div class="agent-card-start-hint" title=${'starts with: ' + text}>
+            <span class="start-hint-label">starts with</span>
+            <span class="start-hint-list">${text}</span>
+          </div>
+        `;
+      })()}
 
       <div class="agent-card-actions">
         ${!isActive && html`
@@ -818,7 +889,7 @@ function Sidebar({ agents, activeAgentId, activePage, version }) {
   `;
 }
 
-function Dashboard({ agents, onStart, onStop, onRescan, loading }) {
+function Dashboard({ agents, onStart, onStop, onRescan, onChannelsChanged, loading }) {
   return html`
     <main class="main">
       <div class="main-header">
@@ -845,6 +916,7 @@ function Dashboard({ agents, onStart, onStop, onRescan, loading }) {
                 agent=${a}
                 onStart=${onStart}
                 onStop=${onStop}
+                onChannelsChanged=${onChannelsChanged}
               />
             `)}
           </div>
@@ -2887,6 +2959,7 @@ function App() {
           onStart=${handleStart}
           onStop=${handleStop}
           onRescan=${handleRescan}
+          onChannelsChanged=${loadAgents}
           loading=${loading}
         />`;
     }

--- a/forge-ui/static/style.css
+++ b/forge-ui/static/style.css
@@ -311,10 +311,125 @@ body {
   color: var(--text-muted);
 }
 
+/* Channel toggle chips (issue #90 / FWS-6). Each chip is one channel
+ * in the agent's channels list; click to flip its enabled state. The
+ * disabled state shows the chip dimmed with strikethrough so a quick
+ * glance at the agent card tells the operator which channels are off. */
+.channel-chip-group {
+  display: inline-flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+/* Enabled chip: green-tinted "on" pill — distinct from neutral info
+ * tags (model / fw / tools / port) so the eye separates "current state"
+ * from "static metadata". Color matches the running-status indicator. */
+.channel-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(34, 197, 94, 0.14);
+  color: var(--green);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-weight: 500;
+  transition: background 0.1s, color 0.1s, opacity 0.1s, border-color 0.1s;
+}
+
+.channel-chip::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  flex-shrink: 0;
+}
+
+.channel-chip:hover {
+  background: rgba(34, 197, 94, 0.22);
+  border-color: var(--green);
+}
+
+/* Disabled chip: muted grey with strikethrough. The leading dot fades
+ * out too so the entire chip reads as "off." Hover lifts opacity to
+ * cue clickability. */
+.channel-chip.disabled {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border-color);
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.channel-chip.disabled::before {
+  background: var(--text-muted);
+  opacity: 0.5;
+}
+
+.channel-chip.disabled:hover {
+  opacity: 1;
+  color: var(--text-secondary);
+}
+
+/* Brief in-flight state while the PUT to /api/user-policy is pending.
+ * Pointer-events off so a fast double-click doesn't fire two requests. */
+.channel-chip.saving {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Locked chip: denied by system OR workspace layer; user can't toggle
+ * it from the UI. Cursor + tooltip carry the "why". */
+.channel-chip.locked {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.channel-chip.locked:hover {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.35);
+}
+.channel-chip.locked.disabled:hover {
+  background: transparent;
+  border-color: var(--border-color);
+}
+
+/* Pre-launch hint shown above Start: previews what
+ * `forge serve start --with …` will actually bring up after the
+ * three-layer policy filter runs. Single line; overflow truncated
+ * with ellipsis; full list available via the title tooltip. */
+.agent-card-start-hint {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.start-hint-label {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.start-hint-list {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
 .agent-card-actions {
   display: flex;
   gap: 8px;
   padding-top: 14px;
+  margin-top: 8px;
   border-top: 1px solid var(--border-color);
 }
 

--- a/forge-ui/types.go
+++ b/forge-ui/types.go
@@ -20,12 +20,19 @@ const (
 
 // AgentInfo describes a discovered agent and its runtime state.
 type AgentInfo struct {
-	ID              string       `json:"id"`
-	Version         string       `json:"version"`
-	Framework       string       `json:"framework"`
-	Model           AgentModel   `json:"model"`
-	Tools           []string     `json:"tools"`
-	Channels        []string     `json:"channels"`
+	ID        string     `json:"id"`
+	Version   string     `json:"version"`
+	Framework string     `json:"framework"`
+	Model     AgentModel `json:"model"`
+	Tools     []string   `json:"tools"`
+	Channels  []string   `json:"channels"`
+	// DeniedChannels is the channel deny set after resolving
+	// system / user / workspace policy layers. The agent card uses
+	// this to render denied channels with a visual disabled state.
+	// Toggling a chip mutates the user policy file via
+	// PUT /api/user-policy, NOT this list directly. See issue #90 /
+	// FWS-6 (three-layer policy resolution).
+	DeniedChannels  []string     `json:"denied_channels,omitempty"`
 	Skills          int          `json:"skills"`
 	Directory       string       `json:"directory"`
 	Status          ProcessState `json:"status"`

--- a/scripts/manual-test-fws-6.sh
+++ b/scripts/manual-test-fws-6.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# manual-test-fws-6.sh — Validate three-layer channel policy (issue #90 / FWS-6).
+#
+# Exercises every redesign-specific path end-to-end against a freshly
+# built forge binary inside a fully-sandboxed environment:
+#
+#   - System layer  → $FORGE_SYSTEM_POLICY (redirected to a temp file —
+#                     does NOT touch /etc/forge/policy.yaml)
+#   - User layer    → $HOME/.forge/policy.yaml (HOME redirected to a
+#                     temp dir — does NOT touch your real ~/.forge/)
+#   - Workspace     → $FORGE_PLATFORM_POLICY (also temp file)
+#
+# Each scenario prints what was set up, what was expected, and what the
+# audit pipeline actually emitted so you can eyeball pass/fail without
+# trusting a self-graded "PASS" badge.
+#
+# Run:    bash scripts/manual-test-fws-6.sh
+# Clean:  rm -rf $TMPDIR/forge-fws-6.*   (sandbox dir is printed at the end)
+
+set -euo pipefail
+
+# ─── Setup ───────────────────────────────────────────────────────────
+WORKTREE="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX="$(mktemp -d -t forge-fws-6.XXXXXX)"
+FORGE_BIN="$SANDBOX/forge"
+AGENT_DIR="$SANDBOX/agent"
+
+# Isolation: every policy path the runtime checks now resolves into
+# the sandbox. Your real ~/.forge/ and /etc/forge/ are not touched.
+export FORGE_SYSTEM_POLICY="$SANDBOX/system-policy.yaml"
+export HOME="$SANDBOX/home"
+mkdir -p "$HOME/.forge" "$AGENT_DIR"
+
+trap 'echo; echo "Sandbox: $SANDBOX (leave it for inspection or rm -rf)"; ' EXIT
+
+step() { printf '\n\033[1;34m════════ %s ════════\033[0m\n' "$*"; }
+sub()  { printf '  \033[1;33m›\033[0m %s\n' "$*"; }
+ok()   { printf '    \033[1;32m✓\033[0m %s\n' "$*"; }
+fail() { printf '    \033[1;31m✗ FAIL\033[0m %s\n' "$*"; }
+dump() { sed 's/^/      /'; }
+
+# ─── Build ───────────────────────────────────────────────────────────
+step "Build forge with -a (force full rebuild to defeat worktree cache)"
+( cd "$WORKTREE/forge-cli/cmd/forge" && go build -a -o "$FORGE_BIN" . )
+"$FORGE_BIN" --version 2>&1 | head -1 || true
+
+# ─── Minimal test agent ──────────────────────────────────────────────
+cat > "$AGENT_DIR/forge.yaml" <<'EOF'
+agent_id: fws6-test
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+channels:
+  - slack
+  - telegram
+egress:
+  mode: deny-all
+EOF
+
+# ─── Runtime probe helpers ───────────────────────────────────────────
+# Starts forge run for ~3s, captures all stderr (banner + audit NDJSON),
+# kills the process, and leaves the log at $1 for inspection.
+run_capture() {
+  local logfile=$1
+  # --with is REQUIRED to exercise the channel filter + audit emit;
+  # without it forge run just brings up the A2A server and the policy
+  # filter never runs (`cfg.Channels` in forge.yaml is a declaration,
+  # not an instruction to start adapters).
+  ( cd "$AGENT_DIR" && "$FORGE_BIN" run --port 18080 --mock-tools \
+      --with slack,telegram ) >"$logfile" 2>&1 &
+  local pid=$!
+  sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# Extract channel_denied_by_policy events. Robust against empty input
+# (grep returning 1 on no-match would otherwise crash the pipeline
+# under `set -o pipefail`).
+channel_denies() {
+  local out
+  out=$(grep -aE '^\{' "$1" 2>/dev/null || true)
+  [ -z "$out" ] && return 0
+  echo "$out" | jq -c 'select(.event == "channel_denied_by_policy")' 2>/dev/null || true
+}
+
+# Extract a single field from a channel_denied event for a given
+# channel name. Empty string when the event is absent.
+field_for() {
+  local events=$1 channel=$2 field=$3
+  local line
+  line=$(echo "$events" | grep "\"channel\":\"$channel\"" 2>/dev/null || true)
+  [ -z "$line" ] && return 0
+  echo "$line" | jq -r ".fields.$field" 2>/dev/null || true
+}
+
+# ─── Scenario 1: backward-compat (no layers, no denies) ──────────────
+step "1. No policy layers → no channel_denied events (backward compat)"
+rm -f "$FORGE_SYSTEM_POLICY" "$HOME/.forge/policy.yaml"
+unset FORGE_PLATFORM_POLICY 2>/dev/null || true
+run_capture "$SANDBOX/1.log"
+events=$(channel_denies "$SANDBOX/1.log")
+if [ -z "$events" ]; then
+  ok "zero channel_denied events"
+else
+  fail "expected zero denies, got:"; echo "$events" | dump
+fi
+
+# ─── Scenario 2: user layer via CLI ─────────────────────────────────
+step "2. forge channel disable telegram → writes user layer"
+( cd "$AGENT_DIR" && "$FORGE_BIN" channel disable telegram 2>&1 | dump )
+sub "User policy file ($HOME/.forge/policy.yaml):"
+cat "$HOME/.forge/policy.yaml" | dump
+run_capture "$SANDBOX/2.log"
+events=$(channel_denies "$SANDBOX/2.log")
+sub "channel_denied events emitted at startup:"
+echo "$events" | dump
+layer=$(field_for "$events" telegram layer)
+[ "$layer" = "user" ] && ok "telegram denied, attributed to layer=user" \
+                       || fail "telegram should be denied with layer=user, got '$layer'"
+
+# ─── Scenario 3: system layer ────────────────────────────────────────
+step "3. Add system layer (denied_channels: [slack]) → two denies, distinct layers"
+cat > "$FORGE_SYSTEM_POLICY" <<'EOF'
+denied_channels:
+  - slack
+EOF
+run_capture "$SANDBOX/3.log"
+events=$(channel_denies "$SANDBOX/3.log")
+sub "channel_denied events:"
+echo "$events" | dump
+slack_layer=$(field_for "$events" slack layer)
+tg_layer=$(field_for "$events" telegram layer)
+[ "$slack_layer" = "system" ] && ok "slack → layer=system" || fail "slack should be layer=system, got '$slack_layer'"
+[ "$tg_layer" = "user" ] && ok "telegram → layer=user" || fail "telegram should be layer=user, got '$tg_layer'"
+
+# ─── Scenario 4: attribution precedence ──────────────────────────────
+step "4. Both system AND user deny telegram → system wins attribution"
+cat > "$FORGE_SYSTEM_POLICY" <<'EOF'
+denied_channels:
+  - telegram
+  - slack
+EOF
+# user policy from scenario 2 already has telegram
+sub "System layer:"; cat "$FORGE_SYSTEM_POLICY" | dump
+sub "User layer:";   cat "$HOME/.forge/policy.yaml" | dump
+run_capture "$SANDBOX/4.log"
+events=$(channel_denies "$SANDBOX/4.log")
+sub "all channel_denied events:"
+echo "$events" | dump
+attrib=$(field_for "$events" telegram layer)
+src=$(field_for "$events" telegram source)
+[ "$attrib" = "system" ] && ok "telegram attributed to layer=system" || fail "expected layer=system, got '$attrib'"
+[ "$src" = "$FORGE_SYSTEM_POLICY" ] && ok "source=$FORGE_SYSTEM_POLICY" || fail "source mismatch: '$src'"
+
+# ─── Scenario 5: enable removes user-layer entry (file cleaned up) ───
+step "5. forge channel enable telegram → user policy file removed when empty"
+( cd "$AGENT_DIR" && "$FORGE_BIN" channel enable telegram 2>&1 | dump )
+if [ -e "$HOME/.forge/policy.yaml" ]; then
+  fail "user policy file still present:"
+  cat "$HOME/.forge/policy.yaml" | dump
+else
+  ok "user policy file removed (empty doc → no on-disk noise)"
+fi
+
+# ─── Scenario 6: --system flag writes to system path ─────────────────
+step "6. forge channel disable msteams --system → writes system path"
+rm -f "$FORGE_SYSTEM_POLICY"
+( cd "$AGENT_DIR" && "$FORGE_BIN" channel disable msteams --system 2>&1 | dump )
+sub "System policy file ($FORGE_SYSTEM_POLICY):"
+cat "$FORGE_SYSTEM_POLICY" | dump
+if grep -q 'msteams' "$FORGE_SYSTEM_POLICY"; then
+  ok "--system wrote to FORGE_SYSTEM_POLICY path (non-root warning expected in output above)"
+else
+  fail "--system did not write expected entry"
+fi
+
+# ─── Scenario 7: forge channel serve refuses denied target ───────────
+step "7. forge channel serve slack → refuses to start when slack is denied"
+cat > "$FORGE_SYSTEM_POLICY" <<'EOF'
+denied_channels:
+  - slack
+EOF
+out=$( cd "$AGENT_DIR" && "$FORGE_BIN" channel serve slack 2>&1 || true )
+echo "$out" | head -10 | dump
+if echo "$out" | grep -qiE 'denied|policy'; then
+  ok "channel serve refused with policy-related error"
+else
+  fail "expected a deny-related error; got:"; echo "$out" | dump
+fi
+
+# ─── Scenario 8: egress violation carries layer attribution ──────────
+step "8. Egress deny via user policy → startup error names enforcing layer"
+cat > "$AGENT_DIR/forge.yaml" <<'EOF'
+agent_id: fws6-test
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+channels: []
+egress:
+  mode: allowlist
+  allowed_domains:
+    - api.notion.com
+EOF
+rm -f "$FORGE_SYSTEM_POLICY"
+cat > "$HOME/.forge/policy.yaml" <<'EOF'
+denied_egress_domains:
+  - api.notion.com
+EOF
+sub "User policy denies api.notion.com; forge.yaml declares it"
+out=$( cd "$AGENT_DIR" && "$FORGE_BIN" run --port 18080 --mock-tools 2>&1 || true )
+echo "$out" | grep -aE 'denied_egress|enforced by|policy' | head -10 | dump
+if echo "$out" | grep -q 'enforced by user policy'; then
+  ok "violation error names the enforcing layer (user) + path"
+else
+  fail "expected 'enforced by user policy' in error; check log $SANDBOX/8.log"
+  echo "$out" > "$SANDBOX/8.log"
+fi
+
+# ─── Scenario 9: forge validate --platform-policy lints each layer ───
+step "9. forge validate --platform-policy lints arbitrary layer files"
+cat > "$SANDBOX/bogus.yaml" <<'EOF'
+denied_channels:
+  - telegram
+unknown_field: this_should_fail   # strict decoding rejects typos
+EOF
+out=$( "$FORGE_BIN" validate --platform-policy="$SANDBOX/bogus.yaml" 2>&1 || true )
+echo "$out" | head -5 | dump
+if echo "$out" | grep -qi 'unknown'; then
+  ok "strict decoding rejected the unknown_field typo"
+else
+  fail "expected an 'unknown field' error"
+fi
+
+# ─── Done ────────────────────────────────────────────────────────────
+step "Logs preserved at $SANDBOX for post-mortem"
+ls "$SANDBOX"/*.log 2>/dev/null | dump || true


### PR DESCRIPTION
## Summary

- Platform policy now resolves across three independent layers — **system** (`/etc/forge/policy.yaml`, sysadmin), **user** (`~/.forge/policy.yaml`, developer), **workspace** (`FORGE_PLATFORM_POLICY`, operator) — with deny-list union, smallest-non-zero max-bound, and first-layer-wins audit attribution.
- **Channel deny is now first-class** — `denied_channels` on any layer skips the named adapter at startup and emits `channel_denied_by_policy` with `fields.layer` + `fields.source`. `forge run --with`, `forge serve start`, and `forge channel serve` all honor it.
- New CLI: `forge channel disable|enable <name>` edits `~/.forge/policy.yaml` by default; `--system` retargets to `/etc/forge/policy.yaml` (warns when not root). Both are idempotent and remove the file when the resulting policy is empty.
- New UI: `GET/PUT /api/user-policy` replaces the per-agent channel endpoints; agent-card chips render green (enabled) / dimmed (disabled) / locked (denied by a higher layer), with optimistic flip + a "starts with: …" hint above Start.
- Per-agent `disabled_channels:` field removed from `forge.yaml` — channel disable is laptop or workspace, never declaration. A brief first cut of FWS-6 shipped it; this PR replaces it with the user layer.

## Why three layers and not the FWS-5 single env

| Layer | Path | Who sets it | Why it can't ride on FORGE_PLATFORM_POLICY |
|---|---|---|---|
| system | `/etc/forge/policy.yaml` | Sysadmin (MDM, corporate image) | Owns fleet machines, doesn't own every agent's deploy pipeline |
| user | `~/.forge/policy.yaml` | Developer (CLI, Web UI chip) | Needs a "off for me locally" toggle without editing `forge.yaml` |
| workspace | `$FORGE_PLATFORM_POLICY` | Operator (Initializ Command, custom controller) | Deploy-time bounds for the specific agent — unchanged from FWS-5 |

## What's in this PR

| Subsystem | Change |
|---|---|
| `forge-core/security/` | New `PolicyLayer` + `LoadAllPolicyLayers` + `FirstLayer*` accessors + `MostRestrictive{Egress,Tool}Max`; `EnforcePolicy` / `EffectiveChannels` / `EffectiveEgressAllowlist` / `EffectiveDeniedTools` take `[]PolicyLayer`; `PolicyViolation` + `ChannelSkip` gain `Layer` + `LayerPath` |
| `forge-core/security/platform_policy.go` | `json:` struct tags added to `PlatformPolicy` (root cause of the broken PUT — Go's case-insensitive field match can't bridge snake_case ↔ PascalCase) |
| `forge-core/runtime/audit.go` | `EmitChannelDeniedByPolicy(channel, layer, source)`; `AuditChannelDisabledByConfig` removed |
| `forge-cli/cmd/channel.go` | `disable` / `enable` edit user policy by default; `--system` flag; non-root warning |
| `forge-cli/cmd/run.go` + `forge-cli/runtime/runner.go` | Walks all layers; one `policy_loaded` event per non-empty layer; tool deny unions; channel filter via `EffectiveChannels` |
| `forge-ui/` | New `handlers_user_policy.go` (`GET/PUT /api/user-policy`); `discovery.go` populates `denied_channels` from `LoadAllPolicyLayers`; per-agent channel endpoints removed |
| `forge-ui/static/app.js` + `style.css` | Chip rewrite: green/grey states, optimistic flip + saving-state dim, locked chips for system/workspace denies, pre-launch "starts with: …" hint with ellipsis on overflow |
| Docs / example / CHANGELOG | `docs/security/platform-policy.md` rewritten for three layers; `examples/platform-policy.yaml` rewritten; CHANGELOG describes redesign + first-cut migration |

## Audit-event shape

```json
{ "event": "policy_loaded",
  "fields": {"layer":"system","source":"/etc/forge/policy.yaml",...} }

{ "event": "policy_violation_at_build_time",
  "fields": {"violation_kind":"denied_egress","layer":"user",
             "source":"/home/dev/.forge/policy.yaml",
             "offending_value":"api.notion.com",
             "forge_yaml_field":"egress.allowed_domains"} }

{ "event": "channel_denied_by_policy",
  "fields": {"channel":"slack","layer":"system",
             "source":"/etc/forge/policy.yaml"} }
```

Developer-facing error from a violation now reads:

```
denied_egress: api.notion.com at forge.yaml field egress.allowed_domains
  (enforced by user policy: /home/dev/.forge/policy.yaml)
```

## Test plan

- [x] `go test -race ./forge-core/...` — green (incl. 7 new layered-channel tests + rewritten enforce tests with multi-layer attribution cases)
- [x] `go test -race ./forge-cli/... ./forge-ui/... ./forge-plugins/...` — green
- [x] `gofmt -w` clean; `golangci-lint run` clean across all 4 modules
- [x] Manual end-to-end via `scripts/manual-test-fws-6.sh` — 9 sandboxed scenarios (backward compat, user-layer CLI write, system-layer attribution, system-wins precedence, file-removed-when-empty, `--system` flag, `forge channel serve` refusal, egress violation with layer attribution, strict-decode unknown-field rejection). All passed; raw audit JSON inspected.
- [x] Web UI: chip toggle PUTs `/api/user-policy`, file updates on disk, chip color reflects state, "starts with: …" hint above Start, locked chips for higher-layer denies.

Closes #90.