### PR TITLE
chore(runtime): ops logs to stdout — stream separation from audit (closes #100, FWS-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,22 @@
 
 ### Changed
 
+- **`forge run` / `forge serve` ops logs now write to stdout (was
+  stderr) — stream separation from audit (issue #100, FWS-9).** The
+  structured `JSONLogger` (`r.logger.Info/Warn/Error`: startup banner,
+  request lines, runtime errors) now writes to **stdout**. Audit NDJSON
+  continues to write to **stderr** (and to the dedicated FWS-7 sink
+  when configured). Container log collectors and SIEM pipelines can
+  now split ops from audit at the stream level — no payload parsing
+  needed. **Operator migration:** if you previously captured ops logs
+  via `forge run 2> ops.log`, switch to `forge run > ops.log` (and
+  `2> audit.log` for audit). Container deployments that capture both
+  streams via the runtime's standard log collector are unaffected.
+  Interactive CLI commands (`forge init`, `forge build`,
+  `forge channel`) still write user-facing warnings + errors to
+  stderr — those are UX messages, not server ops logs, and the
+  stream-split policy doesn't apply. See
+  `docs/security/audit-logging.md#streams-fws-9`.
 - **`SkillBuilderCodegenModel` no longer overrides the operator's model
   (issue #92).** The function previously forced `gpt-4.1` for openai and
   `claude-opus-4-6` for anthropic regardless of what the agent (or

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -303,14 +303,30 @@ interesting happens, instrumentation emits to OTel **and** to audit at
 the same call site. They are deliberately not coupled: do not tap one
 from the other.
 
-### Companion follow-up: stream separation
+## Streams (FWS-9)
 
-Forge currently puts both ops logs (`r.logger.Info(...)` startup
-banners, request logs) **and** audit NDJSON on stderr. A SIEM pipeline
-that wants audit-only records can split by parsing the `event` field,
-but stream-level separation would be cleaner. Tracked as FWS-9 (#100):
-*"Move ops logger output from stderr to stdout (stream separation from
-audit)."* Independent of FWS-7 in code.
+`forge run` / `forge serve` use the OS streams as a stream-level
+audit-vs-ops split, so container log collectors and SIEM pipelines
+can route the two concerns separately without parsing any payload:
+
+| Stream | Carries | Consumer |
+|---|---|---|
+| **stdout** | Ops logs — startup banner, request lines, runtime errors emitted via the structured `JSONLogger` (`r.logger.Info/Warn/Error`). | Container log collector / local debugging. |
+| **stderr** | Audit NDJSON — every `event` constant defined in the table above. | SIEM pipeline today. After FWS-7, also lands on the dedicated UDS / HTTP sink in parallel (stderr stays as the safety-net fallback). |
+| UDS / HTTP sink (FWS-7) | Audit NDJSON (primary, when configured). | initializ platform sidecar / customer SIEM. |
+
+Migration note: pre-FWS-9, ops logs and audit both went to stderr —
+SIEM rules had to filter by the presence of the `event` JSON field.
+After FWS-9, the split is clean. Operators who used to redirect
+`forge run 2> ops.log` for ops capture must switch to
+`forge run > ops.log` (and `2> audit.log` for audit). Container
+deployments that capture both streams via the runtime's standard
+log collector are unaffected.
+
+Interactive CLI commands (`forge init`, `forge build`, `forge channel`)
+keep writing warnings and errors to stderr — those are user-facing UX
+messages, not server ops logs, and the stream-split policy doesn't
+apply to them.
 
 ## Schema contract (FWS-8)
 

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -132,7 +132,13 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 	if cfg.Port <= 0 {
 		cfg.Port = 8080
 	}
-	logger := coreruntime.NewJSONLogger(os.Stderr, cfg.Verbose)
+	// FWS-9 (issue #100): ops logs go to stdout so audit NDJSON on
+	// stderr can be consumed as a single-stream concern by container
+	// log collectors and SIEM pipelines — no payload parsing needed
+	// to split ops from audit. Audit destination is unchanged; it
+	// remains on stderr (with the FWS-7 dedicated sink overlay when
+	// configured).
+	logger := coreruntime.NewJSONLogger(os.Stdout, cfg.Verbose)
 	return &Runner{
 		cfg:            cfg,
 		logger:         logger,


### PR DESCRIPTION
## Summary

- `forge run` / `forge serve` now emit the structured `JSONLogger` ops logs to **stdout** (was stderr).
- Audit NDJSON continues to write to **stderr** (with the FWS-7 dedicated UDS / HTTP sink overlay when configured).
- Container log collectors and SIEM pipelines can now split ops from audit at the stream level — no payload parsing needed.
- One-line code change at `forge-cli/runtime/runner.go`'s `NewRunner` (the only production construction site for the ops `JSONLogger`).

## Why

Pre-FWS-9, ops logs and audit both landed on stderr. SIEM rules had to filter every line by the presence of the `event` JSON field — extra parsing cost at the collector and a risk of accidental rule drift if ops logs ever started carrying an `event` field. After this change the split is clean.

## Streams (new shape)

| Stream | Carries | Consumer |
|---|---|---|
| stdout | Ops logs — startup, request lines, runtime errors via `r.logger.Info/Warn/Error` | Container log collector / local debugging |
| stderr | Audit NDJSON — every `event` constant | SIEM pipeline today. After FWS-7, also on the dedicated sink in parallel (stderr stays as safety-net fallback). |
| UDS / HTTP sink (FWS-7) | Audit NDJSON (primary, when configured) | initializ platform sidecar / customer SIEM |

## What I did NOT change (per issue out-of-scope)

- **Audit destination.** Stays on stderr. FWS-7 (#95) owns the configurable sink.
- **Interactive CLI command output.** `forge init`, `forge build`, `forge channel`, the `forge run` startup banner — those user-facing messages via `fmt.Fprintf(os.Stderr, ...)` are UX, not server ops logs.
- **`JSONLogger` API.** Already takes `io.Writer` — purely a construction-site change.
- **Tests.** All use `bytes.Buffer{}` / `discardWriter{}` / `nil` writers — stream-agnostic and unaffected.

## Test plan

- [x] `go test -race -count=1 ./forge-cli/runtime/...` — green
- [x] `gofmt -w` + `golangci-lint run ./forge-cli/...` — clean
- [x] Manual smoke test (sandboxed):
  ```
  $ forge run --port 18099 --mock-tools > stdout.log 2> stderr.log
  ```
  - `stdout.log` → 2 JSONLogger ops lines (`{"level":"info","msg":"egress proxy started",...}`, `using mock executor`)
  - `stderr.log` → human-readable banner + 1 audit event (`{"event":"agent_card_published","schema_version":"1.0",...}`)
  - Audit events on stdout: **0** (clean separation)
  - Ops JSON lines on stderr: **0** (only banner + audit)

## Operator migration

Anyone capturing ops logs via `forge run 2> ops.log` must switch to `forge run > ops.log` (and `2> audit.log` for audit). Container deployments that capture both streams via the runtime's standard log collector are unaffected.

The CHANGELOG entry calls this out explicitly under `Changed`.

## Files

| File | Change |
|---|---|
| `forge-cli/runtime/runner.go` | One-line: `os.Stderr` → `os.Stdout` in `NewJSONLogger` construction (+ 6-line rationale comment) |
| `docs/security/audit-logging.md` | New "Streams (FWS-9)" section with the stdout/stderr/sink table + operator migration note (replaces the FWS-7 callout that pointed at this issue) |
| `CHANGELOG.md` | Unreleased / Changed entry with operator-facing migration text |

Closes #100.