### PR TITLE
feat(server): rate-limit configurability + orchestration-friendly defaults + cancel exemption (closes #110, FWS-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ### Added
 
+- **Per-IP rate-limit configurability — `server.rate_limit` block +
+  CLI flags + env vars (issue #110, FWS-10).** The A2A server's
+  per-IP rate limiter (originally from issue #31) is now configurable
+  end-to-end via a new top-level `server.rate_limit:` block in
+  `forge.yaml`, matching `--rate-limit-*` CLI flags on both `forge run`
+  and `forge serve start`, and `FORGE_RATE_LIMIT_*` env vars. Resolution
+  order is per-field: CLI > env > yaml > defaults. Five fields exposed:
+  `read_rps`, `read_burst`, `write_rps`, `write_burst`, `cancel_exempt`.
+  See `docs/reference/forge-yaml-schema.md#serverrate_limit--per-ip-a2a-rate-limits-fws-10`.
+
+### Changed
+
+- **A2A server rate-limit defaults bumped for orchestrated workloads
+  (issue #110, FWS-10).** Write limits raised from `10/min` + burst `3`
+  to `60/min` + burst `20`. The old defaults predated parallel workflow
+  execution and cron bursts — a 10-step parallel stage was getting
+  serialized after the 3rd dispatch. **`tasks/cancel` is now exempt
+  from the write bucket by default** (configurable via
+  `cancel_exempt: false`). The cost-ceiling cancel-burst case
+  (orchestrator firing N parallel cancels when a workflow budget trips)
+  was hitting `-32603: rate limit exceeded` at exactly the moment
+  cancellation matters most — that's the failure mode FWS-4's manual
+  test surfaced. Read defaults (`60/min`, burst `10`) unchanged.
+  Operators with stricter threat models can lock down via the new
+  config surface (example for a public-facing agent in the schema docs).
 - **Hardened audit emission — sequence numbers + schema version + opt-in
   payload capture (issue #91, FWS-8).** Every audit event now carries
   `schema_version: "1.0"` (the audit schema is documented as a stable,

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -52,6 +52,14 @@ egress:
 cors_origins:                       # CORS allowed origins for A2A server
   - "https://app.example.com"      # (default: localhost variants)
 
+server:                              # A2A server tuning (optional)
+  rate_limit:                        # per-IP rate limits (issue #110 / FWS-10)
+    read_rps: 1.0                    # GET/HEAD/OPTIONS req/sec (default 1.0 = 60/min)
+    read_burst: 10                   # GET/HEAD/OPTIONS burst (default 10)
+    write_rps: 1.0                   # POST/PUT/DELETE req/sec (default 1.0 = 60/min)
+    write_burst: 20                  # POST/PUT/DELETE burst (default 20)
+    cancel_exempt: true              # tasks/cancel skips the write bucket (default true)
+
 package:
   alpine: false                     # Prefer Alpine base image
   slim: false                       # Minimize image size
@@ -138,3 +146,51 @@ schedules:                          # Recurring scheduled tasks (optional)
     channel: "telegram"             # Optional channel for delivery
     channel_target: "-100123456"    # Destination chat/channel ID
 ```
+
+## `server.rate_limit` — per-IP A2A rate limits (FWS-10)
+
+Bounds the per-IP request rate on the A2A HTTP server. Defaults
+(applied when the block is omitted) target orchestrated workloads —
+60/min sustained on both read and write surfaces, with burst headroom
+for parallel-task dispatch and cron bursts.
+
+| Field | Default | Notes |
+|---|---|---|
+| `read_rps` | `1.0` | Sustained req/sec for `GET` / `HEAD` / `OPTIONS`. |
+| `read_burst` | `10` | Burst headroom for reads. |
+| `write_rps` | `1.0` | Sustained req/sec for `POST` / `PUT` / `DELETE`. Bumped from `10/60` in FWS-10 to absorb orchestrator dispatch. |
+| `write_burst` | `20` | Burst headroom for writes. Bumped from `3` in FWS-10. |
+| `cancel_exempt` | `true` | When true, `tasks/cancel` JSON-RPC calls skip the write bucket entirely. The cost-ceiling cancel-burst case (orchestrator firing N parallel cancels when a workflow budget trips) is the motivating example — sharing the write bucket with `tasks/send` would throttle cancels at exactly the moment cancellation matters most. DoS via cancel-spam is bounded by the cancellation registry's O(1) unknown-task lookup. |
+
+### Resolution order
+
+Per-field, in precedence:
+
+1. **CLI flag** — `--rate-limit-read-rps`, `--rate-limit-read-burst`, `--rate-limit-write-rps`, `--rate-limit-write-burst`, `--rate-limit-cancel-exempt` (works on both `forge run` and `forge serve start`)
+2. **Env var** — `FORGE_RATE_LIMIT_READ_RPS`, `FORGE_RATE_LIMIT_READ_BURST`, `FORGE_RATE_LIMIT_WRITE_RPS`, `FORGE_RATE_LIMIT_WRITE_BURST`, `FORGE_RATE_LIMIT_CANCEL_EXEMPT`
+3. **`server.rate_limit:` block in `forge.yaml`**
+4. **Built-in defaults** (the table above)
+
+Each field falls through layer by layer — a CLI flag for `--rate-limit-write-rps` overrides only that one field; the others still come from env / yaml / default.
+
+### Stricter than default (public-facing agent)
+
+A typical config for a public-facing agent on the open internet:
+
+```yaml
+server:
+  rate_limit:
+    read_rps: 0.5     # 30/min reads
+    read_burst: 5
+    write_rps: 0.1    # 6/min writes — anonymous DoS protection
+    write_burst: 3
+    cancel_exempt: true  # keep cancel responsive even under attack
+```
+
+### Per-IP grouping limitation
+
+The limiter keys on the remote IP. In Kubernetes, multiple orchestrator
+pods behind a single service IP share one bucket. If that becomes a
+practical problem, the right fix is auth-aware rate limiting (per-user
+buckets keyed by `auth.user_id`) — out of scope for FWS-10; file
+separately.

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -43,6 +44,17 @@ var (
 	runAuditSocket       string
 	runAuditHTTPEndpoint string
 	runAuditWriteTimeout time.Duration
+
+	// FWS-10 rate-limit overrides (issue #110). Sentinel zero / "" means
+	// "flag not passed; fall through to env → yaml → defaults". The
+	// cancel-exempt flag is a string ("true"/"false"/"") so the
+	// resolver can distinguish "not passed" from "explicitly false" —
+	// cobra's BoolVar collapses those.
+	runRateLimitReadRPS      float64
+	runRateLimitReadBurst    int
+	runRateLimitWriteRPS     float64
+	runRateLimitWriteBurst   int
+	runRateLimitCancelExempt string
 )
 
 var runCmd = &cobra.Command{
@@ -76,6 +88,15 @@ func init() {
 	runCmd.Flags().StringVar(&runAuditSocket, "audit-socket", "", "Unix socket path to export audit events to (sidecar consumer); empty = stderr only")
 	runCmd.Flags().StringVar(&runAuditHTTPEndpoint, "audit-http-endpoint", "", "localhost HTTP endpoint to POST audit events to (used only when --audit-socket is empty)")
 	runCmd.Flags().DurationVar(&runAuditWriteTimeout, "audit-write-timeout", 0, "per-event timeout for the audit socket/HTTP sink (default 50ms)")
+
+	// FWS-10 — per-IP A2A rate limits (issue #110). All five default
+	// to the matching FORGE_RATE_LIMIT_* env / yaml block / built-in
+	// default (60/min read + write, burst 10/20, cancel exempt).
+	runCmd.Flags().Float64Var(&runRateLimitReadRPS, "rate-limit-read-rps", 0, "per-IP request/sec for read methods (default 1.0 = 60/min)")
+	runCmd.Flags().IntVar(&runRateLimitReadBurst, "rate-limit-read-burst", 0, "per-IP burst size for read methods (default 10)")
+	runCmd.Flags().Float64Var(&runRateLimitWriteRPS, "rate-limit-write-rps", 0, "per-IP request/sec for write methods (default 1.0 = 60/min)")
+	runCmd.Flags().IntVar(&runRateLimitWriteBurst, "rate-limit-write-burst", 0, "per-IP burst size for write methods (default 20)")
+	runCmd.Flags().StringVar(&runRateLimitCancelExempt, "rate-limit-cancel-exempt", "", "exempt tasks/cancel from the write bucket (true/false; default true)")
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
@@ -114,6 +135,11 @@ func runRun(cmd *cobra.Command, args []string) error {
 		auditExport.WriteTimeout = runAuditWriteTimeout
 	}
 
+	// FWS-10 — assemble the CLI-side rate-limit override. Only
+	// explicitly-set flags propagate; everything else stays nil so
+	// the resolver falls through to env → yaml → defaults.
+	rateLimitOverride := buildRateLimitOverride()
+
 	runner, err := runtime.NewRunner(runtime.RunnerConfig{
 		Config:            cfg,
 		WorkDir:           workDir,
@@ -133,6 +159,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		AuthOrgID:         runAuthOrgID,
 		CORSOrigins:       corsOrigins,
 		AuditExport:       auditExport,
+		RateLimitOverride: rateLimitOverride,
 	})
 	if err != nil {
 		return fmt.Errorf("creating runner: %w", err)
@@ -233,4 +260,46 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	return runner.Run(ctx)
+}
+
+// buildRateLimitOverride translates the runRateLimit* flag vars into
+// the resolver's pointer-typed override struct. Only flags that were
+// explicitly set (non-zero float / non-zero int / non-empty bool
+// string) propagate; the rest stay nil so the resolver falls through
+// to FORGE_RATE_LIMIT_* env vars, then `server.rate_limit:` in
+// forge.yaml, then the built-in defaults. Returns nil when nothing
+// was set.
+func buildRateLimitOverride() *runtime.RateLimitOverride {
+	out := &runtime.RateLimitOverride{}
+	any := false
+	if runRateLimitReadRPS != 0 {
+		v := runRateLimitReadRPS
+		out.ReadRPS = &v
+		any = true
+	}
+	if runRateLimitReadBurst != 0 {
+		v := runRateLimitReadBurst
+		out.ReadBurst = &v
+		any = true
+	}
+	if runRateLimitWriteRPS != 0 {
+		v := runRateLimitWriteRPS
+		out.WriteRPS = &v
+		any = true
+	}
+	if runRateLimitWriteBurst != 0 {
+		v := runRateLimitWriteBurst
+		out.WriteBurst = &v
+		any = true
+	}
+	if runRateLimitCancelExempt != "" {
+		if b, err := strconv.ParseBool(runRateLimitCancelExempt); err == nil {
+			out.CancelExempt = &b
+			any = true
+		}
+	}
+	if !any {
+		return nil
+	}
+	return out
 }

--- a/forge-cli/cmd/serve.go
+++ b/forge-cli/cmd/serve.go
@@ -48,6 +48,15 @@ var (
 	serveAuditSocket       string
 	serveAuditHTTPEndpoint string
 	serveAuditWriteTimeout time.Duration
+
+	// FWS-10 rate-limit overrides (issue #110). Forwarded to the
+	// forked `forge run`. Sentinel zero / "" means "not set; let the
+	// child resolve from env / yaml / defaults."
+	serveRateLimitReadRPS      float64
+	serveRateLimitReadBurst    int
+	serveRateLimitWriteRPS     float64
+	serveRateLimitWriteBurst   int
+	serveRateLimitCancelExempt string
 )
 
 var serveCmd = &cobra.Command{
@@ -116,6 +125,11 @@ func registerServeFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&serveAuditSocket, "audit-socket", "", "Unix socket path to export audit events to (sidecar consumer); empty = stderr only")
 	cmd.Flags().StringVar(&serveAuditHTTPEndpoint, "audit-http-endpoint", "", "localhost HTTP endpoint to POST audit events to (used only when --audit-socket is empty)")
 	cmd.Flags().DurationVar(&serveAuditWriteTimeout, "audit-write-timeout", 0, "per-event timeout for the audit socket/HTTP sink (default 50ms)")
+	cmd.Flags().Float64Var(&serveRateLimitReadRPS, "rate-limit-read-rps", 0, "per-IP request/sec for read methods (default 1.0 = 60/min)")
+	cmd.Flags().IntVar(&serveRateLimitReadBurst, "rate-limit-read-burst", 0, "per-IP burst size for read methods (default 10)")
+	cmd.Flags().Float64Var(&serveRateLimitWriteRPS, "rate-limit-write-rps", 0, "per-IP request/sec for write methods (default 1.0 = 60/min)")
+	cmd.Flags().IntVar(&serveRateLimitWriteBurst, "rate-limit-write-burst", 0, "per-IP burst size for write methods (default 20)")
+	cmd.Flags().StringVar(&serveRateLimitCancelExempt, "rate-limit-cancel-exempt", "", "exempt tasks/cancel from the write bucket (true/false; default true)")
 }
 
 func init() {
@@ -228,6 +242,21 @@ func serveStartRun(cmd *cobra.Command, args []string) error {
 	}
 	if serveAuditWriteTimeout > 0 {
 		runArgs = append(runArgs, "--audit-write-timeout", serveAuditWriteTimeout.String())
+	}
+	if serveRateLimitReadRPS != 0 {
+		runArgs = append(runArgs, "--rate-limit-read-rps", strconv.FormatFloat(serveRateLimitReadRPS, 'g', -1, 64))
+	}
+	if serveRateLimitReadBurst != 0 {
+		runArgs = append(runArgs, "--rate-limit-read-burst", strconv.Itoa(serveRateLimitReadBurst))
+	}
+	if serveRateLimitWriteRPS != 0 {
+		runArgs = append(runArgs, "--rate-limit-write-rps", strconv.FormatFloat(serveRateLimitWriteRPS, 'g', -1, 64))
+	}
+	if serveRateLimitWriteBurst != 0 {
+		runArgs = append(runArgs, "--rate-limit-write-burst", strconv.Itoa(serveRateLimitWriteBurst))
+	}
+	if serveRateLimitCancelExempt != "" {
+		runArgs = append(runArgs, "--rate-limit-cancel-exempt", serveRateLimitCancelExempt)
 	}
 
 	// Ensure .forge directory exists

--- a/forge-cli/runtime/rate_limit.go
+++ b/forge-cli/runtime/rate_limit.go
@@ -1,0 +1,181 @@
+package runtime
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/initializ/forge/forge-cli/server"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// rateLimitEnvVars name the env var keys recognized by the runner.
+// Exposed as constants so the CLI flag wiring + the docs reference
+// the exact strings.
+const (
+	EnvRateLimitReadRPS      = "FORGE_RATE_LIMIT_READ_RPS"
+	EnvRateLimitReadBurst    = "FORGE_RATE_LIMIT_READ_BURST"
+	EnvRateLimitWriteRPS     = "FORGE_RATE_LIMIT_WRITE_RPS"
+	EnvRateLimitWriteBurst   = "FORGE_RATE_LIMIT_WRITE_BURST"
+	EnvRateLimitCancelExempt = "FORGE_RATE_LIMIT_CANCEL_EXEMPT"
+)
+
+// RateLimitOverride carries values from any one configuration layer
+// (CLI flags, env vars, or forge.yaml). Pointer-typed fields so the
+// resolver can distinguish "unset → fall through to next layer" from
+// "explicitly set to zero / false" (which must win over a non-zero
+// default). The cmd layer populates one of these per layer, the
+// resolver merges them in precedence order.
+type RateLimitOverride struct {
+	ReadRPS      *float64
+	ReadBurst    *int
+	WriteRPS     *float64
+	WriteBurst   *int
+	CancelExempt *bool
+}
+
+// ResolveRateLimit merges, in precedence order:
+//
+//  1. CLI override (the *RateLimitOverride passed in by the cmd layer)
+//  2. FORGE_RATE_LIMIT_* env vars
+//  3. cfg.Server.RateLimit from forge.yaml
+//  4. server.defaultRateLimitConfig (the bumped FWS-10 defaults)
+//
+// Returned pointer is suitable for ServerConfig.RateLimit. nil means
+// "no overrides anywhere; let the server install its own defaults" —
+// the common case for a forge.yaml that doesn't mention rate limits.
+//
+// See issue #110 / FWS-10.
+func ResolveRateLimit(cfg *types.ForgeConfig, override *RateLimitOverride) *server.RateLimitConfig {
+	envLayer := rateLimitFromEnv()
+	yamlLayer := rateLimitFromYAML(cfg)
+
+	// An override struct with every field nil is the same as no
+	// override at all — the cmd layer can pass `&RateLimitOverride{}`
+	// without intending to override anything, and we don't want that
+	// to surface in the resolved config.
+	if override != nil && override.ReadRPS == nil && override.ReadBurst == nil &&
+		override.WriteRPS == nil && override.WriteBurst == nil && override.CancelExempt == nil {
+		override = nil
+	}
+
+	if override == nil && envLayer == nil && yamlLayer == nil {
+		return nil // no overrides at all → server installs its defaults
+	}
+
+	// Start from the FWS-10 defaults; subsequent layers overlay only
+	// the fields they explicitly set. Keep these literals in sync
+	// with server.defaultRateLimitConfig — that's the single source
+	// of truth, this is a copy so the resolver doesn't import a
+	// private symbol.
+	out := &server.RateLimitConfig{
+		ReadRPS:      1.0,
+		ReadBurst:    10,
+		WriteRPS:     1.0,
+		WriteBurst:   20,
+		CancelExempt: true,
+	}
+	applyLayer(out, yamlLayer)
+	applyLayer(out, envLayer)
+	applyLayer(out, override)
+	return out
+}
+
+// rateLimitFromYAML lifts the populated subset of cfg.Server.RateLimit
+// into a RateLimitOverride. Returns nil when every field is at its
+// zero value (an empty `server.rate_limit:` block or no block at
+// all).
+func rateLimitFromYAML(cfg *types.ForgeConfig) *RateLimitOverride {
+	if cfg == nil {
+		return nil
+	}
+	y := cfg.Server.RateLimit
+	if y.ReadRPS == 0 && y.ReadBurst == 0 && y.WriteRPS == 0 && y.WriteBurst == 0 && y.CancelExempt == nil {
+		return nil
+	}
+	out := &RateLimitOverride{CancelExempt: y.CancelExempt}
+	if y.ReadRPS != 0 {
+		v := y.ReadRPS
+		out.ReadRPS = &v
+	}
+	if y.ReadBurst != 0 {
+		v := y.ReadBurst
+		out.ReadBurst = &v
+	}
+	if y.WriteRPS != 0 {
+		v := y.WriteRPS
+		out.WriteRPS = &v
+	}
+	if y.WriteBurst != 0 {
+		v := y.WriteBurst
+		out.WriteBurst = &v
+	}
+	return out
+}
+
+// rateLimitFromEnv reads FORGE_RATE_LIMIT_* env vars into a layer.
+// Parse failures (e.g. `READ_RPS=abc`) silently skip that field —
+// the runner already warns at startup for malformed config; the env
+// path fails soft so a typo doesn't lock the agent out of starting.
+func rateLimitFromEnv() *RateLimitOverride {
+	out := &RateLimitOverride{}
+	anySet := false
+	if v := os.Getenv(EnvRateLimitReadRPS); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			out.ReadRPS = &f
+			anySet = true
+		}
+	}
+	if v := os.Getenv(EnvRateLimitReadBurst); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			out.ReadBurst = &n
+			anySet = true
+		}
+	}
+	if v := os.Getenv(EnvRateLimitWriteRPS); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			out.WriteRPS = &f
+			anySet = true
+		}
+	}
+	if v := os.Getenv(EnvRateLimitWriteBurst); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			out.WriteBurst = &n
+			anySet = true
+		}
+	}
+	if v := os.Getenv(EnvRateLimitCancelExempt); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			out.CancelExempt = &b
+			anySet = true
+		}
+	}
+	if !anySet {
+		return nil
+	}
+	return out
+}
+
+// applyLayer copies non-nil fields from src onto dst. nil = unset →
+// dst keeps whatever the previous layer wrote. Bool semantics: an
+// explicit `false` from a higher-precedence layer overrides a `true`
+// default — the pointer carries the explicit-set signal.
+func applyLayer(dst *server.RateLimitConfig, src *RateLimitOverride) {
+	if src == nil {
+		return
+	}
+	if src.ReadRPS != nil {
+		dst.ReadRPS = *src.ReadRPS
+	}
+	if src.ReadBurst != nil {
+		dst.ReadBurst = *src.ReadBurst
+	}
+	if src.WriteRPS != nil {
+		dst.WriteRPS = *src.WriteRPS
+	}
+	if src.WriteBurst != nil {
+		dst.WriteBurst = *src.WriteBurst
+	}
+	if src.CancelExempt != nil {
+		dst.CancelExempt = *src.CancelExempt
+	}
+}

--- a/forge-cli/runtime/rate_limit_test.go
+++ b/forge-cli/runtime/rate_limit_test.go
@@ -1,0 +1,140 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// FWS-10 / issue #110 resolver tests: CLI > env > yaml > defaults
+// precedence; pointer semantics for "explicitly set false" on
+// CancelExempt; zero-everything → nil → "use server defaults" path.
+
+func TestResolveRateLimit_NoOverrides_ReturnsNil(t *testing.T) {
+	// Bare forge.yaml + no env + no CLI → no overrides at all → nil
+	// so the server installs its built-in defaults.
+	cfg := &types.ForgeConfig{}
+	if got := ResolveRateLimit(cfg, nil); got != nil {
+		t.Errorf("expected nil (use server defaults), got %+v", got)
+	}
+}
+
+func TestResolveRateLimit_YAMLOnly_AppliesAndFillsDefaults(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{
+				WriteBurst: 50, // set just one field
+			},
+		},
+	}
+	got := ResolveRateLimit(cfg, nil)
+	if got == nil {
+		t.Fatal("expected non-nil resolution when yaml sets a field")
+	}
+	if got.WriteBurst != 50 {
+		t.Errorf("WriteBurst = %d, want 50 (yaml override)", got.WriteBurst)
+	}
+	// Other fields fell through to the FWS-10 defaults.
+	if got.WriteRPS != 1.0 || got.ReadRPS != 1.0 || got.ReadBurst != 10 || !got.CancelExempt {
+		t.Errorf("expected defaults for un-overridden fields, got %+v", got)
+	}
+}
+
+func TestResolveRateLimit_EnvBeatsYAML(t *testing.T) {
+	t.Setenv(EnvRateLimitWriteRPS, "2.5")
+	cfg := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{
+				WriteRPS: 0.5, // yaml says 0.5 — env should win
+			},
+		},
+	}
+	got := ResolveRateLimit(cfg, nil)
+	if got == nil || got.WriteRPS != 2.5 {
+		t.Errorf("env (2.5) should beat yaml (0.5); got %+v", got)
+	}
+}
+
+func TestResolveRateLimit_CLIBeatsEnvBeatsYAML(t *testing.T) {
+	t.Setenv(EnvRateLimitWriteBurst, "33")
+	cfg := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{WriteBurst: 11},
+		},
+	}
+	cliBurst := 99
+	override := &RateLimitOverride{WriteBurst: &cliBurst}
+	got := ResolveRateLimit(cfg, override)
+	if got == nil || got.WriteBurst != 99 {
+		t.Errorf("CLI (99) should beat env (33) and yaml (11); got %+v", got)
+	}
+}
+
+func TestResolveRateLimit_ExplicitFalseCancelExemptWins(t *testing.T) {
+	// The default is true. yaml/env/CLI must each be able to flip
+	// it to false. Pointer-bool plumbing carries the "explicitly
+	// set" signal.
+
+	// yaml: false
+	yamlFalse := false
+	cfg := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{CancelExempt: &yamlFalse},
+		},
+	}
+	got := ResolveRateLimit(cfg, nil)
+	if got == nil || got.CancelExempt {
+		t.Errorf("yaml CancelExempt=false should override default true; got %+v", got)
+	}
+
+	// env: false (overrides yaml true)
+	t.Setenv(EnvRateLimitCancelExempt, "false")
+	yamlTrue := true
+	cfg2 := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{CancelExempt: &yamlTrue},
+		},
+	}
+	got2 := ResolveRateLimit(cfg2, nil)
+	if got2 == nil || got2.CancelExempt {
+		t.Errorf("env CancelExempt=false should beat yaml=true; got %+v", got2)
+	}
+
+	// CLI false beats env true.
+	t.Setenv(EnvRateLimitCancelExempt, "true")
+	cliFalse := false
+	override := &RateLimitOverride{CancelExempt: &cliFalse}
+	got3 := ResolveRateLimit(cfg2, override)
+	if got3 == nil || got3.CancelExempt {
+		t.Errorf("CLI CancelExempt=false should beat env=true; got %+v", got3)
+	}
+}
+
+func TestResolveRateLimit_MalformedEnvSilentlySkipped(t *testing.T) {
+	// A typo'd env value should not prevent the agent from starting;
+	// the field falls through to yaml/default as if unset.
+	t.Setenv(EnvRateLimitWriteRPS, "totally not a number")
+	cfg := &types.ForgeConfig{
+		Server: types.ServerConfig{
+			RateLimit: types.RateLimitYAML{WriteRPS: 7.0},
+		},
+	}
+	got := ResolveRateLimit(cfg, nil)
+	if got == nil || got.WriteRPS != 7.0 {
+		t.Errorf("malformed env should skip; yaml value (7.0) should win; got %+v", got)
+	}
+}
+
+func TestResolveRateLimit_PointerSemanticsForZeroValues(t *testing.T) {
+	// CLI passes ReadBurst=0 → that's a sentinel meaning "unset" in
+	// our pointer-typed override (the cmd layer only sets the
+	// pointer when the flag was actually passed). The resolver
+	// should keep the default (10).
+	override := &RateLimitOverride{} // all nil
+	got := ResolveRateLimit(&types.ForgeConfig{}, override)
+	// Since override is non-nil-but-empty AND there's no yaml/env,
+	// the resolver returns nil per the early-return rule:
+	if got != nil {
+		t.Errorf("empty override + no yaml + no env should still return nil; got %+v", got)
+	}
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -75,6 +75,13 @@ type RunnerConfig struct {
 	// flags default off (metadata-only audit). See issue #91 / FWS-8
 	// and docs/security/audit-logging.md#payload-capture-fws-8.
 	AuditPayloadCapture coreruntime.AuditPayloadCapture
+
+	// RateLimitOverride carries CLI-flag-derived overrides for the
+	// per-IP A2A rate limiter. Nil = no CLI overrides; the resolver
+	// will fall through to FORGE_RATE_LIMIT_* env vars and
+	// cfg.Server.RateLimit before defaulting to the FWS-10 baseline.
+	// See issue #110 / FWS-10.
+	RateLimitOverride *RateLimitOverride
 }
 
 // ScheduleNotifier is called after a scheduled task completes to deliver the
@@ -848,7 +855,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		corsOrigins = server.DefaultAllowedOrigins()
 	}
 
-	// 6. Create A2A server
+	// 6. Create A2A server. Rate limit resolution order
+	// (FWS-10 / issue #110): CLI flags > FORGE_RATE_LIMIT_* env >
+	// cfg.Server.RateLimit in forge.yaml > built-in defaults
+	// (60/min read+write, burst 10/20, tasks/cancel exempt). nil
+	// return means "no overrides anywhere" — let the server install
+	// its own defaults.
+	rateLimit := ResolveRateLimit(r.cfg.Config, r.cfg.RateLimitOverride)
 	r.startTime = time.Now()
 	srv := server.NewServer(server.ServerConfig{
 		Port:            r.cfg.Port,
@@ -857,6 +870,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		AgentCard:       card,
 		AuthMiddleware:  auth.Middleware(authCfg),
 		AllowedOrigins:  corsOrigins,
+		RateLimit:       rateLimit,
 	})
 
 	// 7. Register JSON-RPC handlers

--- a/forge-cli/server/a2a_server.go
+++ b/forge-cli/server/a2a_server.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net"
@@ -26,12 +28,31 @@ type Handler func(ctx context.Context, id any, rawParams json.RawMessage) *a2a.J
 // SSEHandler streams SSE events for a JSON-RPC request.
 type SSEHandler func(ctx context.Context, id any, rawParams json.RawMessage, w http.ResponseWriter, flusher http.Flusher)
 
-// RateLimitConfig controls per-IP rate limiting.
+// RateLimitConfig controls per-IP rate limiting on the A2A server.
+//
+// Defaults (see defaultRateLimitConfig): 60/min for both reads and
+// writes, with burst 10 / 20 respectively, and tasks/cancel exempt
+// from the write bucket entirely. The bumped write defaults (vs the
+// original #31 design of 10/min) reflect operational reality —
+// orchestrated parallel-task dispatch and cron-fire bursts blow past
+// the old 10/min in seconds. The cancel exemption is the most
+// important change: cancel is "stop doing work," it's the recovery
+// mechanism for runaway invocations, and throttling it amplifies the
+// problem it's trying to solve. See issue #110 / FWS-10.
 type RateLimitConfig struct {
 	ReadRPS    float64 // requests per second for read operations (GET/HEAD/OPTIONS)
 	ReadBurst  int     // burst size for reads
 	WriteRPS   float64 // requests per second for write operations (POST/PUT/DELETE)
 	WriteBurst int     // burst size for writes
+	// CancelExempt skips the write limiter for `tasks/cancel` JSON-RPC
+	// requests entirely. Default true. The cost-ceiling cancel-burst
+	// case (orchestrator firing N parallel cancels when a workflow
+	// budget trips) is the canonical example of why this exists —
+	// sharing the write bucket with tasks/send means the cancels are
+	// throttled at exactly the moment cancellation matters most.
+	// DoS via cancel-spam is naturally bounded by the registry's
+	// O(1) unknown-task lookup. See issue #110 / FWS-10.
+	CancelExempt bool
 }
 
 // ServerConfig configures the A2A HTTP server.
@@ -411,12 +432,20 @@ func isAddrInUse(err error) bool {
 }
 
 // defaultRateLimitConfig returns sensible defaults for the A2A server.
+//
+// Write defaults bumped from the original #31 design (10/min, burst 3)
+// to 60/min, burst 20 — large enough to absorb orchestrated
+// parallel-task dispatch and cron-fire bursts without silent throttling,
+// small enough to still bound anonymous-public-internet DoS at
+// 1 task/sec sustained. Cancel is exempt by default; see RateLimitConfig.
+// See issue #110 / FWS-10.
 func defaultRateLimitConfig() *RateLimitConfig {
 	return &RateLimitConfig{
-		ReadRPS:    1.0,         // ~60/min
-		ReadBurst:  10,          //
-		WriteRPS:   10.0 / 60.0, // ~10/min
-		WriteBurst: 3,           //
+		ReadRPS:      1.0, // 60/min
+		ReadBurst:    10,
+		WriteRPS:     1.0, // 60/min (was 10/60 ≈ 10/min)
+		WriteBurst:   20,  // (was 3)
+		CancelExempt: true,
 	}
 }
 
@@ -472,6 +501,20 @@ func rateLimitMiddleware(cfg *RateLimitConfig) func(http.Handler) http.Handler {
 				ip = host
 			}
 
+			// FWS-10: tasks/cancel exemption. Only POST requests to "/"
+			// carry a JSON-RPC envelope, so the peek is gated on that —
+			// no body-read for /healthz, /.well-known/*, GET /. The
+			// peek caps at 4 KiB so a malicious caller can't force the
+			// middleware to buffer a giant body; if the cap is hit
+			// without finding the method field, we fall back to the
+			// standard write classification.
+			if cfg.CancelExempt && r.Method == http.MethodPost && r.URL.Path == "/" {
+				if isTasksCancel(r) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
 			v := getVisitor(ip)
 			var limiter *rate.Limiter
 			switch r.Method {
@@ -491,6 +534,41 @@ func rateLimitMiddleware(cfg *RateLimitConfig) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// jsonRPCPeekCap bounds how many bytes the rate-limit middleware
+// reads off the request body when checking whether it's a tasks/cancel
+// call. 4 KiB is generous for the `method` field (typically the body
+// preamble is well under 100 bytes) without giving a malicious caller
+// a knob to force unbounded buffering.
+const jsonRPCPeekCap = 4 << 10
+
+// isTasksCancel returns true when the request body's JSON-RPC `method`
+// field is "tasks/cancel". The body is read up to jsonRPCPeekCap bytes
+// and then restored via io.NopCloser so downstream handlers see the
+// full payload. Any error (read failure, unparseable JSON, method
+// missing) returns false — the caller falls back to standard write
+// classification.
+func isTasksCancel(r *http.Request) bool {
+	if r.Body == nil {
+		return false
+	}
+	buf := make([]byte, jsonRPCPeekCap)
+	n, _ := io.ReadFull(r.Body, buf)
+	body := buf[:n]
+	// Drain any tail past the cap so r.Body.Close() doesn't leak the
+	// connection — and stitch the cap'd prefix back into a new reader.
+	rest, _ := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(append(body, rest...)))
+
+	var env struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return false
+	}
+	return env.Method == "tasks/cancel"
 }
 
 func init() {

--- a/forge-cli/server/a2a_server_ratelimit_test.go
+++ b/forge-cli/server/a2a_server_ratelimit_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+)
+
+// FWS-10 / issue #110 regression coverage:
+//   - bumped defaults (60/min, burst 20, cancel_exempt=true)
+//   - tasks/cancel exemption from the write bucket
+//   - per-IP isolation unaffected by the cancel branch
+//
+// These tests sit alongside the pre-FWS-10 TestRateLimitMiddleware_*
+// suite (which still passes — read-side behavior + 429 shape are
+// unchanged).
+
+// TestDefaultRateLimitConfig_LocksNewBaseline pins the FWS-10 default
+// shape so an accidental future change can't silently re-tighten it.
+func TestDefaultRateLimitConfig_LocksNewBaseline(t *testing.T) {
+	cfg := defaultRateLimitConfig()
+	if cfg.ReadRPS != 1.0 {
+		t.Errorf("ReadRPS = %v, want 1.0 (60/min)", cfg.ReadRPS)
+	}
+	if cfg.ReadBurst != 10 {
+		t.Errorf("ReadBurst = %d, want 10", cfg.ReadBurst)
+	}
+	if cfg.WriteRPS != 1.0 {
+		t.Errorf("WriteRPS = %v, want 1.0 (60/min — FWS-10 bumped from 10/60)", cfg.WriteRPS)
+	}
+	if cfg.WriteBurst != 20 {
+		t.Errorf("WriteBurst = %d, want 20 (FWS-10 bumped from 3)", cfg.WriteBurst)
+	}
+	if !cfg.CancelExempt {
+		t.Error("CancelExempt should default to true (FWS-10)")
+	}
+}
+
+// TestRateLimitMiddleware_NewDefaults_AllowsBurst20 confirms the
+// orchestrator-friendly write burst — 20 consecutive POSTs from the
+// same IP all pass before throttling kicks in.
+func TestRateLimitMiddleware_NewDefaults_AllowsBurst20(t *testing.T) {
+	cfg := defaultRateLimitConfig()
+	h := rateLimitMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/send", strings.NewReader(`{}`))
+		req.RemoteAddr = "10.0.0.1:1000"
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("burst write %d/20 returned %d (want 200) — write burst too tight", i+1, rec.Code)
+		}
+	}
+}
+
+// TestRateLimitMiddleware_CancelExempt_NotThrottled is the cost-
+// ceiling regression: even when the write bucket is fully drained,
+// tasks/cancel sails through. Without this the FWS-4 cancel-burst
+// scenario hits 429 at exactly the moment cancellation matters.
+func TestRateLimitMiddleware_CancelExempt_NotThrottled(t *testing.T) {
+	// Tight bucket so the write side throttles immediately.
+	cfg := &RateLimitConfig{
+		ReadRPS: 1.0, ReadBurst: 10,
+		WriteRPS: 0.001, WriteBurst: 1, // one write, then drained
+		CancelExempt: true,
+	}
+	h := rateLimitMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Drain the write bucket with one send.
+	send := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","method":"tasks/send","params":{}}`))
+	send.RemoteAddr = "10.0.0.2:1001"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, send)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first tasks/send should pass; got %d", rec.Code)
+	}
+
+	// Next tasks/send is throttled (bucket drained).
+	rec2 := httptest.NewRecorder()
+	send2 := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","method":"tasks/send","params":{}}`))
+	send2.RemoteAddr = "10.0.0.2:1001"
+	h.ServeHTTP(rec2, send2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second tasks/send should hit 429; got %d", rec2.Code)
+	}
+
+	// But tasks/cancel sails through the same IP's empty bucket.
+	for i := 0; i < 5; i++ {
+		body := `{"jsonrpc":"2.0","method":"tasks/cancel","params":{"id":"x"}}`
+		cancelReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+		cancelReq.RemoteAddr = "10.0.0.2:1001"
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, cancelReq)
+		if rec.Code != http.StatusOK {
+			t.Errorf("cancel %d should sail through even when write bucket is drained, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+// TestRateLimitMiddleware_CancelExemptOff_StillThrottles confirms the
+// flag does what it says: when CancelExempt is false, cancel uses the
+// write bucket like any other POST.
+func TestRateLimitMiddleware_CancelExemptOff_StillThrottles(t *testing.T) {
+	cfg := &RateLimitConfig{
+		ReadRPS: 1.0, ReadBurst: 10,
+		WriteRPS: 0.001, WriteBurst: 1,
+		CancelExempt: false,
+	}
+	h := rateLimitMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First cancel — fine.
+	body := `{"jsonrpc":"2.0","method":"tasks/cancel","params":{"id":"x"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "10.0.0.3:1002"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first cancel should pass; got %d", rec.Code)
+	}
+	// Second — throttled.
+	req2 := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req2.RemoteAddr = "10.0.0.3:1002"
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("with CancelExempt=false, second cancel should hit 429; got %d", rec2.Code)
+	}
+}
+
+// TestIsTasksCancel_RestoresBody is the body-restoration regression:
+// the peek consumes bytes off r.Body, then must reset r.Body so the
+// downstream handler can still read the JSON-RPC payload.
+func TestIsTasksCancel_RestoresBody(t *testing.T) {
+	body := `{"jsonrpc":"2.0","method":"tasks/cancel","params":{"id":"abc"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if !isTasksCancel(req) {
+		t.Fatal("expected isTasksCancel to detect tasks/cancel")
+	}
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(req.Body)
+	if buf.String() != body {
+		t.Errorf("body not restored after peek:\n  got:  %q\n  want: %q", buf.String(), body)
+	}
+}
+
+// TestIsTasksCancel_OtherMethodReturnsFalse confirms a non-cancel
+// JSON-RPC envelope falls through to the standard write classification.
+func TestIsTasksCancel_OtherMethodReturnsFalse(t *testing.T) {
+	body := `{"jsonrpc":"2.0","method":"tasks/send","params":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if isTasksCancel(req) {
+		t.Error("tasks/send must not be classified as cancel")
+	}
+}
+
+// TestIsTasksCancel_MalformedFailsClosed treats unparseable JSON as
+// "not cancel" so a malicious caller can't bypass the rate limiter
+// with a garbage body.
+func TestIsTasksCancel_MalformedFailsClosed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json"))
+	if isTasksCancel(req) {
+		t.Error("malformed body must NOT be classified as cancel (fail-closed)")
+	}
+}
+
+// Compile-time anchor: any future change that drops the a2a import
+// will break the package compile, signaling the test suite needs a
+// look. (a2a.NewErrorResponse is what rateLimitMiddleware emits on
+// 429.)
+var _ = a2a.NewErrorResponse

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -29,6 +29,29 @@ type ForgeConfig struct {
 	CORSOrigins    []string         `yaml:"cors_origins,omitempty"`
 	Package        PackageConfig    `yaml:"package,omitempty"`
 	GuardrailsPath string           `yaml:"guardrails_path,omitempty"` // path to guardrails.json (default: "guardrails.json")
+	Server         ServerConfig     `yaml:"server,omitempty"`
+}
+
+// ServerConfig groups A2A-server-side knobs that don't fit elsewhere
+// in the schema. Today it carries only the rate-limit sub-block; new
+// server-level concerns (TLS, request-size limits) belong here.
+// See issue #110 / FWS-10.
+type ServerConfig struct {
+	RateLimit RateLimitYAML `yaml:"rate_limit,omitempty"`
+}
+
+// RateLimitYAML mirrors the runtime RateLimitConfig but lives in
+// forge-core/types so it can be unmarshaled from forge.yaml without
+// importing forge-cli/server. The runner copies the populated fields
+// into the runtime RateLimitConfig. Zero values mean "use the
+// runtime default" — so an empty server.rate_limit block in
+// forge.yaml is equivalent to no block at all.
+type RateLimitYAML struct {
+	ReadRPS      float64 `yaml:"read_rps,omitempty"`
+	ReadBurst    int     `yaml:"read_burst,omitempty"`
+	WriteRPS     float64 `yaml:"write_rps,omitempty"`
+	WriteBurst   int     `yaml:"write_burst,omitempty"`
+	CancelExempt *bool   `yaml:"cancel_exempt,omitempty"` // pointer so "explicitly false" can override the true default
 }
 
 // MCPConfig declares Model Context Protocol servers for the agent.

--- a/forge-core/types/config_ratelimit_test.go
+++ b/forge-core/types/config_ratelimit_test.go
@@ -1,0 +1,74 @@
+package types
+
+import (
+	"testing"
+)
+
+// FWS-10 / issue #110: forge.yaml round-trip of the server.rate_limit
+// block. Locks the YAML tag names so a future rename doesn't silently
+// break operator configs.
+func TestParseForgeConfig_ServerRateLimitRoundTrip(t *testing.T) {
+	yaml := `
+agent_id: rl-test
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+server:
+  rate_limit:
+    read_rps: 0.5
+    read_burst: 5
+    write_rps: 2.0
+    write_burst: 50
+    cancel_exempt: false
+`
+	cfg, err := ParseForgeConfig([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rl := cfg.Server.RateLimit
+	if rl.ReadRPS != 0.5 {
+		t.Errorf("ReadRPS = %v, want 0.5", rl.ReadRPS)
+	}
+	if rl.ReadBurst != 5 {
+		t.Errorf("ReadBurst = %d, want 5", rl.ReadBurst)
+	}
+	if rl.WriteRPS != 2.0 {
+		t.Errorf("WriteRPS = %v, want 2.0", rl.WriteRPS)
+	}
+	if rl.WriteBurst != 50 {
+		t.Errorf("WriteBurst = %d, want 50", rl.WriteBurst)
+	}
+	if rl.CancelExempt == nil {
+		t.Fatal("CancelExempt should be non-nil (explicitly set to false)")
+	}
+	if *rl.CancelExempt {
+		t.Errorf("CancelExempt = true, want false (yaml said false)")
+	}
+}
+
+// TestParseForgeConfig_ServerBlockOptional: omitting `server:` is
+// fully backward compatible — every rate_limit field stays at the
+// zero value, signaling "use the runtime defaults".
+func TestParseForgeConfig_ServerBlockOptional(t *testing.T) {
+	yaml := `
+agent_id: noserver
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+`
+	cfg, err := ParseForgeConfig([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rl := cfg.Server.RateLimit
+	if rl.ReadRPS != 0 || rl.WriteRPS != 0 || rl.ReadBurst != 0 || rl.WriteBurst != 0 {
+		t.Errorf("expected zero-value rate_limit, got %+v", rl)
+	}
+	if rl.CancelExempt != nil {
+		t.Errorf("expected nil CancelExempt (unset), got %v", *rl.CancelExempt)
+	}
+}

--- a/scripts/manual-test-fws-10.sh
+++ b/scripts/manual-test-fws-10.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# manual-test-fws-10.sh — Validate rate-limit configurability + cancel
+# exemption (issue #110 / FWS-10).
+#
+# Three scenarios:
+#   1. Default-config write burst — 20 consecutive POSTs from one IP
+#      all pass. Pre-FWS-10 (burst=3) this would have hit 429 at #4.
+#   2. Cancel exemption — drain the write bucket via tight config,
+#      then fire 10 tasks/cancel requests. All 10 pass. Pre-FWS-10
+#      (or with cancel_exempt=false) cancel #2 would have hit 429.
+#   3. yaml override — server.rate_limit in forge.yaml raises burst
+#      to 50; the agent honors it on next start.
+#
+# Sandboxed: every binary, agent dir, and log lives under a tempdir.
+#
+# Run:    bash scripts/manual-test-fws-10.sh
+# Clean:  rm -rf $TMPDIR/forge-fws-10.*   (sandbox printed at end)
+
+set -euo pipefail
+
+WORKTREE="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX="$(mktemp -d -t forge-fws-10.XXXXXX)"
+FORGE_BIN="$SANDBOX/forge"
+AGENT_DIR="$SANDBOX/agent"
+PORT=18101
+
+trap 'echo; echo "Sandbox: $SANDBOX"; pkill -9 -f "$FORGE_BIN" 2>/dev/null || true' EXIT
+
+step() { printf '\n\033[1;34m════════ %s ════════\033[0m\n' "$*"; }
+sub()  { printf '  \033[1;33m›\033[0m %s\n' "$*"; }
+ok()   { printf '    \033[1;32m✓\033[0m %s\n' "$*"; }
+fail() { printf '    \033[1;31m✗ FAIL\033[0m %s\n' "$*"; }
+dump() { sed 's/^/      /'; }
+
+# ─── Build ───────────────────────────────────────────────────────────
+step "Build forge with -a (force full rebuild)"
+( cd "$WORKTREE/forge-cli/cmd/forge" && go build -a -o "$FORGE_BIN" . )
+
+# Helper: start forge in the background on a fresh port, wait until
+# /healthz responds, leave it running. Caller kills via pkill or by
+# returning the PID via stdout.
+# start_agent writes the spawned PID into the global AGENT_PID and
+# returns 0 on /healthz success, 1 otherwise. Using a global rather
+# than stdout dodges the `set -e + command substitution` gotcha that
+# was aborting the script on the first scenario.
+AGENT_PID=""
+start_agent() {
+  local logfile=$1
+  shift  # any extra args go straight to forge run
+  PORT=$((PORT + 1))
+  ( cd "$AGENT_DIR" && exec "$FORGE_BIN" run --port "$PORT" --mock-tools "$@" ) \
+    >"$logfile" 2>&1 &
+  AGENT_PID=$!
+  # Wait up to 10s for /healthz to respond. curl -m 1 leaves plenty of
+  # room for the first request after a fresh listen-socket — the
+  # tighter 200ms cap was a race on slow CI machines.
+  for _ in $(seq 1 20); do
+    if curl -s -m 1 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  kill -9 "$AGENT_PID" 2>/dev/null || true
+  AGENT_PID=""
+  return 1
+}
+
+stop_agent() {
+  if [ -n "$AGENT_PID" ]; then
+    kill -TERM "$AGENT_PID" 2>/dev/null || true
+    wait "$AGENT_PID" 2>/dev/null || true
+    AGENT_PID=""
+  fi
+  # Brief pause so the OS can release the port before the next
+  # scenario rebinds. macOS in particular keeps the port in TIME_WAIT
+  # for a moment after close.
+  sleep 0.6
+}
+
+token_for() {
+  cat "$AGENT_DIR/.forge/runtime.token" 2>/dev/null || echo ""
+}
+
+post_send() {
+  curl -s -o /dev/null -w "%{http_code}" -m 3 -X POST "http://127.0.0.1:$PORT/" \
+    -H "Authorization: Bearer $(token_for)" -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":"1","method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"kind":"text","text":"hi"}]}}}'
+}
+
+post_cancel() {
+  curl -s -o /dev/null -w "%{http_code}" -m 3 -X POST "http://127.0.0.1:$PORT/" \
+    -H "Authorization: Bearer $(token_for)" -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":"2","method":"tasks/cancel","params":{"id":"t1"}}'
+}
+
+# ─── Minimal agent ───────────────────────────────────────────────────
+mkdir -p "$AGENT_DIR"
+cat > "$AGENT_DIR/forge.yaml" <<'EOF'
+agent_id: fws10-test
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+egress:
+  mode: deny-all
+EOF
+
+# ─── 1. Default burst absorbs 20 writes ──────────────────────────────
+step "1. Default config: 20 consecutive POSTs all pass (write_burst=20)"
+start_agent "$SANDBOX/1.log" || { fail "agent failed to start"; exit 1; }
+pass=0; throttled=0
+for i in $(seq 1 20); do
+  code=$(post_send)
+  if [ "$code" = "200" ] || [ "$code" = "202" ]; then
+    pass=$((pass + 1))
+  elif [ "$code" = "429" ]; then
+    throttled=$((throttled + 1))
+  fi
+done
+stop_agent
+sub "passed: $pass / 20 ; throttled: $throttled"
+if [ "$pass" -ge 20 ] && [ "$throttled" -eq 0 ]; then
+  ok "burst-20 default absorbs orchestrator dispatch without throttling"
+else
+  fail "expected 20 passes / 0 throttles, got $pass / $throttled"
+fi
+
+# ─── 2. Cancel exemption: drain bucket, then cancel-spam ────────────
+step "2. Tight write bucket + cancel_exempt=true: 10 cancels pass after drain"
+start_agent "$SANDBOX/2.log" \
+        --rate-limit-write-rps 0.01 --rate-limit-write-burst 1 \
+        || { fail "agent failed to start"; exit 1; }
+# Drain the write bucket with one send.
+drain_code=$(post_send)
+sub "drain send: $drain_code"
+# Confirm the bucket is now drained — second send should be 429.
+second_code=$(post_send)
+sub "second send (expect 429): $second_code"
+# Now fire 10 cancels — all should pass.
+cancel_pass=0; cancel_429=0
+for i in $(seq 1 10); do
+  code=$(post_cancel)
+  if [ "$code" = "200" ] || [ "$code" = "202" ]; then cancel_pass=$((cancel_pass + 1));
+  elif [ "$code" = "429" ]; then cancel_429=$((cancel_429 + 1)); fi
+done
+stop_agent
+sub "cancel pass: $cancel_pass / 10 ; cancel 429: $cancel_429"
+if [ "$cancel_pass" -ge 10 ] && [ "$cancel_429" -eq 0 ]; then
+  ok "cancel sails through even with the write bucket fully drained"
+else
+  fail "expected 10 cancel passes / 0 throttles, got $cancel_pass / $cancel_429"
+fi
+
+# ─── 3. yaml override — server.rate_limit.write_burst = 50 ───────────
+step "3. forge.yaml server.rate_limit.write_burst = 50 → 50 sends pass"
+cat > "$AGENT_DIR/forge.yaml" <<'EOF'
+agent_id: fws10-test
+version: 0.0.1
+framework: forge
+model:
+  provider: ollama
+  name: llama3
+egress:
+  mode: deny-all
+server:
+  rate_limit:
+    write_burst: 50
+EOF
+start_agent "$SANDBOX/3.log" || { fail "agent failed to start"; exit 1; }
+pass=0
+set +e
+for i in $(seq 1 50); do
+  code=$(post_send)
+  if [ "$code" = "200" ] || [ "$code" = "202" ]; then pass=$((pass + 1)); fi
+done
+set -e
+stop_agent
+sub "passed: $pass / 50"
+if [ "$pass" -ge 50 ]; then
+  ok "yaml-configured write_burst=50 honored on startup"
+else
+  fail "expected 50 passes, got $pass"
+fi
+
+step "Logs preserved at $SANDBOX"
+ls "$SANDBOX"/*.log 2>/dev/null | dump || true


### PR DESCRIPTION
## Summary

Three orthogonal fixes to the per-IP A2A rate limiter from issue #31:

1. **New `server.rate_limit:` block in `forge.yaml`** + matching `--rate-limit-*` CLI flags on `forge run` / `forge serve start` + `FORGE_RATE_LIMIT_*` env vars. Resolution per field: **CLI > env > yaml > defaults**. Five knobs: `read_rps`, `read_burst`, `write_rps`, `write_burst`, `cancel_exempt`.
2. **Bumped write defaults** for orchestrated workloads — `WriteRPS` 10/min → 60/min, `WriteBurst` 3 → 20. Read defaults unchanged.
3. **`tasks/cancel` exempt from the write bucket by default.** The FWS-4 cost-ceiling cancel-burst case was hitting `-32603: rate limit exceeded` at exactly the moment cancellation matters most.

## Why

The original #31 defaults (60/min reads, **10/min writes, burst 3**) predate parallel workflow execution and cron bursts. A 10-step parallel stage was getting serialized after the 3rd dispatch (6 seconds per write at the sustained rate). A cron `forge.yaml` with multiple entries sharing a firing minute silently dropped the 4th+ task. And the kicker: when an orchestrator fires N parallel `tasks/cancel` against in-flight agents (cost ceiling tripped, workflow failure), those cancels share the write bucket — so the recovery mechanism throttles itself at exactly the wrong moment.

## What changed

| Field | Old default | New default | Reason |
|---|---|---|---|
| `ReadRPS` | 1.0 (60/min) | 1.0 (60/min) | unchanged — fine for status polling |
| `ReadBurst` | 10 | 10 | unchanged |
| `WriteRPS` | 10/60 ≈ 10/min | **1.0 (60/min)** | parallel dispatch needs 1/sec sustained |
| `WriteBurst` | 3 | **20** | absorbs orchestrator + cron bursts |
| `CancelExempt` | (didn't exist) | **`true`** | cancel is the recovery surface; throttling it is a footgun |

Operators with stricter threat models can lock down further via the new config surface. Example for a public-facing agent on the open internet is in the schema docs.

## Implementation

- **Middleware** peeks up to 4 KiB of the JSON-RPC body when the route is `POST /` to detect `tasks/cancel` (the only place that route accepts). Body is restored via `io.NopCloser` so the downstream handler sees the full payload. Malformed JSON / cap exhaustion **fail closed** — fall back to the standard write classification so a garbage body can't bypass the limiter.
- **Resolver** uses pointer-typed `RateLimitOverride` so "explicitly false" (e.g. `cancel_exempt: false`) can override a `true` default at any layer. An all-nil override + no yaml + no env returns nil so the server installs its own defaults — the common case for a bare `forge.yaml`.
- **Malformed env values are silently skipped** — a typo'd `FORGE_RATE_LIMIT_WRITE_RPS=abc` shouldn't lock the agent out of starting.

## Test plan

- [x] `go test -race -count=1 ./forge-cli/server/...` — 10 tests (3 pre-existing + 7 new): defaults baseline, burst-20 absorbs orchestrator dispatch, cancel exemption when on / off, body restoration, malformed-body fail-closed
- [x] `go test -race -count=1 ./forge-cli/runtime/...` — 7 new resolver tests: precedence chain, explicit-false at every layer, malformed env skipped, empty override → nil
- [x] `go test -count=1 ./forge-core/types/...` — 2 yaml round-trip tests: tag names locked, omitted `server:` is backward-compatible
- [x] Full forge-core + forge-cli + forge-ui + forge-plugins suites pass with `-race`
- [x] `gofmt -w` + `golangci-lint run` clean across all 4 modules
- [x] Manual end-to-end via `scripts/manual-test-fws-10.sh` — 3 sandboxed scenarios all PASS:
  1. **20 consecutive POSTs all pass** under default config (pre-FWS-10 the 4th hit 429)
  2. **Cancel exemption works under drain**: tight write bucket via flags → drain via 1 send → second send hits 429 as expected → 10 `tasks/cancel` all sail through
  3. **forge.yaml `server.rate_limit.write_burst: 50` honored on startup** — 50 sends pass

## Files

| File | Change |
|---|---|
| `forge-cli/server/a2a_server.go` | `RateLimitConfig.CancelExempt`; bumped `defaultRateLimitConfig`; middleware cancel-exemption branch + `isTasksCancel` helper |
| `forge-cli/runtime/rate_limit.go` (new) | `RateLimitOverride` + `ResolveRateLimit` resolver with CLI > env > yaml > defaults precedence |
| `forge-core/types/config.go` | `ServerConfig` on `ForgeConfig` + `RateLimitYAML` (with `*bool` `CancelExempt` for explicit-false semantics) |
| `forge-cli/runtime/runner.go` | `RunnerConfig.RateLimitOverride`; runner calls `ResolveRateLimit` and passes to `ServerConfig.RateLimit` |
| `forge-cli/cmd/run.go` + `serve.go` | `--rate-limit-*` flags + `FORGE_RATE_LIMIT_*` env binding; serve forwards to forked run |
| `docs/reference/forge-yaml-schema.md` | New "`server.rate_limit` — per-IP A2A rate limits (FWS-10)" section with per-field table + precedence + public-facing-agent example + per-IP grouping limitation callout |
| `CHANGELOG.md` | `Added` (new config surface) + `Changed` (default bump + cancel exemption with operator-facing impact) |
| `scripts/manual-test-fws-10.sh` (new) | 3-scenario sandboxed validation |

## Out of scope (per issue, intentional)

- **Auth-aware rate limiting** (per-user buckets keyed by `auth.user_id` instead of per-IP). Larger redesign; will be filed separately. The per-IP grouping limitation behind k8s service IPs is called out in the schema docs.
- **Distributed rate limiting** (Redis-backed for multi-pod agents). Out of scope for the single-binary runtime.
- **Adaptive rate limiting** that responds to system load. Premature optimization.

Closes #110.