### PR TITLE
fix(a2a): validate Message shape on tasks/send entry points — name the legacy `type` mistake (closes #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@
   `read_rps`, `read_burst`, `write_rps`, `write_burst`, `cancel_exempt`.
   See `docs/reference/forge-yaml-schema.md#serverrate_limit--per-ip-a2a-rate-limits-fws-10`.
 
+### Fixed
+
+- **`tasks/send` now rejects malformed messages at the entry point with a
+  clear diagnostic instead of letting the executor produce a confused
+  reply (issue #119).** The most common failure was a client sending the
+  pre-0.3.0 `"type": "text"` discriminator instead of the A2A 0.3.0
+  spec-correct `"kind": "text"`. `encoding/json` silently dropped the
+  unknown `type` field, leaving `Part.Kind` empty; the executor then
+  produced a reply like *"It looks like your message didn't come
+  through"* — confusing the caller about what actually went wrong.
+  New `Part.Validate()` and `Message.Validate()` (in `forge-core/a2a`)
+  catch this case along with empty `Kind` on a populated part,
+  unknown `Kind` values, missing `role`, and empty `parts` arrays.
+  The validator is invoked on all four `tasks/send` entry points
+  (JSON-RPC sync + SSE, REST sync + SSE) and returns
+  `JSON-RPC -32602 InvalidParams` / `HTTP 400` with the spec
+  divergence named in the message text — e.g. *"parts[0]: part kind
+  is required (A2A 0.3.0); got empty kind with non-empty content —
+  did you send `\"type\"` instead of `\"kind\"`? `\"type\"` is from
+  the pre-0.3.0 dialect and is silently ignored by the decoder"*.
+  Operators see a structured `Warn` log
+  (`tasks/send rejected: invalid message shape` with `task_id`,
+  `reason`, and `remote_addr`) so they can grep for clients still
+  emitting the legacy shape. Sentinel errors
+  (`ErrPartKindMissing`, `ErrPartKindUnknown`, `ErrMessageRoleMissing`,
+  `ErrMessagePartsEmpty`) are exposed for callers that want to branch
+  on the specific cause without parsing strings.
+
 ### Changed
 
 - **A2A server rate-limit defaults bumped for orchestrated workloads

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -931,6 +931,20 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		if err := json.Unmarshal(rawParams, &params); err != nil {
 			return a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, "invalid params: "+err.Error())
 		}
+		// Validate the message shape per A2A 0.3.0 (issue #119). The
+		// most common failure is a client sending `"type": "text"`
+		// instead of `"kind": "text"` — encoding/json silently drops
+		// the unknown field, Part.Kind stays "", and the executor
+		// downstream would respond with a confused "your message
+		// didn't come through" rather than name the spec divergence.
+		// Reject loudly with a diagnostic the operator can act on.
+		if err := params.Message.Validate(); err != nil {
+			r.logger.Warn("tasks/send rejected: invalid message shape", map[string]any{
+				"task_id": params.ID,
+				"reason":  err.Error(),
+			})
+			return a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, "invalid message: "+err.Error())
+		}
 		r.logger.Info("tasks/send", map[string]any{"task_id": params.ID})
 		// Delegate to executeTask so JSON-RPC and REST share the same
 		// audit + accumulator + invocation_complete wiring (issue #87 /
@@ -961,6 +975,20 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		var params a2a.SendTaskParams
 		if err := json.Unmarshal(rawParams, &params); err != nil {
 			server.WriteSSEEvent(w, flusher, "error", a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, err.Error())) //nolint:errcheck
+			return
+		}
+		// A2A 0.3.0 message-shape validation (issue #119). Same
+		// rationale as the JSON-RPC tasks/send path: reject malformed
+		// requests at the entry point with a clear diagnostic instead
+		// of letting the executor produce a confusing "didn't come
+		// through" reply.
+		if err := params.Message.Validate(); err != nil {
+			r.logger.Warn("tasks/sendSubscribe rejected: invalid message shape", map[string]any{
+				"task_id": params.ID,
+				"reason":  err.Error(),
+			})
+			server.WriteSSEEvent(w, flusher, "error", //nolint:errcheck
+				a2a.NewErrorResponse(id, a2a.ErrCodeInvalidParams, "invalid message: "+err.Error()))
 			return
 		}
 
@@ -1398,6 +1426,19 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 			ID:      body.Task.ID,
 			Message: body.Task.Message,
 		}
+		// A2A 0.3.0 message-shape validation (issue #119). Catches the
+		// pre-0.3.0 `type` vs `kind` discriminator mismatch + missing
+		// role / empty parts at the entry point so the executor never
+		// sees a malformed message.
+		if err := params.Message.Validate(); err != nil {
+			r.logger.Warn("REST /tasks/send rejected: invalid message shape", map[string]any{
+				"task_id":     params.ID,
+				"reason":      err.Error(),
+				"remote_addr": req.RemoteAddr,
+			})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid message: " + err.Error()})
+			return
+		}
 
 		// Pull workflow correlation headers (issue #86 / FWS-2) so audit
 		// events tagged via EmitFromContext carry the orchestrator's
@@ -1429,6 +1470,18 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 		}
 		if body.Task.ID == "" {
 			body.Task.ID = coreruntime.GenerateID()
+		}
+		// A2A 0.3.0 message-shape validation (issue #119). Reject before
+		// we commit SSE response headers — once Content-Type is set
+		// to text/event-stream the client expects a stream, not a 400.
+		if err := body.Task.Message.Validate(); err != nil {
+			r.logger.Warn("REST /tasks/sendSubscribe rejected: invalid message shape", map[string]any{
+				"task_id":     body.Task.ID,
+				"reason":      err.Error(),
+				"remote_addr": req.RemoteAddr,
+			})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid message: " + err.Error()})
+			return
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/forge-cli/runtime/runner_message_validation_test.go
+++ b/forge-cli/runtime/runner_message_validation_test.go
@@ -1,0 +1,223 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/auth"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// TestRunner_JSONRPC_TasksSend_RejectsLegacyTypeDiscriminator is the
+// regression test for issue #119 — the canonical scenario where an
+// operator hits a Forge dev runner with `curl` carrying parts that
+// use the pre-0.3.0 `"type"` discriminator instead of the spec-correct
+// `"kind"`. Pre-fix: 200 OK + a confused "your message didn't come
+// through" agent response. Post-fix: a clear JSON-RPC error
+// identifying the spec divergence so the caller can act on it without
+// reading source.
+func TestRunner_JSONRPC_TasksSend_RejectsLegacyTypeDiscriminator(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &types.ForgeConfig{
+		AgentID:    "msg-validation-jsonrpc",
+		Version:    "0.1.0",
+		Framework:  "forge",
+		Entrypoint: "python main.py",
+		Tools:      []types.ToolRef{{Name: "search"}},
+	}
+	port, err := findFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := NewRunner(RunnerConfig{
+		Config: cfg, WorkDir: dir, Port: port, MockTools: true,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL, 5*time.Second)
+	token, _ := auth.LoadToken(dir)
+
+	// Exact payload shape from issue #119: parts use `"type"` instead
+	// of `"kind"`. encoding/json drops `type` (the Part struct only
+	// knows `kind`), so the Part decodes with empty Kind + populated
+	// Text. Pre-fix: the executor saw a kind-less part and the LLM
+	// produced a confused reply. Post-fix: Validate rejects.
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tasks/send",
+		"params": {
+			"id": "t-legacy-type",
+			"message": {
+				"role": "user",
+				"parts": [{ "type": "text", "text": "Reply with a one-line hello." }]
+			}
+		}
+	}`)
+	resp, err := authPost(baseURL+"/", token, body)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (JSON-RPC errors are still HTTP 200; the error is in the envelope)", resp.StatusCode)
+	}
+	var rpcResp a2a.JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if rpcResp.Error == nil {
+		t.Fatalf("expected a JSON-RPC error rejecting the malformed message; got result=%v", rpcResp.Result)
+	}
+	if rpcResp.Error.Code != a2a.ErrCodeInvalidParams {
+		t.Errorf("error.code = %d, want %d (InvalidParams)", rpcResp.Error.Code, a2a.ErrCodeInvalidParams)
+	}
+	// The error message must be actionable — name the spec divergence
+	// the operator's payload exhibited so they can fix it without
+	// digging through source. Anything that just says "invalid params"
+	// is a regression.
+	msg := rpcResp.Error.Message
+	for _, want := range []string{`"type"`, `"kind"`, "pre-0.3.0"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error.message must name the type/kind mistake; want substring %q, got %q", want, msg)
+		}
+	}
+}
+
+// TestRunner_JSONRPC_TasksSend_SpecCompliantPayloadStillWorks confirms
+// the validator doesn't over-reject — the well-formed A2A 0.3.0 shape
+// continues to succeed end-to-end (status 200, no JSON-RPC error,
+// task in completed state). Without this companion test, an
+// over-eager validation rewrite that broke the happy path would
+// pass the rejection test above and ship.
+func TestRunner_JSONRPC_TasksSend_SpecCompliantPayloadStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &types.ForgeConfig{
+		AgentID:    "msg-validation-happy",
+		Version:    "0.1.0",
+		Framework:  "forge",
+		Entrypoint: "python main.py",
+		Tools:      []types.ToolRef{{Name: "search"}},
+	}
+	port, err := findFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := NewRunner(RunnerConfig{
+		Config: cfg, WorkDir: dir, Port: port, MockTools: true,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL, 5*time.Second)
+	token, _ := auth.LoadToken(dir)
+
+	// Same payload, but with the spec-correct `"kind"` discriminator.
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tasks/send",
+		"params": {
+			"id": "t-spec-correct",
+			"message": {
+				"role": "user",
+				"parts": [{ "kind": "text", "text": "Reply with a one-line hello." }]
+			}
+		}
+	}`)
+	resp, err := authPost(baseURL+"/", token, body)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var rpcResp a2a.JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rpcResp.Error != nil {
+		t.Fatalf("spec-correct payload must not produce an error; got %+v", rpcResp.Error)
+	}
+	resultBytes, _ := json.Marshal(rpcResp.Result)
+	var task a2a.Task
+	if err := json.Unmarshal(resultBytes, &task); err != nil {
+		t.Fatalf("unmarshal task: %v", err)
+	}
+	if task.Status.State != a2a.TaskStateCompleted {
+		t.Errorf("task state = %q, want %q", task.Status.State, a2a.TaskStateCompleted)
+	}
+}
+
+// TestRunner_JSONRPC_TasksSend_RejectsEmptyParts confirms the
+// validator catches the other Message-level shape failures: missing
+// role and empty parts array. Without this the validator could
+// regress to handling only the type-vs-kind case and miss the other
+// classes of malformed message Message.Validate documents.
+func TestRunner_JSONRPC_TasksSend_RejectsEmptyParts(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &types.ForgeConfig{
+		AgentID:    "msg-validation-empty-parts",
+		Version:    "0.1.0",
+		Framework:  "forge",
+		Entrypoint: "python main.py",
+		Tools:      []types.ToolRef{{Name: "search"}},
+	}
+	port, err := findFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := NewRunner(RunnerConfig{
+		Config: cfg, WorkDir: dir, Port: port, MockTools: true,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = runner.Run(ctx) }()
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL, 5*time.Second)
+	token, _ := auth.LoadToken(dir)
+
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tasks/send",
+		"params": {
+			"id": "t-empty-parts",
+			"message": { "role": "user", "parts": [] }
+		}
+	}`)
+	resp, err := authPost(baseURL+"/", token, body)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var rpcResp a2a.JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rpcResp.Error == nil {
+		t.Fatalf("empty parts must produce an error; got result=%v", rpcResp.Result)
+	}
+	if !strings.Contains(rpcResp.Error.Message, "parts") {
+		t.Errorf("error must name the parts violation; got %q", rpcResp.Error.Message)
+	}
+}

--- a/forge-core/a2a/validate.go
+++ b/forge-core/a2a/validate.go
@@ -1,0 +1,91 @@
+package a2a
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Errors returned by Validate. Exposed as sentinels so callers can
+// branch on them (e.g. emit a specific audit-event reason code or log
+// a dedicated counter) without parsing error strings.
+var (
+	// ErrPartKindMissing is returned when a Part has empty Kind. This
+	// is the canonical "you sent `type` instead of `kind`" signal —
+	// the wrapped error message names the likely mistake when the
+	// part has content despite the missing discriminator.
+	ErrPartKindMissing = errors.New("part kind is required")
+
+	// ErrPartKindUnknown is returned when a Part has a Kind value the
+	// runtime doesn't recognize. A2A 0.3.0 defines text / data / file.
+	ErrPartKindUnknown = errors.New("part kind is not one of text/data/file")
+
+	// ErrMessageRoleMissing is returned when a Message has no role.
+	ErrMessageRoleMissing = errors.New("message role is required")
+
+	// ErrMessagePartsEmpty is returned when a Message has zero parts.
+	// Some A2A clients emit empty parts arrays for heartbeat-style
+	// pings; Forge rejects those at the entry point so the executor
+	// never sees a message with nothing to interpret.
+	ErrMessagePartsEmpty = errors.New("message parts must contain at least one element")
+)
+
+// Validate reports whether the Part conforms to the A2A 0.3.0 shape.
+//
+// The most common failure — and the one this method was added to
+// surface clearly — is a Part that omits `kind`. encoding/json
+// silently drops unknown fields, so a client sending the pre-0.3.0
+// `type` discriminator gets a Part with Kind == "" and a populated
+// content field (Text / Data / File). Without explicit validation
+// the executor receives a part it can't classify and the LLM
+// responds with something like "It looks like your message didn't
+// come through" — confusing the caller about what actually went
+// wrong. See issue #119.
+//
+// The returned error wraps the sentinel (ErrPartKindMissing or
+// ErrPartKindUnknown) so callers can branch on the cause; the
+// wrapped message names the likely mistake when content is present.
+func (p Part) Validate() error {
+	if p.Kind == "" {
+		// A part with empty Kind but populated content didn't
+		// arrive that way honestly — it almost certainly came from
+		// a client sending the legacy `type` discriminator, which
+		// encoding/json dropped on the floor. Name the likely
+		// mistake in the error string so the operator's logs are
+		// self-explanatory.
+		if p.Text != "" || p.Data != nil || p.File != nil {
+			return fmt.Errorf(`%w (A2A 0.3.0); got empty kind with non-empty content — did you send "type" instead of "kind"? "type" is from the pre-0.3.0 dialect and is silently ignored by the decoder`, ErrPartKindMissing)
+		}
+		return fmt.Errorf("%w (A2A 0.3.0); got empty part", ErrPartKindMissing)
+	}
+	switch p.Kind {
+	case PartKindText, PartKindData, PartKindFile:
+		// Recognized kind. We intentionally do NOT require the
+		// matching content field to be non-empty — an empty text
+		// part is a legitimate A2A shape for placeholder /
+		// streaming-warmup turns and rejecting it would be
+		// over-strict.
+		return nil
+	default:
+		return fmt.Errorf("%w; got %q", ErrPartKindUnknown, p.Kind)
+	}
+}
+
+// Validate reports whether the Message conforms to the A2A 0.3.0
+// shape. Role must be non-empty, Parts must be non-empty, and every
+// part must Validate cleanly. The first failing part's error is
+// returned (wrapped with its index) so the caller can name the
+// offending position in their HTTP / JSON-RPC error message.
+func (m Message) Validate() error {
+	if m.Role == "" {
+		return ErrMessageRoleMissing
+	}
+	if len(m.Parts) == 0 {
+		return ErrMessagePartsEmpty
+	}
+	for i := range m.Parts {
+		if err := m.Parts[i].Validate(); err != nil {
+			return fmt.Errorf("parts[%d]: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/forge-core/a2a/validate_test.go
+++ b/forge-core/a2a/validate_test.go
@@ -1,0 +1,136 @@
+package a2a
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestPart_Validate_KindMissingWithContent_NamesLegacyTypeMistake is
+// the canonical regression test for issue #119: a client sending
+// `"type": "text"` produces a Part with empty Kind + non-empty Text,
+// and the validation error must say so in terms the operator can act
+// on without reading source.
+func TestPart_Validate_KindMissingWithContent_NamesLegacyTypeMistake(t *testing.T) {
+	// Simulate the exact bug 2 repro: JSON-decode a payload using the
+	// pre-0.3.0 `type` discriminator. encoding/json discards `type`
+	// because the Part struct only knows `kind`.
+	body := `{"type":"text","text":"Reply with a one-line hello."}`
+	var p Part
+	if err := json.Unmarshal([]byte(body), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Kind != "" {
+		t.Fatalf("expected Kind to be empty after legacy-type decode; got %q", p.Kind)
+	}
+	if p.Text == "" {
+		t.Fatalf("expected Text to be populated; got empty")
+	}
+
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("expected Validate to fail on empty Kind")
+	}
+	if !errors.Is(err, ErrPartKindMissing) {
+		t.Errorf("error should wrap ErrPartKindMissing; got %v", err)
+	}
+	msg := err.Error()
+	// The error must name the likely mistake explicitly so an operator
+	// reading it (or grepping their logs for it) understands what
+	// happened without diving into source.
+	for _, want := range []string{`"type"`, `"kind"`, "pre-0.3.0"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message must mention %q; got %q", want, msg)
+		}
+	}
+}
+
+func TestPart_Validate_KindMissingEmptyPart(t *testing.T) {
+	var p Part // zero value: Kind == "", no content
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("zero-value Part should fail Validate")
+	}
+	if !errors.Is(err, ErrPartKindMissing) {
+		t.Errorf("error should wrap ErrPartKindMissing; got %v", err)
+	}
+	// No content present → the error should NOT name the type-vs-kind
+	// mistake (a zero-value part isn't the legacy-dialect case).
+	if strings.Contains(err.Error(), `"type"`) {
+		t.Errorf("empty-part error should not speculate about legacy `type` field; got %q", err.Error())
+	}
+}
+
+func TestPart_Validate_KnownKindsPassThrough(t *testing.T) {
+	for _, kind := range []PartKind{PartKindText, PartKindData, PartKindFile} {
+		t.Run(string(kind), func(t *testing.T) {
+			p := Part{Kind: kind}
+			if err := p.Validate(); err != nil {
+				t.Errorf("kind=%q with no content should be valid (empty parts allowed); got %v", kind, err)
+			}
+		})
+	}
+}
+
+func TestPart_Validate_UnknownKindRejected(t *testing.T) {
+	p := Part{Kind: "image", Text: "hi"}
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("expected unknown kind to fail Validate")
+	}
+	if !errors.Is(err, ErrPartKindUnknown) {
+		t.Errorf("error should wrap ErrPartKindUnknown; got %v", err)
+	}
+	if !strings.Contains(err.Error(), `"image"`) {
+		t.Errorf("error should name the offending kind; got %q", err.Error())
+	}
+}
+
+func TestMessage_Validate_RoleRequired(t *testing.T) {
+	m := Message{Parts: []Part{{Kind: PartKindText, Text: "hi"}}}
+	err := m.Validate()
+	if !errors.Is(err, ErrMessageRoleMissing) {
+		t.Errorf("expected ErrMessageRoleMissing; got %v", err)
+	}
+}
+
+func TestMessage_Validate_PartsNonEmpty(t *testing.T) {
+	m := Message{Role: MessageRoleUser, Parts: nil}
+	err := m.Validate()
+	if !errors.Is(err, ErrMessagePartsEmpty) {
+		t.Errorf("expected ErrMessagePartsEmpty; got %v", err)
+	}
+}
+
+func TestMessage_Validate_NamesOffendingPartIndex(t *testing.T) {
+	m := Message{
+		Role: MessageRoleUser,
+		Parts: []Part{
+			{Kind: PartKindText, Text: "first"}, // valid
+			{Text: "second-but-no-kind"},        // invalid — empty Kind
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error from second part")
+	}
+	if !errors.Is(err, ErrPartKindMissing) {
+		t.Errorf("error should wrap the part-level sentinel; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "parts[1]") {
+		t.Errorf("error should name the offending part index; got %q", err.Error())
+	}
+}
+
+func TestMessage_Validate_HappyPath(t *testing.T) {
+	m := Message{
+		Role: MessageRoleUser,
+		Parts: []Part{
+			NewTextPart("Reply with a one-line hello."),
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("well-formed message should validate; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Forge's `tasks/send` accepted requests where `parts[]` used `"type": "text"` (a pre-A2A 0.3.0 dialect) instead of the spec-correct `"kind": "text"`. `encoding/json` silently dropped the unknown `type` field, `Part.Kind` stayed empty, and the executor produced a confused reply like *"It looks like your message didn't come through"* — 200 OK with no clue that the caller's payload was actually wrong.

This PR catches the spec divergence at the entry point and returns a clear `JSON-RPC -32602 InvalidParams` / `HTTP 400` naming the mistake.

## Repro (pre-fix, from #119)

```bash
curl -s -D - http://127.0.0.1:8080/ \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
        "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
        "params": {
          "id": "t-001",
          "message": { "role": "user",
                       "parts": [{ "type": "text", "text": "Reply with a one-line hello." }] }
        }
      }'
```

Pre-fix: 200 OK + *"It looks like your message didn't come through..."*

Post-fix:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32602,
    "message": "invalid message: parts[0]: part kind is required (A2A 0.3.0); got empty kind with non-empty content — did you send \"type\" instead of \"kind\"? \"type\" is from the pre-0.3.0 dialect and is silently ignored by the decoder"
  }
}
```

## Implementation

Two new methods in `forge-core/a2a`:

- **`Part.Validate()`** — requires non-empty `Kind`, recognizes `text`/`data`/`file`, and names the type-vs-kind mistake when content is present despite a missing discriminator (the canonical legacy case).
- **`Message.Validate()`** — requires non-empty `Role` and non-empty `Parts`, walks each part, wraps the failure with its index.

Four exported sentinel errors (`ErrPartKindMissing`, `ErrPartKindUnknown`, `ErrMessageRoleMissing`, `ErrMessagePartsEmpty`) so callers can branch on the cause without parsing strings.

Wire-up: `params.Message.Validate()` is invoked immediately after JSON unmarshal on **every** `tasks/send` entry point — JSON-RPC sync, JSON-RPC SSE, REST sync, and REST SSE. The REST SSE handler validates *before* committing the `text/event-stream` content-type (once committed, the client expects a stream — rejecting after would be a protocol surprise).

Each rejection emits a structured `Warn` line:

```
{"level":"warn","msg":"tasks/send rejected: invalid message shape",
 "reason":"parts[0]: ... did you send \"type\" instead of \"kind\"?",
 "task_id":"t-001","remote_addr":"[::1]:65232"}
```

Operators grep their **stdout** ops stream (FWS-9) for clients still emitting the legacy shape. No new audit event added — the schema stays clean.

## Why post-decode validate vs strict decoder

The filed issue laid out three options:

| Option | Trade-off |
|---|---|
| (A) `json.Decoder.DisallowUnknownFields()` | Catches the legacy `type` field but also rejects every other forward-compat extra field clients might add — too broad |
| **(B) Validate post-decode (this PR)** | Targeted at the exact divergence; decoder stays tolerant for unrelated extensions; diagnostic is actionable |
| (C) Accept `type` as legacy alias via custom `UnmarshalJSON` | Papers over the spec divergence; clients never learn they're sending the wrong field |

B wins: loud rejection on the case that hides a real bug, no surface-area change for unrelated extra fields.

## Behavior change

Clients sending the pre-0.3.0 `type` discriminator previously got a 200 OK + a confused agent reply. After this PR they get a JSON-RPC `InvalidParams` (or HTTP 400 on REST) naming the spec divergence. Any consumer relying on the silent-drop behavior was incorrect — the agent reply they were seeing was a broken-input artifact, not a legitimate response.

## Test plan

- [x] `go test -race ./forge-core/a2a/...` — green (9 new unit tests covering the canonical bug 2 repro, zero-value parts, each known kind, unknown kind, missing role, empty parts, offending-index naming)
- [x] `go test -race ./forge-cli/runtime/...` — green (3 new e2e tests on a real `Runner`):
  - `TestRunner_JSONRPC_TasksSend_RejectsLegacyTypeDiscriminator` — verbatim payload from #119
  - `TestRunner_JSONRPC_TasksSend_SpecCompliantPayloadStillWorks` — happy path stays happy
  - `TestRunner_JSONRPC_TasksSend_RejectsEmptyParts` — other Message-level shape failures
- [x] Full forge-core + forge-cli + forge-ui + forge-plugins suites pass with `-race`
- [x] `gofmt -w` + `golangci-lint run` clean (0 issues)

## Files

| File | Change |
|---|---|
| `forge-core/a2a/validate.go` (new) | `Part.Validate()` + `Message.Validate()` + four exported sentinel errors |
| `forge-cli/runtime/runner.go` | 4 entry points (JSON-RPC sync + SSE, REST sync + SSE) call `Validate()` post-decode, return clear errors, log structured `Warn` |
| `forge-core/a2a/validate_test.go` (new) | 9 unit tests covering the diagnostic paths |
| `forge-cli/runtime/runner_message_validation_test.go` (new) | 3 e2e tests on a real `Runner` |
| `CHANGELOG.md` | `Fixed` entry under Unreleased |

Closes #119.