### PR TITLE
feat(observability): span instrumentation across A2A → executor → tool (Phase 3, #104)

### DIFF
--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -426,7 +426,20 @@ func (r *Runner) Run(ctx context.Context) error {
 				Fields:        map[string]any{"domain": domain, "mode": string(egressCfg.Mode)},
 			})
 		}
-		egressClient = &http.Client{Transport: enforcer}
+		// Phase 3 (#104) — wrap the egress-enforced transport with
+		// otelhttp instrumentation so every outbound HTTP request the
+		// in-process clients (LLM providers, MCP, channels, OAuth)
+		// make through this client produces an "http.client" span
+		// automatically. The wrap also injects the OTel
+		// traceparent + baggage headers on outbound requests (Phase 0
+		// installed the composite propagator), which is the wire-level
+		// precursor to Phase 5 (#106) end-to-end propagation.
+		//
+		// When tracing is disabled the otelhttp wrapper is a near
+		// pass-through (the noop TracerProvider short-circuits span
+		// creation), so this is safe to always-wrap regardless of
+		// observability.tracing.enabled.
+		egressClient = &http.Client{Transport: observability.WrapHTTPTransport(enforcer)}
 
 		// Start local proxy for subprocess egress enforcement
 		if !security.InContainer() && egressCfg.Mode != security.ModeDevOpen {

--- a/forge-cli/server/a2a_server.go
+++ b/forge-cli/server/a2a_server.go
@@ -18,7 +18,11 @@ import (
 	"time"
 
 	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/observability"
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/time/rate"
 )
 
@@ -286,6 +290,34 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	ctx := coreruntime.WithWorkflowContext(r.Context(),
 		coreruntime.WorkflowContextFromHTTPHeaders(r.Header))
 
+	// Phase 3 (#104) — open the inbound dispatch span. Span name
+	// mirrors the JSON-RPC method ("a2a.tasks/send", "a2a.tasks/get",
+	// "a2a.tasks/cancel") so backend dashboards key by the same
+	// vocabulary the audit events use. When tracing is disabled the
+	// noop tracer returns a non-recording span and the SetAttributes /
+	// End calls are near-zero cost.
+	//
+	// The span sits ABOVE the SSE/handler branches so it covers both —
+	// streaming and unary methods share the same dispatch envelope.
+	// Per-iteration LLM and tool spans live in the executor (Phase 3
+	// continues in forge-core/runtime/loop.go); this is the root for
+	// every inbound A2A request.
+	ctx, span := coreruntime.Tracer().Start(ctx, "a2a."+req.Method,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(attribute.String(observability.AttrForgeA2AMethod, req.Method)),
+	)
+	defer span.End()
+	if wf := coreruntime.WorkflowContextFromContext(ctx); !wf.IsZero() {
+		// FWS-2 orchestrator correlation surfaces on the span so a
+		// trace browser can pivot from a workflow run to every Forge
+		// agent invocation that workflow triggered.
+		span.SetAttributes(
+			attribute.String(observability.AttrForgeWorkflowID, wf.WorkflowID),
+			attribute.String(observability.AttrForgeWorkflowStageID, wf.StageID),
+			attribute.String(observability.AttrForgeWorkflowStepID, wf.StepID),
+		)
+	}
+
 	// Check SSE handlers first (for streaming methods)
 	if h, ok := s.sseHandlers[req.Method]; ok {
 		flusher, ok := w.(http.Flusher)
@@ -311,10 +343,21 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		ctx = WithResponseHeaderStage(ctx)
 		resp := h(ctx, req.ID, req.Params)
 		DrainResponseHeaderStage(ctx, w.Header())
+		if resp != nil && resp.Error != nil {
+			// JSON-RPC errors surface as Error/Ok on the span (the
+			// HTTP response itself is still 200 — JSON-RPC semantics).
+			// Numeric code stays attribute-only; descriptive text goes
+			// on the status so trace browsers display it inline.
+			span.SetAttributes(attribute.Int("rpc.jsonrpc.error_code", resp.Error.Code))
+			span.SetStatus(codes.Error, resp.Error.Message)
+		}
 		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 
+	// Method not found also surfaces as a span error so an operator
+	// scanning traces sees the misroute without having to grep the body.
+	span.SetStatus(codes.Error, "method not found: "+req.Method)
 	writeJSON(w, http.StatusOK, a2a.NewErrorResponse(req.ID, a2a.ErrCodeMethodNotFound, "method not found: "+req.Method))
 }
 

--- a/forge-cli/server/a2a_server_spans_test.go
+++ b/forge-cli/server/a2a_server_spans_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// TestHandleJSONRPC_EmitsDispatchSpan pins the Phase 3 (#104) invariant:
+// every JSON-RPC inbound request produces a span named "a2a.<method>"
+// carrying the method name as forge.a2a.method, plus the FWS-2
+// workflow ids when the matching X-Workflow-* headers are present.
+//
+// The test installs a recording TracerProvider, fires a single request,
+// and asserts the resulting span's name, status, and attribute set.
+// Failing this means the inbound side of the trace tree is broken —
+// every downstream span (Phase 5 cross-process propagation, Phase 4
+// audit ↔ trace cross-linking) inherits from it.
+func TestHandleJSONRPC_EmitsDispatchSpan(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	srv.RegisterHandler("tasks/send", func(_ context.Context, id any, _ json.RawMessage) *a2a.JSONRPCResponse {
+		return a2a.NewResponse(id, map[string]string{"ok": "1"})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond); err == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "tasks/send", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(coreruntime.HeaderWorkflowID, "wf-xyz")
+	req.Header.Set(coreruntime.HeaderWorkflowStageID, "stage-1")
+	req.Header.Set(coreruntime.HeaderWorkflowStepID, "step-7")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Span was exported synchronously by the test provider.
+	span, ok := rec.FindSpan("a2a.tasks/send")
+	if !ok {
+		names := []string{}
+		for _, s := range rec.Spans() {
+			names = append(names, s.Name())
+		}
+		t.Fatalf("missing a2a.tasks/send span; recorded spans = %v", names)
+	}
+
+	var sawMethod, sawWF, sawStage, sawStep bool
+	for _, kv := range span.Attributes() {
+		switch string(kv.Key) {
+		case observability.AttrForgeA2AMethod:
+			if kv.Value.AsString() == "tasks/send" {
+				sawMethod = true
+			}
+		case observability.AttrForgeWorkflowID:
+			if kv.Value.AsString() == "wf-xyz" {
+				sawWF = true
+			}
+		case observability.AttrForgeWorkflowStageID:
+			if kv.Value.AsString() == "stage-1" {
+				sawStage = true
+			}
+		case observability.AttrForgeWorkflowStepID:
+			if kv.Value.AsString() == "step-7" {
+				sawStep = true
+			}
+		}
+	}
+	if !sawMethod {
+		t.Errorf("a2a span missing %s=tasks/send", observability.AttrForgeA2AMethod)
+	}
+	if !sawWF || !sawStage || !sawStep {
+		t.Errorf("a2a span missing FWS-2 workflow attrs (wf=%v stage=%v step=%v)", sawWF, sawStage, sawStep)
+	}
+	if span.Status().Code.String() != "Unset" {
+		t.Errorf("happy-path span status = %s; want Unset (only error paths set Error)", span.Status().Code.String())
+	}
+}
+
+// TestHandleJSONRPC_UnknownMethodSpanIsError confirms the dispatcher
+// records "method not found" as an Error status on the span so an
+// operator scanning the trace browser sees the misroute without
+// reading the body.
+func TestHandleJSONRPC_UnknownMethodSpanIsError(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond); err == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "no/such/method", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	span, ok := rec.FindSpan("a2a.no/such/method")
+	if !ok {
+		t.Fatal("missing a2a.no/such/method span")
+	}
+	if span.Status().Code.String() != "Error" {
+		t.Errorf("unknown-method span status = %s; want Error", span.Status().Code.String())
+	}
+}

--- a/forge-core/go.mod
+++ b/forge-core/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/initializ/forge/forge-skills v0.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
@@ -19,6 +20,7 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/forge-core/go.sum
+++ b/forge-core/go.sum
@@ -5,6 +5,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -40,6 +42,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 h1:CV7UdSGJt/Ao6Gp4CXckLxVRRsRgDHoI8XjbL3PDl8s=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0/go.mod h1:FRmFuRJfag1IZ2dPkHnEoSFVgTVPUd2qf5Vi69hLb8I=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=

--- a/forge-core/observability/attrs.go
+++ b/forge-core/observability/attrs.go
@@ -1,0 +1,101 @@
+package observability
+
+// Span attribute key constants Phase 3 (#104) instrumentation sites use.
+// Centralized so dashboards / alerts in the operator's backend can be
+// pinned to one source of truth — flipping an attribute name here is a
+// breaking change and shows up in CI diffs.
+//
+// Two groups:
+//
+//  1. Semconv pass-throughs — names the OpenTelemetry community has
+//     standardized. We re-declare them as constants here (rather than
+//     importing semconv for every call site) so an upgrade of semconv
+//     is a one-file mechanical sweep. The pinned-version constants
+//     stay byte-identical to semconv until we choose to bump.
+//
+//  2. Forge-specific keys — namespaced under `forge.*` to avoid
+//     collisions with vendor-supplied instrumentation. These don't
+//     have a semconv equivalent (forge_task.id is a Forge concept,
+//     not a generic OTel one).
+//
+// Span name conventions, separate from attributes, are documented at
+// each instrumentation site rather than centralized here — a span name
+// captures *what* operation is being measured ("a2a.tasks/send",
+// "llm.completion") and reads naturally inline.
+
+const (
+	// ─── GenAI semconv (draft, pinned to OTel semconv 1.26.0 GenAI). ──
+	// Backends like Honeycomb / Datadog / Grafana Tempo group LLM
+	// activity by these. Naming follows the OTel GenAI spec exactly.
+
+	// AttrGenAISystem identifies the LLM vendor: "anthropic",
+	// "openai", "ollama", "openai-compatible".
+	AttrGenAISystem = "gen_ai.system"
+
+	// AttrGenAIRequestModel is the model the agent ASKED for.
+	AttrGenAIRequestModel = "gen_ai.request.model"
+
+	// AttrGenAIResponseModel is the model the vendor REPORTED back.
+	// Often identical to the request, but enterprise routers can
+	// substitute (e.g. Anthropic returns a versioned suffix).
+	AttrGenAIResponseModel = "gen_ai.response.model"
+
+	// AttrGenAIUsageInputTokens / AttrGenAIUsageOutputTokens — counted
+	// directly from the provider's usage block. Drives cost
+	// dashboards.
+	AttrGenAIUsageInputTokens  = "gen_ai.usage.input_tokens"
+	AttrGenAIUsageOutputTokens = "gen_ai.usage.output_tokens"
+
+	// AttrGenAIResponseFinishReasons mirrors the Anthropic/OpenAI
+	// "stop_reason" / "finish_reason" — "stop", "tool_use",
+	// "max_tokens", "end_turn", etc.
+	AttrGenAIResponseFinishReasons = "gen_ai.response.finish_reasons"
+
+	// ─── Forge-specific attributes. ──────────────────────────────────
+
+	// AttrForgeAgentID is the agent_id from forge.yaml — the operator's
+	// primary identifier. Dashboards typically group by this first.
+	AttrForgeAgentID = "forge.agent.id"
+
+	// AttrForgeTaskID is the A2A task id (the same id surfaced in audit
+	// events and the X-Forge-Task-Id response header). Lets operators
+	// jump from an audit event to the corresponding trace.
+	AttrForgeTaskID = "forge.task.id"
+
+	// AttrForgeCorrelationID is the cross-process correlation id
+	// (X-Forge-Correlation-Id header). Survives across the dispatcher
+	// boundary so a span can be tied back to the inbound request.
+	AttrForgeCorrelationID = "forge.correlation_id"
+
+	// AttrForgeWorkflowID / Stage / Step are the FWS-2 orchestrator
+	// correlation ids extracted from inbound X-Workflow-* headers.
+	// Spans get these when the inbound request was issued by an
+	// orchestrator (otherwise the keys are absent — backends should
+	// treat missing keys as "ad-hoc invocation").
+	AttrForgeWorkflowID      = "forge.workflow.id"
+	AttrForgeWorkflowStageID = "forge.workflow.stage.id"
+	AttrForgeWorkflowStepID  = "forge.workflow.step.id"
+
+	// AttrForgeA2AMethod is the JSON-RPC method name on the inbound
+	// span — "tasks/send", "tasks/get", "tasks/cancel". Span name is
+	// also derived from this, but the explicit attribute simplifies
+	// querying.
+	AttrForgeA2AMethod = "forge.a2a.method"
+
+	// AttrForgeLoopIteration is the executor iteration counter on the
+	// agent.execute parent span — set after the loop finishes so
+	// dashboards can chart "iterations per task."
+	AttrForgeLoopIteration = "forge.loop.iteration"
+
+	// AttrForgeToolName / AttrForgeToolError name the tool call
+	// instrumentation. Tool args / results are NOT recorded here —
+	// Phase 3 is metadata-only. A future "capture_content=true with
+	// PII redaction" phase will add args/result attribute keys.
+	AttrForgeToolName  = "forge.tool.name"
+	AttrForgeToolError = "forge.tool.error"
+
+	// AttrForgeTaskFinalState is the terminal A2A TaskState the loop
+	// resolved to — "completed", "failed", "canceled". Set on the
+	// agent.execute span just before End.
+	AttrForgeTaskFinalState = "forge.task.final_state"
+)

--- a/forge-core/observability/httpclient.go
+++ b/forge-core/observability/httpclient.go
@@ -1,0 +1,39 @@
+package observability
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// WrapHTTPTransport decorates an http.RoundTripper with OpenTelemetry
+// HTTP instrumentation. Every request the wrapped transport handles
+// produces an "http.client" span automatically — method, host,
+// status code, and trace-context injection come for free, with no
+// per-call-site changes.
+//
+// Wiring is one line at the runner setup point: after the egress
+// enforcer builds its transport, the runner passes it through this
+// wrapper before stashing the http.Client downstream code uses. LLM
+// providers / MCP clients / channel adapters that retrieve the
+// egress-enforced client therefore get HTTP-level spans for free.
+//
+// Nil-tolerant: passing nil returns nil so a caller that builds a
+// transport conditionally (and decided not to) doesn't have to guard.
+//
+// Span propagation: otelhttp.NewTransport reads the OTel global
+// TextMapPropagator (Phase 0 installs traceparent + baggage). The
+// outbound request therefore carries the parent span's
+// traceparent header automatically — Phase 5 (#106) end-to-end
+// propagation rides on this without further work here.
+//
+// The instrumentation honors the global TracerProvider, so when the
+// tracer is the noop (tracing disabled) the wrapper is effectively a
+// pass-through — no per-request overhead beyond a single interface
+// dispatch.
+func WrapHTTPTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		return nil
+	}
+	return otelhttp.NewTransport(base)
+}

--- a/forge-core/observability/testing.go
+++ b/forge-core/observability/testing.go
@@ -1,0 +1,104 @@
+package observability
+
+import (
+	"context"
+	"sync"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SpanRecorder is an in-memory sdktrace.SpanExporter for tests. It
+// captures every finished span and returns the captured slice on
+// demand so test assertions can pin span hierarchy, attributes, and
+// status without spinning up a real collector.
+//
+// Production code must NEVER use this — the recorder retains every
+// span forever. Phase 3 instrumentation tests (#104) and any future
+// phase that asserts on spans use it via NewTestTracerProvider.
+type SpanRecorder struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+// ExportSpans implements sdktrace.SpanExporter.
+func (r *SpanRecorder) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	r.mu.Lock()
+	r.spans = append(r.spans, spans...)
+	r.mu.Unlock()
+	return nil
+}
+
+// Shutdown implements sdktrace.SpanExporter. The recorder has no
+// background goroutines so Shutdown is a no-op; the test owns the
+// recorder's lifecycle.
+func (r *SpanRecorder) Shutdown(_ context.Context) error { return nil }
+
+// Spans returns a snapshot of every span recorded so far. Safe to call
+// from any goroutine; the returned slice does not share backing memory
+// with the recorder so a test may sort / mutate it freely.
+func (r *SpanRecorder) Spans() []sdktrace.ReadOnlySpan {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]sdktrace.ReadOnlySpan, len(r.spans))
+	copy(out, r.spans)
+	return out
+}
+
+// FindSpan returns the first recorded span whose name matches. Useful
+// when a test produces one span per name (the common case for
+// non-loop instrumentation). For loop sites (per-iteration spans of
+// the same name), iterate Spans() directly.
+func (r *SpanRecorder) FindSpan(name string) (sdktrace.ReadOnlySpan, bool) {
+	for _, s := range r.Spans() {
+		if s.Name() == name {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// FindSpans returns every recorded span whose name matches, in the
+// order spans were exported.
+func (r *SpanRecorder) FindSpans(name string) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range r.Spans() {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Reset clears every recorded span. Call between test sub-stages when
+// reusing the same recorder.
+func (r *SpanRecorder) Reset() {
+	r.mu.Lock()
+	r.spans = nil
+	r.mu.Unlock()
+}
+
+// NewTestTracerProvider constructs an sdktrace.TracerProvider that
+// records every span synchronously into the returned SpanRecorder.
+// The processor is *SimpleSpanProcessor* (not BatchSpanProcessor) so
+// tests do not need to call ForceFlush before reading recorded spans —
+// every span is exported on End.
+//
+// Sampler is AlwaysSample so a test can install the provider and
+// immediately get spans regardless of the production sampler default.
+//
+// Typical test setup:
+//
+//	tp, rec := observability.NewTestTracerProvider()
+//	coreruntime.SetTracerProvider(tp)
+//	defer coreruntime.ResetTracerProviderForTest()
+//	defer tp.Shutdown(context.Background())
+//	// ... exercise code under test ...
+//	got := rec.FindSpans("agent.execute")
+func NewTestTracerProvider() (*sdktrace.TracerProvider, *SpanRecorder) {
+	rec := &SpanRecorder{}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(rec),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	return tp, rec
+}

--- a/forge-core/observability/testing_test.go
+++ b/forge-core/observability/testing_test.go
@@ -1,0 +1,119 @@
+package observability
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// TestNewTestTracerProvider_RecordsSpans confirms the
+// SimpleSpanProcessor wiring: a span ended after the test installs the
+// provider is visible via Spans() immediately, no ForceFlush required.
+func TestNewTestTracerProvider_RecordsSpans(t *testing.T) {
+	tp, rec := NewTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tr := tp.Tracer("test")
+	_, span := tr.Start(context.Background(), "my-span")
+	span.SetAttributes(attribute.String("k", "v"))
+	span.End()
+
+	got := rec.Spans()
+	if len(got) != 1 {
+		t.Fatalf("recorded %d spans; want 1", len(got))
+	}
+	if got[0].Name() != "my-span" {
+		t.Errorf("Name() = %q; want %q", got[0].Name(), "my-span")
+	}
+	// Attribute set on the span survives to the exporter.
+	var foundK bool
+	for _, kv := range got[0].Attributes() {
+		if string(kv.Key) == "k" && kv.Value.AsString() == "v" {
+			foundK = true
+		}
+	}
+	if !foundK {
+		t.Error("attribute k=v not present on recorded span")
+	}
+}
+
+func TestSpanRecorder_FindSpanAndFindSpans(t *testing.T) {
+	tp, rec := NewTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	_, s := tr.Start(context.Background(), "alpha")
+	s.End()
+	_, s = tr.Start(context.Background(), "beta")
+	s.End()
+	_, s = tr.Start(context.Background(), "alpha")
+	s.End()
+
+	if _, ok := rec.FindSpan("alpha"); !ok {
+		t.Error("FindSpan(alpha) should find the first alpha")
+	}
+	if _, ok := rec.FindSpan("does-not-exist"); ok {
+		t.Error("FindSpan should miss for an unknown name")
+	}
+	if n := len(rec.FindSpans("alpha")); n != 2 {
+		t.Errorf("FindSpans(alpha) returned %d; want 2", n)
+	}
+	if n := len(rec.FindSpans("beta")); n != 1 {
+		t.Errorf("FindSpans(beta) returned %d; want 1", n)
+	}
+}
+
+func TestSpanRecorder_ResetClearsHistory(t *testing.T) {
+	tp, rec := NewTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	_, s := tr.Start(context.Background(), "one")
+	s.End()
+	if len(rec.Spans()) != 1 {
+		t.Fatal("setup precondition failed")
+	}
+	rec.Reset()
+	if len(rec.Spans()) != 0 {
+		t.Errorf("Reset() did not clear; %d spans left", len(rec.Spans()))
+	}
+}
+
+// TestWrapHTTPTransport_NilPassthrough — a nil base must return nil so
+// the runner can wrap conditionally without guarding the call site.
+func TestWrapHTTPTransport_NilPassthrough(t *testing.T) {
+	if WrapHTTPTransport(nil) != nil {
+		t.Error("WrapHTTPTransport(nil) must return nil for caller-guard-free wiring")
+	}
+}
+
+// TestWrapHTTPTransport_RoundTripsRequestAndCallsBase — minimal proof
+// the wrapper actually delegates to the wrapped transport. A more
+// thorough check (HTTP-client span name, attributes) belongs in
+// instrumentation-site tests that use the recorder.
+func TestWrapHTTPTransport_RoundTripsRequestAndCallsBase(t *testing.T) {
+	tp, _ := NewTestTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: WrapHTTPTransport(http.DefaultTransport)}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if hits.Load() != 1 {
+		t.Errorf("wrapped transport did not delegate to the base transport (hits=%d)", hits.Load())
+	}
+}

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/initializ/forge/forge-core/a2a"
 	"github.com/initializ/forge/forge-core/llm"
+	"github.com/initializ/forge/forge-core/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // ToolExecutor provides tool execution capabilities to the engine.
@@ -115,9 +118,52 @@ func NewLLMExecutor(cfg LLMExecutorConfig) *LLMExecutor {
 }
 
 // Execute processes a message through the LLM agent loop.
-func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Message) (*a2a.Message, error) {
+func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Message) (outMsg *a2a.Message, outErr error) {
 	if e.filesDir != "" {
 		ctx = WithFilesDir(ctx, e.filesDir)
+	}
+
+	// Phase 3 (#104) — open the agent-execution span. Parent (when
+	// present) is the inbound dispatch span set by
+	// forge-cli/server/a2a_server.go; otherwise this span is a root
+	// (the scheduler, channel adapters, and other non-A2A entry
+	// points run without a parent span). Final attributes
+	// (iteration count, final state) are stamped just before End via
+	// the deferred closure below — using named returns so the closure
+	// can read the actual returned error without us having to mutate
+	// finalState at every return site.
+	ctx, span := Tracer().Start(ctx, "agent.execute")
+	finalIter := 0
+	defer func() {
+		state := "completed"
+		switch {
+		case ctx.Err() != nil:
+			// Cancellation / deadline propagated up — distinct from a
+			// regular failure so the trace browser can group "operator
+			// cancelled" separately from "agent crashed."
+			state = "canceled"
+		case outErr != nil:
+			state = "failed"
+			span.RecordError(outErr)
+			span.SetStatus(codes.Error, outErr.Error())
+		}
+		span.SetAttributes(
+			attribute.Int(observability.AttrForgeLoopIteration, finalIter),
+			attribute.String(observability.AttrForgeTaskFinalState, state),
+		)
+		span.End()
+	}()
+	if task != nil && task.ID != "" {
+		span.SetAttributes(attribute.String(observability.AttrForgeTaskID, task.ID))
+	}
+	if cid := CorrelationIDFromContext(ctx); cid != "" {
+		span.SetAttributes(attribute.String(observability.AttrForgeCorrelationID, cid))
+	}
+	if e.provider != "" {
+		span.SetAttributes(attribute.String(observability.AttrGenAISystem, e.provider))
+	}
+	if e.modelName != "" {
+		span.SetAttributes(attribute.String(observability.AttrGenAIRequestModel, e.modelName))
 	}
 
 	mem := NewMemory(e.systemPrompt, e.charBudget, e.modelName)
@@ -219,6 +265,9 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 
 	// Agent loop
 	for i := 0; i < e.maxIter; i++ {
+		// Record iteration count on the outer span — the closure stamps
+		// the final value before End.
+		finalIter = i + 1
 		// Honor cancellation at iteration boundary. Returning ctx.Err()
 		// here propagates context.Canceled / DeadlineExceeded up to the
 		// runner, which maps it to TaskStateCanceled +
@@ -257,9 +306,24 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 		// AfterLLMCall hook can stamp duration_ms on the llm_call audit
 		// event and X-Forge-Duration-Ms header. See issue #87 / FWS-3.
 		llmStart := time.Now()
-		resp, err := e.client.Chat(ctx, req)
+		// Phase 3 (#104) — child span around the provider call. The
+		// span carries the same gen_ai.* attributes the audit event
+		// does so a backend can join the two by trace_id without a
+		// translation table. Span ends right after the response is
+		// observed (before AfterLLMCall hook) so the hook runs in the
+		// parent span's context — the hook is a Forge-internal step,
+		// not part of the LLM call's wall-clock measurement.
+		llmCtx, llmSpan := Tracer().Start(ctx, "llm.completion")
+		llmSpan.SetAttributes(
+			attribute.String(observability.AttrGenAISystem, e.provider),
+			attribute.String(observability.AttrGenAIRequestModel, e.modelName),
+		)
+		resp, err := e.client.Chat(llmCtx, req)
 		llmDuration := time.Since(llmStart)
 		if err != nil {
+			llmSpan.RecordError(err)
+			llmSpan.SetStatus(codes.Error, err.Error())
+			llmSpan.End()
 			// Cancellation is not a "something went wrong." When ctx was
 			// cancelled, the provider's error (whatever its concrete type
 			// — net/http wraps inconsistently across DNS / TLS / body
@@ -282,6 +346,18 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 			// Return user-friendly error (raw error is already logged via OnError hook)
 			return nil, fmt.Errorf("something went wrong while processing your request, please try again")
 		}
+		// Happy-path: stamp usage + finish_reason from the response,
+		// then close the span. Doing this BEFORE the AfterLLMCall hook
+		// keeps the hook's redaction / audit work outside the LLM
+		// span's duration — the span is the provider call alone.
+		llmSpan.SetAttributes(
+			attribute.Int(observability.AttrGenAIUsageInputTokens, resp.Usage.InputTokens),
+			attribute.Int(observability.AttrGenAIUsageOutputTokens, resp.Usage.OutputTokens),
+		)
+		if resp.FinishReason != "" {
+			llmSpan.SetAttributes(attribute.StringSlice(observability.AttrGenAIResponseFinishReasons, []string{resp.FinishReason}))
+		}
+		llmSpan.End()
 
 		// Fire AfterLLMCall hook
 		if err := e.hooks.Fire(ctx, AfterLLMCall, &HookContext{
@@ -483,11 +559,23 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 			// AfterToolExec hook can stamp duration_ms on the tool_exec
 			// audit event. See issue #87 / FWS-3.
 			toolStart := time.Now()
-			result, execErr := e.tools.Execute(ctx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
+			// Phase 3 (#104) — child span around the tool call. Span
+			// name is "tool.<tool_name>" so a flame graph groups tools
+			// by kind without a query. Tool args / results are NOT
+			// recorded as attributes here — Phase 3 is metadata-only;
+			// content capture lands when the FWS-8 redactor can be
+			// reused for spans.
+			toolCtx, toolSpan := Tracer().Start(ctx, "tool."+tc.Function.Name)
+			toolSpan.SetAttributes(attribute.String(observability.AttrForgeToolName, tc.Function.Name))
+			result, execErr := e.tools.Execute(toolCtx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
 			toolDuration := time.Since(toolStart)
 			if execErr != nil {
+				toolSpan.RecordError(execErr)
+				toolSpan.SetStatus(codes.Error, execErr.Error())
+				toolSpan.SetAttributes(attribute.String(observability.AttrForgeToolError, execErr.Error()))
 				result = fmt.Sprintf("Error executing tool %s: %s", tc.Function.Name, execErr.Error())
 			}
+			toolSpan.End()
 			iterResults = append(iterResults, toolIterResult{
 				Name:     tc.Function.Name,
 				Failed:   execErr != nil,

--- a/forge-core/runtime/loop_spans_test.go
+++ b/forge-core/runtime/loop_spans_test.go
@@ -1,0 +1,306 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/llm"
+	"github.com/initializ/forge/forge-core/observability"
+)
+
+// TestExecuteEmitsHappyPathSpanTree pins the Phase 3 (#104) instrumentation
+// shape: a single-turn task with one tool call produces three spans —
+// agent.execute (parent), llm.completion (1st turn), tool.<name>,
+// llm.completion (2nd turn after tool result). Failing this test means
+// the executor's span hierarchy regressed and dashboards keyed on it
+// will go blank silently.
+func TestExecuteEmitsHappyPathSpanTree(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	callCount := 0
+	client := &mockLLMClient{
+		chatFunc: func(ctx context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return &llm.ChatResponse{
+					Message: llm.ChatMessage{
+						Role: llm.RoleAssistant,
+						ToolCalls: []llm.ToolCall{{
+							ID:       "tc-1",
+							Type:     "function",
+							Function: llm.FunctionCall{Name: "echo", Arguments: `{"x":1}`},
+						}},
+					},
+					Usage:        llm.UsageInfo{InputTokens: 100, OutputTokens: 25},
+					FinishReason: "tool_calls",
+				}, nil
+			}
+			return &llm.ChatResponse{
+				Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "done"},
+				Usage:        llm.UsageInfo{InputTokens: 110, OutputTokens: 5},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	tools := &mockToolExecutor{
+		executeFunc: func(_ context.Context, _ string, _ json.RawMessage) (string, error) {
+			return "echoed", nil
+		},
+	}
+
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client:        client,
+		Tools:         tools,
+		MaxIterations: 5,
+		ModelName:     "claude-test",
+		Provider:      "anthropic",
+	})
+
+	task := &a2a.Task{ID: "task-happy"}
+	msg := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "hi"}}}
+	if _, err := exec.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Exactly one outer span.
+	root, ok := rec.FindSpan("agent.execute")
+	if !ok {
+		t.Fatal("missing agent.execute root span")
+	}
+
+	// Outer-span attributes — operator dashboards key by these.
+	gotTask := false
+	gotModel := false
+	gotState := ""
+	gotIter := -1
+	gotSystem := ""
+	for _, kv := range root.Attributes() {
+		switch string(kv.Key) {
+		case observability.AttrForgeTaskID:
+			if kv.Value.AsString() == "task-happy" {
+				gotTask = true
+			}
+		case observability.AttrGenAIRequestModel:
+			if kv.Value.AsString() == "claude-test" {
+				gotModel = true
+			}
+		case observability.AttrGenAISystem:
+			gotSystem = kv.Value.AsString()
+		case observability.AttrForgeTaskFinalState:
+			gotState = kv.Value.AsString()
+		case observability.AttrForgeLoopIteration:
+			gotIter = int(kv.Value.AsInt64())
+		}
+	}
+	if !gotTask {
+		t.Errorf("agent.execute missing %q", observability.AttrForgeTaskID)
+	}
+	if !gotModel {
+		t.Errorf("agent.execute missing %q", observability.AttrGenAIRequestModel)
+	}
+	if gotSystem != "anthropic" {
+		t.Errorf("agent.execute gen_ai.system = %q; want %q", gotSystem, "anthropic")
+	}
+	if gotState != "completed" {
+		t.Errorf("agent.execute final_state = %q; want %q", gotState, "completed")
+	}
+	if gotIter != 2 {
+		t.Errorf("agent.execute iteration = %d; want 2 (1 turn that produced tools + 1 turn that produced the answer)", gotIter)
+	}
+
+	// Two llm.completion spans (one per turn).
+	llmSpans := rec.FindSpans("llm.completion")
+	if len(llmSpans) != 2 {
+		t.Errorf("got %d llm.completion spans; want 2", len(llmSpans))
+	}
+	// Each llm.completion carries usage tokens — the Phase-3 conformance
+	// invariant the audit-event join relies on.
+	for _, s := range llmSpans {
+		var in, out int64
+		var sawSystem bool
+		for _, kv := range s.Attributes() {
+			switch string(kv.Key) {
+			case observability.AttrGenAIUsageInputTokens:
+				in = kv.Value.AsInt64()
+			case observability.AttrGenAIUsageOutputTokens:
+				out = kv.Value.AsInt64()
+			case observability.AttrGenAISystem:
+				sawSystem = true
+			}
+		}
+		if in == 0 || out == 0 {
+			t.Errorf("llm.completion missing usage tokens (in=%d out=%d)", in, out)
+		}
+		if !sawSystem {
+			t.Error("llm.completion missing gen_ai.system attribute")
+		}
+	}
+
+	// Exactly one tool.echo span.
+	toolSpans := rec.FindSpans("tool.echo")
+	if len(toolSpans) != 1 {
+		t.Errorf("got %d tool.echo spans; want 1", len(toolSpans))
+	}
+
+	// Parent relationships: every llm.completion and tool span's parent
+	// span id must equal the root agent.execute span's span id. This
+	// is the structural invariant trace browsers render the flame graph
+	// from.
+	rootSpanID := root.SpanContext().SpanID()
+	for _, s := range llmSpans {
+		if s.Parent().SpanID() != rootSpanID {
+			t.Errorf("llm.completion parent span id %s; want %s (agent.execute)", s.Parent().SpanID(), rootSpanID)
+		}
+	}
+	for _, s := range toolSpans {
+		if s.Parent().SpanID() != rootSpanID {
+			t.Errorf("tool span parent span id %s; want %s (agent.execute)", s.Parent().SpanID(), rootSpanID)
+		}
+	}
+}
+
+// TestExecuteRecordsLLMErrorOnSpan confirms that when the provider's
+// Chat() returns an error, the llm.completion span records it (status
+// = Error, error event present) AND the outer agent.execute span's
+// final_state is "failed."
+func TestExecuteRecordsLLMErrorOnSpan(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	client := &mockLLMClient{
+		chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+			return nil, errors.New("upstream 500")
+		},
+	}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client:        client,
+		Tools:         &mockToolExecutor{},
+		MaxIterations: 3,
+		ModelName:     "x",
+		Provider:      "openai",
+	})
+	_, err := exec.Execute(context.Background(),
+		&a2a.Task{ID: "task-err"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "hi"}}})
+	if err == nil {
+		t.Fatal("expected Execute to return an error")
+	}
+
+	llmSpan, ok := rec.FindSpan("llm.completion")
+	if !ok {
+		t.Fatal("missing llm.completion span")
+	}
+	if llmSpan.Status().Code.String() != "Error" {
+		t.Errorf("llm.completion status = %s; want Error", llmSpan.Status().Code.String())
+	}
+	if len(llmSpan.Events()) == 0 {
+		t.Error("llm.completion expected at least one event (RecordError)")
+	}
+
+	root, ok := rec.FindSpan("agent.execute")
+	if !ok {
+		t.Fatal("missing agent.execute span on error path")
+	}
+	for _, kv := range root.Attributes() {
+		if string(kv.Key) == observability.AttrForgeTaskFinalState {
+			if kv.Value.AsString() != "failed" {
+				t.Errorf("agent.execute final_state = %q; want %q", kv.Value.AsString(), "failed")
+			}
+		}
+	}
+}
+
+// TestExecuteRecordsToolErrorOnSpan confirms the tool.<name> span
+// captures Error status when the tool returns an error. The executor
+// keeps running (tool errors are surfaced as text to the LLM, not
+// fatal), so the agent.execute final_state should still be
+// "completed" — the tool span carries the failure detail.
+func TestExecuteRecordsToolErrorOnSpan(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	call := 0
+	client := &mockLLMClient{
+		chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+			call++
+			if call == 1 {
+				return &llm.ChatResponse{
+					Message: llm.ChatMessage{
+						Role: llm.RoleAssistant,
+						ToolCalls: []llm.ToolCall{{
+							ID:       "tc-1",
+							Type:     "function",
+							Function: llm.FunctionCall{Name: "broken", Arguments: `{}`},
+						}},
+					},
+					Usage:        llm.UsageInfo{InputTokens: 50, OutputTokens: 10},
+					FinishReason: "tool_calls",
+				}, nil
+			}
+			return &llm.ChatResponse{
+				Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "ok"},
+				Usage:        llm.UsageInfo{InputTokens: 60, OutputTokens: 3},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	tools := &mockToolExecutor{
+		executeFunc: func(_ context.Context, _ string, _ json.RawMessage) (string, error) {
+			return "", fmt.Errorf("tool exploded")
+		},
+	}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client:        client,
+		Tools:         tools,
+		MaxIterations: 3,
+		ModelName:     "x",
+		Provider:      "openai",
+	})
+	if _, err := exec.Execute(context.Background(),
+		&a2a.Task{ID: "task-tool-err"},
+		&a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "hi"}}}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	toolSpan, ok := rec.FindSpan("tool.broken")
+	if !ok {
+		t.Fatal("missing tool.broken span")
+	}
+	if toolSpan.Status().Code.String() != "Error" {
+		t.Errorf("tool.broken status = %s; want Error", toolSpan.Status().Code.String())
+	}
+	gotErrAttr := false
+	for _, kv := range toolSpan.Attributes() {
+		if string(kv.Key) == observability.AttrForgeToolError {
+			gotErrAttr = true
+		}
+	}
+	if !gotErrAttr {
+		t.Errorf("tool.broken missing %q attribute", observability.AttrForgeToolError)
+	}
+
+	// Outer span is "completed" — tool errors aren't fatal.
+	root, _ := rec.FindSpan("agent.execute")
+	for _, kv := range root.Attributes() {
+		if string(kv.Key) == observability.AttrForgeTaskFinalState && kv.Value.AsString() != "completed" {
+			t.Errorf("agent.execute final_state = %q; tool errors must not fail the task", kv.Value.AsString())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the **OpenTelemetry Tracing v1** initiative (#108) — the largest phase by surface area, and the first that actually produces spans in the operator's backend.

- Phase 0 (#101 / PR #122 / merged) shipped the tracer **seam**.
- Phase 1 (#102 / PR #123 / merged) shipped the OTLP **provider**.
- Phase 2 (#103 / PR #124 / merged) shipped the **config wiring**.
- **This PR** adds the **instrumentation** that produces spans across the hot path.

## Span tree this PR produces

```
a2a.<method>                             [server, forge-cli/server/a2a_server.go]
└── agent.execute                        [forge-core/runtime/loop.go]
    ├── llm.completion (× N turns)       [child per loop iteration]
    │   └── http.client (× per HTTP request, via otelhttp)
    └── tool.<tool_name> (× M calls)     [child per tool call]
        └── http.client (if the tool calls HTTP)
```

## What's in this PR

### 1. Inbound A2A dispatch — `forge-cli/server/a2a_server.go`

- Span name: `a2a.<method>` (e.g. `a2a.tasks/send`, `a2a.tasks/cancel`)
- `SpanKind = Server`
- Attributes: `forge.a2a.method`, plus `forge.workflow.id` / `stage.id` / `step.id` when the FWS-2 `X-Workflow-*` headers are present
- JSON-RPC errors set `Error` status on the span — including `method not found` so misroutes are visible without reading the body
- Covers **both** unary and SSE handler branches

### 2. Executor loop — `forge-core/runtime/loop.go` `LLMExecutor.Execute`

**Outer `agent.execute` span** — root for everything the task does.
- Attributes: `forge.task.id`, `forge.correlation_id`, `gen_ai.system`, `gen_ai.request.model`
- Final attrs stamped at `End` via a deferred closure: `forge.loop.iteration` and `forge.task.final_state` (`completed` / `failed` / `canceled`)
- Cancellation vs failure is inferred from `ctx.Err()` at defer time, so an operator-cancelled trace doesn't appear in "agent crashed" dashboards

**Per-turn `llm.completion` child span:**
- Attributes: `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`
- Provider error → `RecordError` + `Error` status

**Per-tool `tool.<tool_name>` sibling span:**
- Attributes: `forge.tool.name`, `forge.tool.error` (on failure)
- Tool errors do **not** fail the outer span — they surface to the LLM as text and the loop continues. The tool span carries the failure detail so an operator can pivot from a trace to the specific failed invocation.

**Hook layer runs outside the inner spans.** Spans measure only the provider/tool call itself, not the audit + duration bookkeeping that wraps them — same posture audit events have.

**Phase 3 is metadata-only.** Tool args / results, prompts, completions are **not** recorded as span attributes. The config schema's `CaptureContent` + `Redact` knobs (Phase 2) are plumbed but not honored by the instrumentation yet — content capture will reuse the FWS-8 audit redactor in a follow-up so the same PII scrub passes both pipelines.

### 3. Outbound HTTP via the egress-enforced client — `forge-cli/runtime/runner.go`

```go
egressClient = &http.Client{Transport: observability.WrapHTTPTransport(enforcer)}
```

- Every request through `egressClient` produces an `http.client` span automatically (method / host / status_code) with outbound `traceparent` + `baggage` header injection
- LLM providers, MCP, channels, OAuth — **all** inherit instrumentation without per-provider changes
- When tracing is disabled the otelhttp wrapper is a near pass-through (noop TracerProvider short-circuits span creation)
- The outbound `traceparent` injection is the **wire-level precursor to Phase 5** (#106) end-to-end propagation

## New helper package additions — `forge-core/observability/`

| File | Purpose |
|---|---|
| `attrs.go` | Span attribute key constants. Centralized so a backend dashboard pinned to `forge.task.id` survives any future rename — one edit here, CI catches divergence. |
| `testing.go` | `SpanRecorder` (in-memory `sdktrace.SpanExporter`) + `NewTestTracerProvider` helper. Uses `SimpleSpanProcessor` so tests don't need `ForceFlush`. |
| `httpclient.go` | `WrapHTTPTransport(rt)` — wraps an `http.RoundTripper` with `otelhttp.NewTransport`. Nil-tolerant. |

## Dependencies

`forge-core/go.mod`:
- `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0`
- `github.com/felixge/httpsnoop` (indirect, otelhttp middleware)

## Coverage (10 new tests)

- **`forge-core/observability/testing_test.go`** (5 tests): recorder semantics — exports happen synchronously, `FindSpan` / `FindSpans` work, `Reset` clears, `WrapHTTPTransport(nil)` is nil, wrapped transport delegates to the base.
- **`forge-core/runtime/loop_spans_test.go`** (3 tests):
  - Happy-path span tree: `agent.execute` parent + 2× `llm.completion` + 1× `tool.echo`, structural parent-child relationships pinned by `SpanContext().SpanID()` comparison.
  - LLM error path: `llm.completion` records `Error` status + outer `agent.execute` has `final_state="failed"`.
  - Tool error path: `tool.<name>` records `Error` status + outer `agent.execute` stays `final_state="completed"` because tool errors aren't fatal.
- **`forge-cli/server/a2a_server_spans_test.go`** (2 tests):
  - Happy-path dispatch span carries `forge.a2a.method` + FWS-2 workflow ids, status `Unset`.
  - Unknown method produces an `Error`-status span.

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean in `forge-core/` (all packages pass)
- [x] `go test -race ./...` clean in `forge-cli/` (all packages pass)
- [x] `golangci-lint run ./forge-core/...` → **0 issues**
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## What this unlocks

After this PR, a `forge run` with tracing enabled (per Phase 2) produces real spans in the configured collector. An operator can:

- See per-task traces in their backend, grouped by `forge.task.id`
- Chart LLM cost by `gen_ai.system` × `gen_ai.usage.*_tokens`
- See per-iteration LLM duration on the flame graph
- Pivot from a tool error to the specific tool invocation that failed
- Trace egress calls (HTTP method, host, status_code) to LLM / MCP / channel APIs

Phase 4 (#105) is next — audit ↔ trace cross-linking. It will stamp the current span's `trace_id` + `span_id` on audit events emitted from context, so an operator can pivot from an audit row to the parent trace and vice versa.

## Refs

- Closes #104 (Phase 3)
- Part of #108 (initiative)
- Builds on #101 / PR #122 (Phase 0), #102 / PR #123 (Phase 1), #103 / PR #124 (Phase 2)