### PR TITLE
feat(observability): audit ↔ trace cross-linking (Phase 4, #105)

### DIFF
--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Audit event type constants.
@@ -203,6 +205,27 @@ type AuditEvent struct {
 	// `id`, OpenAI `id`, etc.) — kept as an opaque debug-correlation
 	// handle, never used for cost attribution.
 	RequestID string `json:"request_id,omitempty"`
+
+	// TraceID + SpanID cross-link this audit event to the OTel trace
+	// the same logical operation produced (Phase 4 of the OTel
+	// Tracing v1 initiative — issue #105 / #108). Populated by
+	// EmitFromContext when the context carries a recording span;
+	// omitted when there is no span on the context or the tracer is
+	// the noop default (tracing disabled).
+	//
+	// Format: lowercase hex, matching W3C traceparent semantics —
+	// trace_id is 32 hex chars (128-bit), span_id is 16 hex chars
+	// (64-bit). Operators paste these directly into their trace
+	// backend's search box to pivot from an audit row to the parent
+	// trace, and vice versa.
+	//
+	// Backward compatibility: both fields use omitempty so consumers
+	// that have not been upgraded continue to see the pre-Phase-4
+	// shape verbatim (no trace_id / span_id keys at all). The
+	// AuditSchemaVersion is NOT bumped — adding optional fields is a
+	// schema-compatible change per the documented policy.
+	TraceID string `json:"trace_id,omitempty"`
+	SpanID  string `json:"span_id,omitempty"`
 
 	Fields map[string]any `json:"fields,omitempty"`
 }
@@ -404,6 +427,24 @@ func (a *AuditLogger) EmitFromContext(ctx context.Context, event AuditEvent) {
 	// See issue #91 / FWS-8.
 	if event.Sequence == 0 {
 		event.Sequence = NextSequence(ctx)
+	}
+	// Phase 4 (#105) — stamp the active span's trace_id + span_id when
+	// the context carries a recording span. SpanContext.IsValid() is
+	// false for both "no span at all" (Background context) and "noop
+	// span" (tracing disabled — the package-default tracer Phase 0
+	// installed), so the omitempty tag drops both keys whenever
+	// tracing isn't producing real spans. Net effect: when tracing is
+	// off the audit JSON is byte-identical to pre-Phase-4 output.
+	if event.TraceID == "" || event.SpanID == "" {
+		sc := trace.SpanFromContext(ctx).SpanContext()
+		if sc.IsValid() {
+			if event.TraceID == "" {
+				event.TraceID = sc.TraceID().String()
+			}
+			if event.SpanID == "" {
+				event.SpanID = sc.SpanID().String()
+			}
+		}
 	}
 	a.Emit(event)
 }

--- a/forge-core/runtime/audit_trace_link_test.go
+++ b/forge-core/runtime/audit_trace_link_test.go
@@ -1,0 +1,204 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/observability"
+)
+
+// TestEmitFromContext_StampsTraceIDsFromRecordingSpan pins the Phase 4
+// (#105) cross-link invariant: when the context carries a recording
+// span, the resulting audit event carries that span's trace_id and
+// span_id as lowercase-hex W3C-style strings. Operators paste these
+// directly into their backend (Tempo, Jaeger, Honeycomb) to pivot
+// from an audit row to the parent trace.
+func TestEmitFromContext_StampsTraceIDsFromRecordingSpan(t *testing.T) {
+	tp, _ := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	var buf bytes.Buffer
+	al := NewAuditLogger(&buf)
+
+	ctx, span := Tracer().Start(context.Background(), "test-span")
+	defer span.End()
+
+	al.EmitFromContext(ctx, AuditEvent{Event: AuditToolExec})
+
+	var got AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &got); err != nil {
+		t.Fatalf("decode: %v\nline: %s", err, buf.String())
+	}
+
+	wantTrace := span.SpanContext().TraceID().String()
+	wantSpan := span.SpanContext().SpanID().String()
+	if got.TraceID != wantTrace {
+		t.Errorf("trace_id = %q, want %q", got.TraceID, wantTrace)
+	}
+	if got.SpanID != wantSpan {
+		t.Errorf("span_id = %q, want %q", got.SpanID, wantSpan)
+	}
+	// Format conformance: lowercase hex, 32 chars / 16 chars per W3C
+	// traceparent. Pin both so a future change to a non-standard
+	// encoding (uppercase, dashed) is caught at CI.
+	if len(got.TraceID) != 32 || strings.ToLower(got.TraceID) != got.TraceID {
+		t.Errorf("trace_id must be 32-char lowercase hex; got %q", got.TraceID)
+	}
+	if len(got.SpanID) != 16 || strings.ToLower(got.SpanID) != got.SpanID {
+		t.Errorf("span_id must be 16-char lowercase hex; got %q", got.SpanID)
+	}
+}
+
+// TestEmitFromContext_OmitsTraceIDsWhenNoSpan confirms the backward-
+// compatibility invariant: an emit from a bare context.Background()
+// (no span on the context, tracer is the package-default noop)
+// produces JSON with NEITHER trace_id NOR span_id keys present.
+// Audit-event consumers that haven't been upgraded continue to see
+// the pre-Phase-4 shape byte-identically.
+func TestEmitFromContext_OmitsTraceIDsWhenNoSpan(t *testing.T) {
+	// Force the default noop tracer so the test doesn't inherit a
+	// recording provider from a sibling test in the same package.
+	ResetTracerProviderForTest()
+
+	var buf bytes.Buffer
+	al := NewAuditLogger(&buf)
+
+	al.EmitFromContext(context.Background(), AuditEvent{Event: AuditToolExec})
+
+	line := strings.TrimSpace(buf.String())
+	// JSON-level absence check — the keys must NOT appear in the
+	// serialized output (omitempty must drop them when zero-valued).
+	if strings.Contains(line, `"trace_id"`) {
+		t.Errorf("trace_id must be omitted when no span; got line: %s", line)
+	}
+	if strings.Contains(line, `"span_id"`) {
+		t.Errorf("span_id must be omitted when no span; got line: %s", line)
+	}
+}
+
+// TestEmitFromContext_NoopSpanProducesNoTraceIDs targets the specific
+// failure mode where tracing is "off" (noop provider installed) but
+// some code still calls Tracer().Start(...). The noop span's
+// SpanContext().IsValid() must be false → trace_id / span_id must be
+// omitted. Without this guard a Phase-2-disabled deploy would still
+// emit noisy invalid-id fields.
+func TestEmitFromContext_NoopSpanProducesNoTraceIDs(t *testing.T) {
+	ResetTracerProviderForTest()
+
+	var buf bytes.Buffer
+	al := NewAuditLogger(&buf)
+
+	ctx, span := Tracer().Start(context.Background(), "noop-span")
+	defer span.End()
+
+	al.EmitFromContext(ctx, AuditEvent{Event: AuditToolExec})
+
+	line := strings.TrimSpace(buf.String())
+	if strings.Contains(line, `"trace_id"`) || strings.Contains(line, `"span_id"`) {
+		t.Errorf("noop span must NOT produce trace_id/span_id (tracing-off invariant); got line: %s", line)
+	}
+}
+
+// TestEmitFromContext_ExplicitTraceIDsWin protects the "context is a
+// fallback, not an override" invariant the rest of EmitFromContext
+// already honors for CorrelationID / TaskID / WorkflowID. A caller
+// that pre-stamps TraceID/SpanID on the AuditEvent gets exactly those
+// values out — not the span's.
+func TestEmitFromContext_ExplicitTraceIDsWin(t *testing.T) {
+	tp, _ := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	var buf bytes.Buffer
+	al := NewAuditLogger(&buf)
+
+	ctx, span := Tracer().Start(context.Background(), "ambient")
+	defer span.End()
+
+	const explicitTrace = "deadbeefcafebabe1234567890abcdef"
+	const explicitSpan = "facefacefaceface"
+	al.EmitFromContext(ctx, AuditEvent{
+		Event:   AuditToolExec,
+		TraceID: explicitTrace,
+		SpanID:  explicitSpan,
+	})
+
+	var got AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.TraceID != explicitTrace {
+		t.Errorf("explicit trace_id was overwritten (got %q want %q)", got.TraceID, explicitTrace)
+	}
+	if got.SpanID != explicitSpan {
+		t.Errorf("explicit span_id was overwritten (got %q want %q)", got.SpanID, explicitSpan)
+	}
+}
+
+// TestEmitFromContext_TraceLinkMatchesEmittedSpanTree is the end-to-end
+// join check: an executor-style flow (parent span → child llm.completion
+// → audit emit) produces audit events whose span_id matches whichever
+// span was active at emit time. Pivots from a span's
+// gen_ai.usage.input_tokens attribute to the corresponding llm_call
+// audit row depend on this — they're the same logical event captured
+// in two pipelines.
+func TestEmitFromContext_TraceLinkMatchesEmittedSpanTree(t *testing.T) {
+	tp, _ := observability.NewTestTracerProvider()
+	SetTracerProvider(tp)
+	t.Cleanup(func() {
+		ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	var buf bytes.Buffer
+	al := NewAuditLogger(&buf)
+
+	ctx, parent := Tracer().Start(context.Background(), "agent.execute")
+	defer parent.End()
+
+	childCtx, child := Tracer().Start(ctx, "llm.completion")
+
+	// Emit from the CHILD context — the linked span_id must be the
+	// child's, not the parent's. Otherwise correlated dashboards would
+	// always pivot to the parent and lose the inner step.
+	al.EmitFromContext(childCtx, AuditEvent{Event: "llm_call"})
+	child.End()
+
+	// Then emit from the PARENT context after child ended — the
+	// linked span_id must be the parent's.
+	al.EmitFromContext(ctx, AuditEvent{Event: "invocation_complete"})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit lines, got %d:\n%s", len(lines), buf.String())
+	}
+
+	var llmCall, invComplete AuditEvent
+	_ = json.Unmarshal([]byte(lines[0]), &llmCall)
+	_ = json.Unmarshal([]byte(lines[1]), &invComplete)
+
+	parentTrace := parent.SpanContext().TraceID().String()
+	parentSpan := parent.SpanContext().SpanID().String()
+	childSpan := child.SpanContext().SpanID().String()
+
+	if llmCall.TraceID != parentTrace || invComplete.TraceID != parentTrace {
+		t.Errorf("both events must share parent trace_id; got llm=%q inv=%q want=%q",
+			llmCall.TraceID, invComplete.TraceID, parentTrace)
+	}
+	if llmCall.SpanID != childSpan {
+		t.Errorf("llm_call must link to child span; got %q want %q", llmCall.SpanID, childSpan)
+	}
+	if invComplete.SpanID != parentSpan {
+		t.Errorf("invocation_complete must link to parent span; got %q want %q", invComplete.SpanID, parentSpan)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the **OpenTelemetry Tracing v1** initiative (#108) — closes the gap between the two pipelines an operator already has: the audit stream and the trace stream.

- Phase 0 (#101 / PR #122 / merged) — tracer seam.
- Phase 1 (#102 / PR #123 / merged) — OTLP provider.
- Phase 2 (#103 / PR #124 / merged) — config wiring.
- Phase 3 (#104 / PR #125 / merged) — span instrumentation.
- **This PR** — audit events carry `trace_id` + `span_id` of the active span so an operator pivots between the two with a single copy-paste.

## What's in this PR

### 1. `forge-core/runtime/audit.go` `AuditEvent`

```go
// TraceID + SpanID cross-link this audit event to the OTel trace.
TraceID string `json:"trace_id,omitempty"`
SpanID  string `json:"span_id,omitempty"`
```

- Lowercase hex, **W3C traceparent format** — 32-char (128-bit) `trace_id`, 16-char (64-bit) `span_id`. Bytes-identical to what Tempo / Jaeger / Honeycomb show in their search boxes, so the audit value pastes directly.
- Both `omitempty`. **`AuditSchemaVersion` is NOT bumped** — the documented schema policy treats adding optional fields as backward-compatible.

### 2. `EmitFromContext` chokepoint

After the existing `CorrelationID` / `TaskID` / `Workflow*` / `Sequence` fallbacks:

```go
if event.TraceID == "" || event.SpanID == "" {
    sc := trace.SpanFromContext(ctx).SpanContext()
    if sc.IsValid() {
        if event.TraceID == "" { event.TraceID = sc.TraceID().String() }
        if event.SpanID  == "" { event.SpanID  = sc.SpanID().String() }
    }
}
```

`SpanContext.IsValid()` is **false** for both "no span at all" (bare `context.Background()`) **and** "noop span" (Phase 0's default provider, installed when tracing is disabled). The `omitempty` tag drops both keys in both cases — **when tracing is off the audit JSON is byte-identical to pre-Phase-4 output.**

Explicit `TraceID`/`SpanID` set on the `AuditEvent` take precedence over the context-derived values, mirroring the "context is a fallback, not an override" semantic the rest of `EmitFromContext` already honors.

### 3. Surface coverage

Every typed emit helper **already routes through `EmitFromContext`**:

- `EmitLLMCall`
- `EmitToolExec`
- `EmitInvocationComplete`
- `EmitInvocationCancelled`
- the egress allow/block emit in the runner's egress enforcer
- the JSON-RPC FWS-3 stamping path

A single change at the chokepoint propagates the link to every event in the audit pipeline without per-call-site edits.

## Coverage (5 new tests)

| Test | What it pins |
|---|---|
| `StampsTraceIDsFromRecordingSpan` | Recording span on ctx → `trace_id`/`span_id` stamped; lengths + casing pinned to W3C format |
| `OmitsTraceIDsWhenNoSpan` | Bare `context.Background()` → neither key appears in JSON (backward-compat invariant) |
| `NoopSpanProducesNoTraceIDs` | Noop provider + `Tracer().Start` → still no `trace_id`/`span_id`. Guards against a regression where `IsValid()`'s noop case stops being false |
| `ExplicitTraceIDsWin` | Caller-set values survive — fallback-not-override |
| `TraceLinkMatchesEmittedSpanTree` | End-to-end: parent → child `llm.completion` → audit emit. The audit row's `span_id` is the CHILD's — pivot from a `llm_call` row to the matching `llm.completion` span (which carries `gen_ai.usage.*` attrs) lands on the right node |

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean in `forge-core/` (all packages)
- [x] `go test -race ./...` clean in `forge-cli/` (all packages — audit JSON is backward-compatible by construction; nothing downstream needed updating)
- [x] `golangci-lint run ./forge-core/...` → **0 issues**
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## What this unlocks

| Pivot direction | How |
|---|---|
| audit row → trace | Paste an `llm_call` row's `trace_id` into Tempo's search box → land on `agent.execute` parent. Paste the `span_id` → land directly on the `llm.completion` child carrying matching `gen_ai.usage.input_tokens` / `output_tokens` |
| trace → audit row | Copy `trace_id` from a Tempo trace, grep the audit log for the corresponding row, get the FWS-8 payload metadata the trace doesn't carry |
| dashboards | Cost / compliance dashboards (audit) and latency / hierarchy dashboards (trace) share a join key for free |

## Test plan (post-merge smoke)

With Phase 2 tracing config enabled:

```sh
# fire a task at the agent
curl ...tasks/send -d '{...}' ...

# tail audit
tail -f .forge/audit.log | jq 'select(.event == "llm_call")'
# should now show trace_id and span_id fields:
# {
#   "event": "llm_call",
#   "trace_id": "4a8f95a0e1bedda42c9dd5350fb3b33a",
#   "span_id":  "f3c2...8a0d",
#   ...
# }

# paste trace_id into Tempo search → see the matching agent.execute trace
# paste span_id → land directly on the llm.completion child
```

With tracing disabled (default): audit JSON shows neither key — fully backward-compatible.

## Refs

- Closes #105 (Phase 4)
- Part of #108 (initiative)
- Builds on #101 / #102 / #103 / #104 (Phases 0-3)