### PR TITLE
feat(observability): end-to-end A2A trace propagation (Phase 5, #106)

### DIFF
--- a/forge-cli/server/a2a_server.go
+++ b/forge-cli/server/a2a_server.go
@@ -20,8 +20,10 @@ import (
 	"github.com/initializ/forge/forge-core/a2a"
 	"github.com/initializ/forge/forge-core/observability"
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/time/rate"
 )
@@ -281,13 +283,30 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Phase 5 (#106) — extract the inbound W3C tracecontext + baggage
+	// BEFORE wrapping with workflow context so the dispatcher span
+	// becomes a CHILD of the upstream caller's span when a
+	// `traceparent` header is present. Multi-hop A2A flows
+	// (orchestrator → agent → downstream agent) then display as a
+	// single trace in the backend instead of N disconnected roots.
+	//
+	// The propagator is the composite TraceContext + Baggage installed
+	// on the OTel global by Phase 0's SetTracerProvider. When the
+	// inbound request has NO traceparent header the propagator returns
+	// the ctx unchanged — and Tracer().Start below opens a new root,
+	// matching the pre-Phase-5 behavior verbatim.
+	ctx := otel.GetTextMapPropagator().Extract(
+		r.Context(),
+		propagation.HeaderCarrier(r.Header),
+	)
+
 	// Extract initializ orchestration headers (issue #86 / FWS-2) ONCE
 	// at the dispatch boundary so every downstream handler sees the
 	// same WorkflowContext via ctx without having to parse headers
 	// itself. Absent headers produce an IsZero WorkflowContext —
 	// audit events then omit the workflow fields, matching pre-FWS-2
 	// shape (backward compatible).
-	ctx := coreruntime.WithWorkflowContext(r.Context(),
+	ctx = coreruntime.WithWorkflowContext(ctx,
 		coreruntime.WorkflowContextFromHTTPHeaders(r.Header))
 
 	// Phase 3 (#104) — open the inbound dispatch span. Span name
@@ -301,7 +320,8 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	// streaming and unary methods share the same dispatch envelope.
 	// Per-iteration LLM and tool spans live in the executor (Phase 3
 	// continues in forge-core/runtime/loop.go); this is the root for
-	// every inbound A2A request.
+	// every inbound A2A request — OR a child of the upstream span
+	// when Phase 5's propagator extracted one above.
 	ctx, span := coreruntime.Tracer().Start(ctx, "a2a."+req.Method,
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attribute.String(observability.AttrForgeA2AMethod, req.Method)),

--- a/forge-cli/server/a2a_server_propagation_test.go
+++ b/forge-cli/server/a2a_server_propagation_test.go
@@ -1,0 +1,305 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+// waitForListen blocks until the given addr accepts a TCP connection,
+// or fails the test after 2s. Used by every propagation test below to
+// give the server's listener time to bind before firing the request.
+func waitForListen(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server did not start listening on %s within 2s", addr)
+}
+
+// baggageMemberValue extracts a single baggage member's value from
+// ctx. Returns the empty string when the member is absent — callers
+// then assert against the expected value with a == comparison.
+func baggageMemberValue(ctx context.Context, key string) string {
+	return baggage.FromContext(ctx).Member(key).Value()
+}
+
+// TestHandleJSONRPC_InboundTraceparent_AdoptsUpstreamTrace pins the
+// Phase 5 (#106) invariant: when an upstream caller sends a request
+// with a `traceparent` header, the dispatcher span MUST become a
+// child of that upstream span — same trace_id, parent span_id =
+// upstream span_id. Multi-hop A2A flows (orchestrator → agent →
+// downstream agent) then display as a single trace in the backend.
+//
+// Without this, every hop starts a new root trace, and the operator
+// has to manually correlate by correlation_id — defeating the point
+// of distributed tracing.
+func TestHandleJSONRPC_InboundTraceparent_AdoptsUpstreamTrace(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	srv.RegisterHandler("tasks/send", func(_ context.Context, id any, _ json.RawMessage) *a2a.JSONRPCResponse {
+		return a2a.NewResponse(id, map[string]string{"ok": "1"})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	waitForListen(t, addr)
+
+	// Synthesize a well-formed W3C traceparent header. Format:
+	//   <version>-<trace_id (32 hex)>-<parent_span_id (16 hex)>-<flags>
+	// The `01` flag means "sampled" — required for the inbound
+	// dispatch span to also be recorded.
+	const upstreamTraceID = "0af7651916cd43dd8448eb211c80319c"
+	const upstreamSpanID = "b7ad6b7169203331"
+	const traceparent = "00-" + upstreamTraceID + "-" + upstreamSpanID + "-01"
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "tasks/send", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("traceparent", traceparent)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	span, ok := rec.FindSpan("a2a.tasks/send")
+	if !ok {
+		t.Fatal("missing a2a.tasks/send span")
+	}
+	gotTrace := span.SpanContext().TraceID().String()
+	if gotTrace != upstreamTraceID {
+		t.Errorf("dispatcher span trace_id = %q; want %q (upstream's)", gotTrace, upstreamTraceID)
+	}
+	gotParent := span.Parent().SpanID().String()
+	if gotParent != upstreamSpanID {
+		t.Errorf("dispatcher span parent_span_id = %q; want %q (upstream's span_id)", gotParent, upstreamSpanID)
+	}
+	if !span.SpanContext().IsSampled() {
+		t.Error("dispatcher span must inherit the upstream's sampled flag")
+	}
+}
+
+// TestHandleJSONRPC_NoInboundTraceparent_StartsRoot confirms the
+// backward-compatibility invariant — when there is no `traceparent`
+// header, the dispatcher span is a fresh root, same as pre-Phase-5
+// behavior. Direct A2A invocations (no orchestrator above) must keep
+// working unchanged.
+func TestHandleJSONRPC_NoInboundTraceparent_StartsRoot(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	srv.RegisterHandler("tasks/send", func(_ context.Context, id any, _ json.RawMessage) *a2a.JSONRPCResponse {
+		return a2a.NewResponse(id, map[string]string{"ok": "1"})
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	waitForListen(t, addr)
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "tasks/send", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// Deliberately NO traceparent header.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	span, ok := rec.FindSpan("a2a.tasks/send")
+	if !ok {
+		t.Fatal("missing a2a.tasks/send span")
+	}
+	// A root span has an invalid (zero) parent span context.
+	if span.Parent().IsValid() {
+		t.Errorf("dispatcher must be a root span when no traceparent inbound; got parent %+v", span.Parent())
+	}
+	if !span.SpanContext().TraceID().IsValid() {
+		t.Error("dispatcher span must still have a valid (newly-generated) trace_id")
+	}
+}
+
+// TestHandleJSONRPC_MalformedTraceparent_StartsRoot guards against a
+// failure mode where a misformatted upstream header propagates a
+// broken context. The W3C propagator silently ignores malformed
+// traceparent values (returns the ctx unchanged); the dispatcher
+// must then start a fresh root span rather than carry the broken
+// context forward. Without this guard, an upstream bug ships a span
+// tree rooted on garbage.
+func TestHandleJSONRPC_MalformedTraceparent_StartsRoot(t *testing.T) {
+	tp, rec := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	srv.RegisterHandler("tasks/send", func(_ context.Context, id any, _ json.RawMessage) *a2a.JSONRPCResponse {
+		return a2a.NewResponse(id, map[string]string{"ok": "1"})
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	waitForListen(t, addr)
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "tasks/send", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("traceparent", "not-a-real-traceparent")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	span, ok := rec.FindSpan("a2a.tasks/send")
+	if !ok {
+		t.Fatal("missing a2a.tasks/send span")
+	}
+	if span.Parent().IsValid() {
+		t.Errorf("malformed traceparent must not produce a parented span; got parent %+v", span.Parent())
+	}
+}
+
+// TestHandleJSONRPC_InboundBaggage_PropagatesToHandlerContext confirms
+// the OTel baggage propagator (the other half of the composite
+// installed by Phase 0) also makes it through the dispatcher. Phase 5
+// is about end-to-end propagation; baggage is the standard channel
+// for application-level identifiers (tenant_id, user_id, ab_test
+// bucket) that need to travel with the trace context.
+func TestHandleJSONRPC_InboundBaggage_PropagatesToHandlerContext(t *testing.T) {
+	tp, _ := observability.NewTestTracerProvider()
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		coreruntime.ResetTracerProviderForTest()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	_ = lis.Close()
+
+	srv := NewServer(ServerConfig{
+		Port: port, Host: "127.0.0.1", ShutdownTimeout: 1 * time.Second,
+		AgentCard: &a2a.AgentCard{
+			Name: "test", URL: "http://x", Version: "0.1.0", ProtocolVersion: "0.3.0",
+		},
+	})
+	var capturedCtx context.Context
+	srv.RegisterHandler("test/echo", func(ctx context.Context, id any, _ json.RawMessage) *a2a.JSONRPCResponse {
+		capturedCtx = ctx
+		return a2a.NewResponse(id, map[string]string{"ok": "1"})
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Start(ctx) }()
+
+	addr := "127.0.0.1:" + itoaShim(port)
+	waitForListen(t, addr)
+
+	body, _ := json.Marshal(a2a.JSONRPCRequest{
+		JSONRPC: "2.0", Method: "test/echo", Params: json.RawMessage(`{}`), ID: "1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("baggage", "tenant_id=acme,ab_bucket=control")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if capturedCtx == nil {
+		t.Fatal("handler was not invoked")
+	}
+	// The ctx the handler sees must carry the upstream baggage so
+	// downstream outbound HTTP (through otelhttp on the egress
+	// transport) re-injects it on the next hop.
+	bag := baggageMemberValue(capturedCtx, "tenant_id")
+	if bag != "acme" {
+		t.Errorf("tenant_id baggage = %q; want %q", bag, "acme")
+	}
+	if v := baggageMemberValue(capturedCtx, "ab_bucket"); v != "control" {
+		t.Errorf("ab_bucket baggage = %q; want %q", v, "control")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 5 of the **OpenTelemetry Tracing v1** initiative (#108) — closes the last gap. When an upstream caller hits Forge with a `traceparent` header, the dispatcher span becomes a **child** of the upstream span instead of starting a new root.

- Phase 0 (#101 / PR #122 / merged) — tracer seam + propagator installed.
- Phase 1 (#102 / PR #123 / merged) — OTLP provider.
- Phase 2 (#103 / PR #124 / merged) — config wiring.
- Phase 3 (#104 / PR #125 / merged) — span instrumentation + outbound otelhttp on the egress transport.
- Phase 4 (#105 / PR #126 / merged) — audit ↔ trace cross-linking.
- **This PR** — inbound `traceparent` extract at the dispatcher.

## What changes (five lines)

`forge-cli/server/a2a_server.go` `handleJSONRPC`:

```go
ctx := otel.GetTextMapPropagator().Extract(
    r.Context(),
    propagation.HeaderCarrier(r.Header),
)
```

Then `Tracer().Start(ctx, "a2a.<method>", ...)` opens a span that is **automatically a child** of the extracted parent when a `traceparent` header was present, or a **fresh root** when there wasn't (or the header was malformed).

## What it unlocks

Multi-hop A2A flows display as a **single** trace in the backend:

```
orchestrator
    │  traceparent: 00-T-S1-01
    ▼
┌───────────────┐
│   forge agent │  span_id=S2, parent=S1   (a2a.tasks/send)
│      ▼        │  span_id=S3, parent=S2   (agent.execute)
│      ▼        │  span_id=S4, parent=S3   (llm.completion)
└──────│────────┘
       ▼  traceparent: 00-T-S2-01  ← otelhttp re-injects on outbound
                                      (Phase 3 wired the egress wrap)
┌───────────────┐
│  downstream   │  span_id=S5, parent=S2   (a2a.tasks/send)
│  forge agent  │
└───────────────┘
```

All five spans share `trace_id = T` and chain by `parent_span_id`. Operator sees **one connected flame graph** instead of five disconnected roots.

## Why it's only five lines

Wire-level work was already done in earlier phases:

- **Phase 0** installs the composite `TraceContext + Baggage` propagator on the OTel global, so propagator extract/inject calls "just work" against the standard W3C header format.
- **Phase 3** wraps the egress transport with `otelhttp` on the runner so outbound HTTP automatically injects the current span's `traceparent + baggage` on every request. The downstream agent's Phase-5 extract paired with this PR's Phase-5 extract completes the round-trip.

Phase 5 only adds the **inbound** extract — five lines that plug the last hole.

## Coverage (4 new tests)

| Test | What it pins |
|---|---|
| `InboundTraceparent_AdoptsUpstreamTrace` | Pinned upstream `trace_id`+`span_id` arrives via header; dispatcher span's `TraceID()` matches the upstream's, `Parent().SpanID()` matches the upstream `span_id`, sampled flag inherited |
| `NoInboundTraceparent_StartsRoot` | Backward compat: no traceparent → fresh root (`Parent().IsValid() == false`), same as pre-Phase-5 |
| `MalformedTraceparent_StartsRoot` | Defensive: invalid header → propagator returns ctx unchanged → dispatcher starts a root rather than carrying a broken context forward |
| `InboundBaggage_PropagatesToHandlerContext` | The other half of the composite propagator (baggage) also makes it through; handler ctx carries `tenant_id=acme,ab_bucket=control` so downstream outbound HTTP re-injects baggage on the next hop |

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean in `forge-core/` (all packages, no behavior change)
- [x] `go test -race ./...` clean in `forge-cli/` (all packages)
- [x] `golangci-lint run ./forge-core/...` → **0 issues**
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## Test plan (post-merge smoke)

Two agents, A → B. Configure both with tracing enabled. Fire a task at A that calls into B:

```sh
# Agent A on :8080, Agent B on :8081 — both pointed at the same collector

# Pretend to be an orchestrator: send a request to A with a known traceparent
TRACEPARENT="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
curl -H "Authorization: Bearer $TOKEN_A" \
     -H "Content-Type: application/json" \
     -H "traceparent: $TRACEPARENT" \
     -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send",
          "params":{"id":"t-multihop","message":{"role":"user","parts":[{"kind":"text","text":"Ask agent B"}]}}}' \
     http://localhost:8080/
```

In Tempo, search for `trace_id = 0af7651916cd43dd8448eb211c80319c`. You should see ONE trace with both agents' spans nested under the orchestrator's parent span.

## Refs

- Closes #106 (Phase 5)
- Part of #108 (initiative)
- Builds on #101 / #102 / #103 / #104 / #105 (Phases 0-4)