### PR TITLE
feat(observability): auto-allowlist OTLP collector in build + runtime egress (Phase 6, #107)

### DIFF
--- a/forge-cli/build/egress_stage.go
+++ b/forge-cli/build/egress_stage.go
@@ -31,12 +31,18 @@ func (s *EgressStage) Execute(ctx context.Context, bc *pipeline.BuildContext) er
 		}
 	}
 
-	// Merge auth + MCP domains into the explicit allowlist BEFORE
-	// resolving. Without this, an OIDC issuer or an MCP server URL
-	// configured in forge.yaml would be silently blocked at runtime.
+	// Merge auth + MCP + OTel collector domains into the explicit
+	// allowlist BEFORE resolving. Without this an OIDC issuer, MCP
+	// server URL, or OTLP collector configured in forge.yaml would be
+	// silently blocked at runtime — spans would accumulate in the
+	// BatchSpanProcessor queue and drop on shutdown timeout, leaving
+	// the operator with an inexplicably empty trace backend. Phase 6
+	// of OTel Tracing v1 (#107 / #108) closes the loop: "tracing on in
+	// forge.yaml" implies "tracing reaches the backend."
 	allowed := append([]string{}, cfg.AllowedDomains...)
 	allowed = append(allowed, security.AuthDomains(bc.Config.Auth)...)
 	allowed = append(allowed, security.MCPDomains(bc.Config.MCP)...)
+	allowed = append(allowed, security.OTelDomain(bc.Config.Observability.Tracing)...)
 
 	resolved, err := security.Resolve(cfg.Profile, cfg.Mode, allowed, toolNames, cfg.Capabilities)
 	if err != nil {

--- a/forge-cli/build/egress_stage_otel_test.go
+++ b/forge-cli/build/egress_stage_otel_test.go
@@ -1,0 +1,125 @@
+package build
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// TestEgressStage_OTelEndpointInAllowlist is the Phase 6 (#107) end-to-end
+// invariant: when forge.yaml has observability.tracing enabled with an
+// endpoint, the build pipeline's egress_allowlist.json carries the
+// collector hostname so the generated NetworkPolicy will admit OTLP
+// traffic. Without this, a deploy ships with tracing enabled but
+// silently fails to export — spans accumulate in the queue and drop
+// on shutdown timeout, leaving the operator with an empty trace
+// backend.
+func TestEgressStage_OTelEndpointInAllowlist(t *testing.T) {
+	tmpDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: tmpDir, WorkDir: tmpDir})
+	bc.Config = &types.ForgeConfig{
+		AgentID:    "test",
+		Version:    "1.0.0",
+		Entrypoint: "python main.py",
+		Egress: types.EgressRef{
+			Profile:        "standard",
+			Mode:           "allowlist",
+			AllowedDomains: []string{"api.example.com"},
+		},
+		Observability: types.ObservabilityConfig{
+			Tracing: types.TracingYAML{
+				Enabled:  true,
+				Endpoint: "https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces",
+			},
+		},
+	}
+	bc.Spec = &agentspec.AgentSpec{AgentID: "test"}
+
+	stage := &EgressStage{}
+	if err := stage.Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Read the generated allowlist file and confirm the collector
+	// hostname is present. We assert on the FILE rather than on the
+	// in-memory bc.EgressResolved because the file is what the
+	// k8s_stage downstream + the runtime egress matcher consume —
+	// regressing only the file would be invisible to a struct-only
+	// assertion.
+	data, err := os.ReadFile(filepath.Join(tmpDir, "compiled", "egress_allowlist.json"))
+	if err != nil {
+		t.Fatalf("read egress_allowlist.json: %v", err)
+	}
+	var got struct {
+		AllowedDomains []string `json:"allowed_domains"`
+		AllDomains     []string `json:"all_domains"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode allowlist: %v", err)
+	}
+
+	const want = "otel-collector.monitoring.svc.cluster.local"
+	if !contains(got.AllDomains, want) {
+		t.Errorf("all_domains missing collector host %q; got %v", want, got.AllDomains)
+	}
+	// The operator's manually-declared domain must still be present
+	// — Phase 6 adds the collector, it does not replace anything.
+	if !contains(got.AllDomains, "api.example.com") {
+		t.Errorf("explicit allowed_domains entry lost; got all_domains=%v", got.AllDomains)
+	}
+}
+
+// TestEgressStage_OTelDisabled_NoExtraEntry — the corollary backward-
+// compat check. A forge.yaml with no observability.tracing block (or
+// Enabled=false) must NOT inject anything new into the allowlist. The
+// pre-Phase-6 set of entries is preserved verbatim.
+func TestEgressStage_OTelDisabled_NoExtraEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: tmpDir, WorkDir: tmpDir})
+	bc.Config = &types.ForgeConfig{
+		AgentID:    "test",
+		Version:    "1.0.0",
+		Entrypoint: "python main.py",
+		Egress: types.EgressRef{
+			Profile:        "standard",
+			Mode:           "allowlist",
+			AllowedDomains: []string{"api.example.com"},
+		},
+		Observability: types.ObservabilityConfig{
+			Tracing: types.TracingYAML{
+				Enabled:  false,
+				Endpoint: "https://otel.example.com:4318/v1/traces",
+			},
+		},
+	}
+	bc.Spec = &agentspec.AgentSpec{AgentID: "test"}
+
+	stage := &EgressStage{}
+	if err := stage.Execute(context.Background(), bc); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "compiled", "egress_allowlist.json"))
+	var got struct {
+		AllDomains []string `json:"all_domains"`
+	}
+	_ = json.Unmarshal(data, &got)
+	if contains(got.AllDomains, "otel.example.com") {
+		t.Errorf("disabled tracing leaked collector host into allowlist; got %v", got.AllDomains)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -394,6 +394,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Same for MCP servers — without this, every HTTPS MCP call would
 	// be silently blocked. Mirror the AuthDomains pattern.
 	egressDomains = append(egressDomains, security.MCPDomains(r.cfg.Config.MCP)...)
+	// Phase 6 (#107 / #108) — same for the OTel collector. Without
+	// this, dev runs with `observability.tracing.enabled: true` and
+	// `egress.mode: allowlist` would silently drop spans on shutdown.
+	// Matches the build pipeline's egress_stage so `forge run` and
+	// `forge package`-then-deploy behave identically on the
+	// allowlist surface.
+	egressDomains = append(egressDomains, security.OTelDomain(r.cfg.Config.Observability.Tracing)...)
 	egressCfg, egressErr := security.Resolve(
 		r.cfg.Config.Egress.Profile,
 		r.cfg.Config.Egress.Mode,

--- a/forge-core/security/otel_domains.go
+++ b/forge-core/security/otel_domains.go
@@ -1,0 +1,49 @@
+package security
+
+import "github.com/initializ/forge/forge-core/types"
+
+// OTelDomain returns the hostname of the OTLP collector configured in
+// observability.tracing.endpoint, as a single-element slice ready to
+// be merged into the egress allowlist alongside AuthDomains and
+// MCPDomains.
+//
+// Why this exists (Phase 6 of OTel Tracing v1, #107 / #108):
+//
+//	Without this entry, a deployment with tracing enabled in
+//	forge.yaml ships a NetworkPolicy that blocks the OTLP exporter's
+//	outbound traffic — spans accumulate in the BatchSpanProcessor
+//	queue and silently drop on shutdown timeout. The operator sees a
+//	working `forge run` locally and an inexplicably empty trace
+//	backend in cluster. The build pipeline must inject the collector
+//	host into the allowlist automatically so "tracing on in
+//	forge.yaml" implies "tracing reaches the backend" without a
+//	second egress edit.
+//
+// The function returns nil when tracing is disabled, when no endpoint
+// is configured, or when the endpoint is unparseable — every "skip"
+// case yields an empty slice the caller appends as a no-op. A
+// malformed endpoint is NOT a build-time error here; the cli's tracing
+// resolver (Phase 2) is the single place that fails loudly on bad
+// configuration, and Phase 6 is intentionally tolerant so the build
+// stage can never block a deployment over telemetry config.
+//
+// Port stripping is handled by hostFromURL (see auth_domains.go for
+// the cross-package contract — every egress matcher callsite strips
+// the port from the OUTBOUND host before checking the allowlist, so a
+// hostname-only entry suffices for any port).
+//
+// Source tagging: this helper returns bare hostnames matching the
+// AuthDomains / MCPDomains convention. The egress_allowlist.json
+// shape does not currently carry per-domain source provenance — a
+// future allowlist schema upgrade could introduce a "source: otel"
+// tag, mirroring MCPDomainSources, without changing this helper.
+func OTelDomain(cfg types.TracingYAML) []string {
+	if !cfg.Enabled || cfg.Endpoint == "" {
+		return nil
+	}
+	host := hostFromURL(cfg.Endpoint)
+	if host == "" {
+		return nil
+	}
+	return []string{host}
+}

--- a/forge-core/security/otel_domains_test.go
+++ b/forge-core/security/otel_domains_test.go
@@ -1,0 +1,105 @@
+package security_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/security"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// TestOTelDomain_Empty pins the "no telemetry → no allowlist entry"
+// invariant: a forge.yaml with no observability.tracing block produces
+// no additions to the egress allowlist. Without this, an empty config
+// could spuriously inject "" (the empty hostname) and break matcher
+// resolution downstream.
+func TestOTelDomain_Empty(t *testing.T) {
+	if got := security.OTelDomain(types.TracingYAML{}); got != nil {
+		t.Errorf("OTelDomain(empty) = %v, want nil", got)
+	}
+}
+
+// TestOTelDomain_DisabledIgnoresEndpoint guards the "off by default"
+// posture the initiative ruled on (#108): even when an endpoint is
+// configured, Enabled=false means tracing is dormant and the egress
+// allowlist must not carry the collector host. Otherwise turning
+// tracing off in yaml would leave a stale entry punched through the
+// NetworkPolicy.
+func TestOTelDomain_DisabledIgnoresEndpoint(t *testing.T) {
+	got := security.OTelDomain(types.TracingYAML{
+		Enabled:  false,
+		Endpoint: "https://otel.example.com:4318/v1/traces",
+	})
+	if got != nil {
+		t.Errorf("disabled tracing must not contribute an allowlist entry; got %v", got)
+	}
+}
+
+// TestOTelDomain_HTTPCollector covers the recommended HTTP/Protobuf
+// path. The endpoint URL includes scheme, port, and a path; only the
+// hostname should survive into the allowlist. Phase 6's contract
+// matches the AuthDomains / MCPDomains convention — hostname only, no
+// port (the egress matcher is port-agnostic).
+func TestOTelDomain_HTTPCollector(t *testing.T) {
+	got := security.OTelDomain(types.TracingYAML{
+		Enabled:  true,
+		Endpoint: "https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces",
+	})
+	want := []string{"otel-collector.monitoring.svc.cluster.local"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("OTelDomain = %v, want %v", got, want)
+	}
+}
+
+// TestOTelDomain_GRPCCollector covers the OTLP/gRPC path. Forge's
+// tracing config accepts `protocol: grpc` with a host:port endpoint
+// (no scheme, no path); the hostFromURL helper handles this via
+// url.Parse's host parsing rules. The Phase-1 PR explicitly
+// recommends HTTP because gRPC bypasses the in-process egress
+// enforcer — but the build-time allowlist contribution still needs to
+// land so the NetworkPolicy admits the traffic.
+func TestOTelDomain_GRPCCollector(t *testing.T) {
+	got := security.OTelDomain(types.TracingYAML{
+		Enabled:  true,
+		Protocol: "grpc",
+		// gRPC endpoints carry a scheme too (the SDK normalizes either
+		// host:port OR a scheme://host:port form). We test the
+		// scheme-bearing form because url.Parse would otherwise
+		// interpret the bare host:port as a relative path.
+		Endpoint: "https://otel-collector.monitoring.svc.cluster.local:4317",
+	})
+	want := []string{"otel-collector.monitoring.svc.cluster.local"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("OTelDomain (grpc) = %v, want %v", got, want)
+	}
+}
+
+// TestOTelDomain_MalformedEndpoint_NoEntry confirms the
+// fault-tolerance contract: a malformed endpoint URL must NOT cause
+// the build to fail. The cli's tracing config resolver (Phase 2) is
+// the single place that fails loudly on bad config; the build stage
+// silently skips and lets the runtime path surface the error so a
+// broken telemetry URL never blocks an otherwise-valid deployment.
+func TestOTelDomain_MalformedEndpoint_NoEntry(t *testing.T) {
+	got := security.OTelDomain(types.TracingYAML{
+		Enabled:  true,
+		Endpoint: "::::not-a-url::::",
+	})
+	if got != nil {
+		t.Errorf("malformed endpoint must produce no entry; got %v", got)
+	}
+}
+
+// TestOTelDomain_EmptyEndpoint_NoEntry — Enabled=true but no Endpoint
+// is the "tracing is wired but unconfigured" state. The cli resolver
+// already returns ErrDisabled here at runtime; the build stage
+// matches that posture — no allowlist entry, no error.
+func TestOTelDomain_EmptyEndpoint_NoEntry(t *testing.T) {
+	got := security.OTelDomain(types.TracingYAML{
+		Enabled:  true,
+		Endpoint: "",
+	})
+	if got != nil {
+		t.Errorf("empty endpoint must produce no entry; got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

**Final phase** of the OpenTelemetry Tracing v1 initiative (#108). Closes the deployment loop: when `forge.yaml` has tracing enabled with an endpoint, the collector host is auto-injected into the egress allowlist at **both build time** (`forge package` → `egress_allowlist.json` → generated NetworkPolicy) **and runtime** (`forge run` dev mode).

| Phase | Issue | PR | What it shipped |
|---|---|---|---|
| 0 | #101 | #122 | Tracer seam + composite W3C propagator |
| 1 | #102 | #123 | OTLP SDK provider |
| 2 | #103 | #124 | Config resolver + CLI flags + runner wiring |
| 3 | #104 | #125 | Span instrumentation across A2A → executor → tool |
| 4 | #105 | #126 | Audit ↔ trace cross-linking |
| 5 | #106 | #127 | Inbound `traceparent` extract at dispatcher |
| **6** | **#107** | **this PR** | **Auto-allowlist OTLP collector at build + runtime** |

## The bug this prevents

Without this PR, an operator who turns on tracing in `forge.yaml` ships a deployment whose NetworkPolicy blocks OTLP traffic. Spans accumulate in the `BatchSpanProcessor` queue and drop on shutdown timeout — `forge run` works locally, the cluster trace backend is inexplicably empty. Today's remediation is a manual `egress.allowed_domains` edit for every agent, which is exactly the kind of "duplicate the config" boilerplate the egress-merge pattern (`AuthDomains` / `MCPDomains`) was introduced to eliminate.

## What's in this PR

### 1. `forge-core/security/otel_domains.go` — new helper

```go
func OTelDomain(cfg types.TracingYAML) []string {
    if !cfg.Enabled || cfg.Endpoint == "" {
        return nil
    }
    host := hostFromURL(cfg.Endpoint)
    if host == "" {
        return nil
    }
    return []string{host}
}
```

Returns `[]{collector-host}` when tracing is enabled with a parseable endpoint; returns `nil` otherwise. Reuses the package-private `hostFromURL` helper for the same port-agnostic hostname extraction the `AuthDomains` / `MCPDomains` contributors use.

### 2. `forge-cli/build/egress_stage.go` — one-line merge

```go
allowed = append(allowed,
    security.OTelDomain(bc.Config.Observability.Tracing)...)
```

Mirrors the existing `AuthDomains` / `MCPDomains` merges. The downstream `k8s_stage` and the runtime egress matcher consume the resulting `egress_allowlist.json` directly — no change required at either site.

### 3. `forge-cli/runtime/runner.go` — same merge in dev mode

So `forge run` and `forge package`-then-deploy behave identically on the allowlist surface. Without this, dev mode with `egress.mode=allowlist` and tracing enabled would silently drop spans the same way the unpatched build pipeline did.

## Tolerance contract

Malformed / empty / disabled-tracing configs produce a **nil slice, not an error**. The CLI's Phase 2 tracing resolver is the single place that fails loudly on bad config; the build stage matches the runtime resolver's posture — **never block a deployment over telemetry config**.

## Coverage

**`forge-core/security/otel_domains_test.go`** (6 unit tests):

| Test | What it pins |
|---|---|
| `Empty` | No config → nil |
| `DisabledIgnoresEndpoint` | `Enabled=false` with endpoint set → nil (off-by-default invariant — turning tracing off in yaml does NOT leave a stale entry in the NetworkPolicy) |
| `HTTPCollector` | Endpoint with scheme/port/path → bare hostname |
| `GRPCCollector` | gRPC endpoint with port → bare hostname |
| `MalformedEndpoint_NoEntry` | Invalid URL → nil (build never blocks on telemetry config) |
| `EmptyEndpoint_NoEntry` | `Enabled=true` + `Endpoint=""` → nil |

**`forge-cli/build/egress_stage_otel_test.go`** (2 end-to-end tests):

| Test | What it pins |
|---|---|
| `OTelEndpointInAllowlist` | forge.yaml with `observability.tracing` enabled → `egress_allowlist.json`'s `all_domains` carries the collector host **alongside** the operator's explicit entries (collector is added, not replacing) |
| `OTelDisabled_NoExtraEntry` | Disabled tracing must NOT leak the endpoint host into the file — backward-compat |

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean in `forge-core/` (all packages)
- [x] `go test -race ./...` clean in `forge-cli/` (all packages)
- [x] `golangci-lint run ./forge-core/...` → **0 issues**
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## What this completes

OTel Tracing v1 (#108) ships in production-ready shape. An operator's path is now:

1. `observability.tracing.enabled: true` + endpoint in `forge.yaml`
2. `forge build && forge package && kubectl apply`
3. Traces arrive in the configured backend

**No second egress edit, no NetworkPolicy patch, no runtime override.** The final-mile boilerplate the initiative ruled needed to be eliminated is gone.

## Refs

- Closes #107 (Phase 6)
- **Closes #108 (initiative)**
- Builds on #101 / #102 / #103 / #104 / #105 / #106 (Phases 0-5)