### PR TITLE
docs(observability): sync OTel Tracing v1 (#108) across docs + skill

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -606,6 +606,70 @@ a third party).
 
 **Read**: `docs/security/trust-model.md`, `docs/security/overview.md`.
 
+### 12.9 Observability — OpenTelemetry tracing (OTel v1, #108)
+
+Off by default. When enabled (`observability.tracing.enabled: true` in
+`forge.yaml`), Forge exports OTLP spans covering A2A dispatch, agent
+execution, every LLM completion, every tool call, and every outbound
+HTTP request. Span hierarchy:
+
+```
+a2a.<method>                          [SpanKindServer; dispatcher]
+└── agent.execute                     [outer loop; root for the task]
+    ├── llm.completion (× N turns)    [per LLM provider call]
+    │   └── http.client (× outbound)  [auto via otelhttp]
+    └── tool.<tool_name> (× M calls)
+        └── http.client (if HTTP)
+```
+
+Key design points:
+
+- **Off by default.** The tracer seam (Phase 0) returns a noop tracer
+  unless the cli explicitly installs one. Audit pipeline is the
+  always-on compliance stream; tracing is the opt-in observability
+  stream.
+- **Standard config surface.** All 10 standard OTel SDK env vars are
+  honored (`OTEL_EXPORTER_OTLP_*`, `OTEL_TRACES_SAMPLER`,
+  `OTEL_SERVICE_NAME`, ...). Precedence: defaults < yaml < env < CLI
+  flags.
+- **Egress-enforced.** The OTLP HTTP exporter rides through the same
+  egress enforcer as every other in-process client — a misconfigured
+  collector URL cannot exfiltrate spans to an unapproved destination.
+- **End-to-end propagation.** Composite W3C `tracecontext + baggage`
+  propagator installed at startup. The dispatcher extracts inbound
+  `traceparent` so multi-hop A2A flows show as one connected trace.
+  Outbound HTTP through the egress-enforced transport auto-injects
+  the current span's `traceparent` (via otelhttp).
+- **Audit cross-link.** `EmitFromContext` stamps the active span's
+  `trace_id` + `span_id` on every audit event. Operators paste either
+  value into their backend to pivot audit row ↔ span node. Both
+  fields use `omitempty` — when tracing is off, audit JSON is
+  byte-identical to the pre-Phase-4 shape.
+- **Build-time egress merge.** `forge package` extracts the collector
+  hostname and auto-injects it into `egress_allowlist.json` (mirrored
+  at `forge run`). Disabled tracing produces no entry. No second
+  egress edit, no NetworkPolicy patch.
+- **Telemetry failures never crash the agent.** Bad endpoint,
+  malformed traceparent, unreachable collector — every failure mode
+  falls through to the noop tracer with a warning in the ops log.
+
+GenAI semconv attributes on `llm.completion`: `gen_ai.system`,
+`gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`.
+Forge-specific attributes use the `forge.*` namespace
+(`forge.task.id`, `forge.task.final_state`, `forge.tool.name`,
+`forge.workflow.id`, ...).
+
+Phase 3 ships **metadata-only** spans. `capture_content` is plumbed
+through the config schema but not yet honored by the instrumentation;
+content capture is a follow-up that will reuse the FWS-8 audit
+redactor.
+
+**Read**: `docs/core-concepts/observability-tracing.md`,
+`docs/reference/forge-yaml-schema.md` § `observability.tracing`,
+`docs/security/audit-logging.md` § Trace cross-link,
+`docs/security/egress-control.md` § OTel collector auto-extension.
+
 ---
 
 ## 13. CLI surface
@@ -617,7 +681,7 @@ Full reference: `docs/reference/cli-reference.md`.
 | `forge init` | Scaffold a new agent: `forge.yaml`, `.env`, `SKILL.md`, `guardrails.json`. Interactive TUI by default; `--non-interactive` for CI | `--model-provider`, `--model-name`, `--channels`, `--auth`, `--from-skills` |
 | `forge build` | Run the build pipeline → `.forge-output/agent.json` + container Dockerfile + K8s manifests + (optional) signature | `--output-dir`, `--sign` |
 | `forge validate` | Lint `forge.yaml` + SKILL.md. `--platform-policy=PATH` lints a policy file standalone | `--strict`, `--command-compat`, `--platform-policy` |
-| `forge run` | Dev-mode A2A server with hot-reload | `--port`, `--host`, `--with slack,telegram`, `--mock-tools`, `--no-auth`, `--cors-origins`, `--audit-socket`, `--audit-http-endpoint`, `--rate-limit-*` |
+| `forge run` | Dev-mode A2A server with hot-reload | `--port`, `--host`, `--with slack,telegram`, `--mock-tools`, `--no-auth`, `--cors-origins`, `--audit-socket`, `--audit-http-endpoint`, `--rate-limit-*`, `--otel-enabled`, `--otel-endpoint`, `--otel-sampler` |
 | `forge serve start \| stop \| status \| logs` | Daemonized A2A server (forks `forge run`). Forwards CLI flags + env to the child | `--port`, `--shutdown-timeout`, `--with` |
 | `forge export` | Export `agent.json` for registry upload | |
 | `forge package` | Generate Dockerfile + Kubernetes manifests + `egress_allowlist.json`. `--prod` rejects `dev-open` egress + dev-only tools | `--registry`, `--tag`, `--base`, `--prod` |
@@ -714,6 +778,20 @@ package:
   bin_overrides:
     forge: { local: "/path/to/forge" }
     jq: { apt: "jq" }
+
+observability:                       # OTel Tracing v1 (#108) — off by default
+  tracing:
+    enabled: true
+    endpoint: https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+    protocol: http/protobuf          # or "grpc"
+    sampler: parentbased_always_on   # standard OTEL_TRACES_SAMPLER name
+    sampler_ratio: 1.0
+    timeout: 10s
+    service_name: ""                 # default: agent_id
+    headers: { x-tenant: demo }
+    resource_attrs: { deployment.environment: prod }
+    redact: true
+    capture_content: false           # Phase 3 ships metadata-only
 
 skills:
   path: SKILL.md                     # main agent skill file
@@ -830,6 +908,13 @@ Sourced from `forge-core/runtime/audit.go` constants. See
 `docs/security/audit-logging.md` for the full per-event field
 inventory.
 
+Every event emitted via `EmitFromContext` (the typed helpers —
+`EmitLLMCall`, `EmitToolExec`, `EmitInvocationComplete`,
+`EmitInvocationCancelled`, the egress allow/block emit, the FWS-3
+stamping path) auto-includes optional `trace_id` + `span_id` fields
+when OTel tracing is enabled (OTel v1 / Phase 4 / #105). Both use
+`omitempty` — tracing-off deploys see byte-identical pre-Phase-4 JSON.
+
 | Event constant | Wire value | When |
 |---|---|---|
 | `AuditSessionStart` | `session_start` | New task session begins |
@@ -868,7 +953,7 @@ Every event also carries `schema_version: "1.0"` (FWS-8) and `seq`
 
 ---
 
-## 18. Workstream recap — FWS-1 through FWS-10
+## 18. Workstream recap — FWS-1 through FWS-10 + OTel v1
 
 | # | Issue | Title | Doc |
 |---|---|---|---|
@@ -882,6 +967,7 @@ Every event also carries `schema_version: "1.0"` (FWS-8) and `seq`
 | **FWS-8** | #91 | Hardened audit emission — `schema_version` + monotonic `seq` per invocation; default metadata-only invariant pinned by regression test; opt-in `AuditPayloadCapture` with per-field byte caps | `docs/security/audit-logging.md` § Schema contract |
 | **FWS-9** | #100 | Ops logger output stream separation — stdout for `JSONLogger`, stderr stays for audit NDJSON | `docs/security/audit-logging.md` § Streams |
 | **FWS-10** | #110 | Rate-limit configurability + orchestration-friendly defaults + cancel exemption — `server.rate_limit:` yaml block + CLI flags + env; `tasks/cancel` exempt from the write bucket by default | `docs/reference/forge-yaml-schema.md` § `server.rate_limit` |
+| **OTel v1** | #108 | OpenTelemetry tracing — shipped across phases #101-#107 (PRs #122-#128). Tracer seam → OTLP provider → config resolver + CLI flags → span instrumentation across A2A/executor/LLM/tool → audit ↔ trace cross-link → end-to-end A2A propagation → build-time egress merge. Off by default; reuses the egress-enforced transport. | `docs/core-concepts/observability-tracing.md` |
 
 Side issues filed during this run: FWS-9 was filed as a companion to
 FWS-7's "stream separation would be cleaner" callout; FWS-10 was filed
@@ -910,7 +996,8 @@ docs/
 │   ├── skill-md-format.md        ← SKILL.md schema
 │   ├── channels.md
 │   ├── memory-system.md
-│   └── scheduling.md
+│   ├── scheduling.md
+│   └── observability-tracing.md  ← OTel v1 (#108) — spans, propagation, audit cross-link
 ├── security/
 │   ├── overview.md               ← start here for security
 │   ├── trust-model.md
@@ -977,3 +1064,6 @@ and which canonical doc to deep-dive.
 | "Can I disable rate limiting entirely?" | § 12.5 | Don't. Set `WriteRPS` / `ReadRPS` very high in `server.rate_limit` if you trust your network, but anonymous public-facing agents need the limiter for DoS protection |
 | "How do I capture LLM prompts in audit for debugging?" | § 12.4 | `AuditPayloadCapture{LLMMessages: true, LLMResponse: true}`; payloads truncated to 16 KiB per field with `…[truncated:N]` markers; route the audit stream to a store appropriate to the captured content's sensitivity |
 | "How do I extend `sync-docs` for my new doc?" | n/a | `.claude/commands/sync-docs.md` — add a row to the mapping table mapping the changed code path to the affected doc |
+| "How do I enable distributed tracing?" | § 12.9 | `docs/core-concepts/observability-tracing.md`; set `observability.tracing.enabled: true` + `endpoint` in forge.yaml (or `--otel-enabled --otel-endpoint`); collector host is auto-allowlisted at build time |
+| "How do I pivot from an audit row to a trace?" | § 12.4 + § 12.9 | Audit rows carry `trace_id` + `span_id` when tracing is on; paste either into Tempo / Jaeger / Honeycomb. `docs/security/audit-logging.md` § Trace cross-link |
+| "How do multi-hop A2A traces connect?" | § 12.9 | Phase 5 (#106): the dispatcher extracts the inbound W3C `traceparent` header; outbound HTTP through the egress-enforced transport auto-injects `traceparent` via otelhttp. Both pair to form one connected trace tree |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Added
 
+- **OpenTelemetry tracing v1 — full end-to-end distributed tracing
+  (initiative #108, PRs #122–#128).** Off-by-default OTLP export
+  covering A2A dispatch (`a2a.<method>` SpanKindServer), the
+  executor loop (`agent.execute`), every LLM completion
+  (`llm.completion` with GenAI semconv `gen_ai.usage.*_tokens`),
+  every tool call (`tool.<name>`), and every outbound HTTP request
+  (auto via `otelhttp` on the egress-enforced transport). New
+  `observability.tracing` block in `forge.yaml`, nine `--otel-*`
+  CLI flags, and all 10 standard `OTEL_*` env vars
+  (`OTEL_EXPORTER_OTLP_*`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME`,
+  ...) honored with full precedence (CLI > env > yaml > defaults).
+  Audit events emitted via `EmitFromContext` carry `trace_id` +
+  `span_id` so operators pivot audit row ↔ trace tree with a single
+  copy-paste (`omitempty` — tracing-off audit JSON is byte-identical
+  to pre-Phase-4). The composite W3C `tracecontext + baggage`
+  propagator is installed at startup; the dispatcher extracts inbound
+  `traceparent` and outbound HTTP re-injects it, so multi-hop A2A
+  flows display as one connected trace. The OTLP HTTP exporter rides
+  through the same egress enforcer as every other in-process client
+  — a misconfigured collector URL cannot exfiltrate spans. `forge
+  package` and `forge run` auto-add the collector hostname to
+  `egress_allowlist.json` so the generated NetworkPolicy admits
+  OTLP traffic with no second egress edit. Phase 3 ships
+  metadata-only; content capture (the `capture_content` knob) is
+  a follow-up that will reuse the FWS-8 audit redactor. See
+  `docs/core-concepts/observability-tracing.md` for the full
+  reference. Issue breakdown: #101 (Phase 0, seam, PR #122), #102
+  (Phase 1, OTLP provider, PR #123), #103 (Phase 2, config wiring,
+  PR #124), #104 (Phase 3, span instrumentation, PR #125), #105
+  (Phase 4, audit cross-link, PR #126), #106 (Phase 5, inbound
+  propagation, PR #127), #107 (Phase 6, build-time egress, PR #128).
+
 - **Per-IP rate-limit configurability — `server.rate_limit` block +
   CLI flags + env vars (issue #110, FWS-10).** The A2A server's
   per-IP rate limiter (originally from issue #31) is now configurable

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You write a `SKILL.md`. Forge compiles it into a secure, runnable agent with egr
 | [Memory](docs/core-concepts/memory-system.md) | Session persistence and long-term memory |
 | [Channels](docs/core-concepts/channels.md) | Slack and Telegram adapter setup |
 | [Scheduling](docs/core-concepts/scheduling.md) | Cron configuration and schedule tools |
+| [Tracing](docs/core-concepts/observability-tracing.md) | OpenTelemetry distributed tracing — spans, propagation, audit cross-link |
 
 ### Security
 

--- a/docs/core-concepts/observability-tracing.md
+++ b/docs/core-concepts/observability-tracing.md
@@ -1,0 +1,288 @@
+---
+title: "Observability — Tracing"
+description: "OpenTelemetry distributed tracing across A2A → executor → LLM → tool — config, propagation, audit cross-link, and build-time egress."
+order: 9
+---
+
+OpenTelemetry tracing in Forge is off by default. When enabled, every inbound A2A request becomes one trace whose span tree covers the dispatcher, the agent execution loop, every LLM completion, every tool call, and every outbound HTTP request. Trace context propagates across multi-hop A2A flows, audit events carry the active span's `trace_id` + `span_id`, and the OTLP collector host is auto-allowlisted at build time so deployments need no second egress edit.
+
+> **Status:** shipped as OTel Tracing v1 — initiative tracking issue #108, delivered across phases #101–#107 (PRs #122–#128).
+
+## Quick start
+
+```yaml
+# forge.yaml
+observability:
+  tracing:
+    enabled: true
+    endpoint: https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+    sampler: parentbased_always_on
+```
+
+Run:
+
+```bash
+forge run                    # tracing on, defaults applied
+forge build && forge package # collector host auto-added to egress allowlist
+kubectl apply -f ...
+```
+
+Spans arrive at the collector. The agent's `agent_id` is the `service.name` your trace backend groups by.
+
+## forge.yaml schema
+
+```yaml
+observability:
+  tracing:
+    enabled: true                           # off by default
+    endpoint: https://collector:4318/v1/traces
+    protocol: http/protobuf                  # or "grpc"
+    sampler: parentbased_always_on           # standard OTEL_TRACES_SAMPLER name
+    sampler_ratio: 1.0                       # used by *traceidratio* samplers
+    timeout: 10s                             # per-request exporter timeout
+    service_name: my-agent                   # default: agent_id
+    headers:                                  # OTLP request headers (auth tokens etc.)
+      x-tenant: demo
+    resource_attrs:                          # extra OTel resource attributes
+      deployment.environment: prod
+    redact: true                             # default true — Phase 3 metadata-only ships now
+    capture_content: false                   # enterprise opt-in for prompt/completion content
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `false` | Off by default per the initiative ruling. |
+| `endpoint` | string | — | Required when `enabled: true`. Empty endpoint collapses to "off." |
+| `protocol` | string | `http/protobuf` | Or `grpc`. HTTP is recommended (egress enforcer can wrap it; gRPC bypasses). |
+| `sampler` | string | `parentbased_always_on` | Standard `OTEL_TRACES_SAMPLER` names — see below. |
+| `sampler_ratio` | float | `1.0` | Only applies to `traceidratio` variants. |
+| `timeout` | duration | `10s` | Per-request OTLP exporter timeout. |
+| `service_name` | string | `agent_id` | `OTEL_SERVICE_NAME` env wins if set. |
+| `headers` | map | — | OTLP HTTP/gRPC headers. Env is the preferred path for secrets. |
+| `resource_attrs` | map | — | Merged with the auto-stamped `service.*` + `forge.runtime.version`. |
+| `redact` | bool | `true` | PII redaction posture flag (consumed by Phase 3+ instrumentation). |
+| `capture_content` | bool | `false` | Reserved — metadata-only spans ship now; content capture is a follow-up. |
+
+## Config precedence
+
+Lowest → highest:
+
+1. Defaults
+2. `observability.tracing` block in `forge.yaml`
+3. `OTEL_*` environment variables (standard SDK names)
+4. CLI flags (`--otel-*`)
+
+A set-but-empty env var does **not** wipe a non-empty yaml field. Absence-of-value is "no override," not "unset."
+
+### Environment variables
+
+| Env var | Maps to |
+|---|---|
+| `OTEL_SDK_DISABLED` | inverted → `enabled` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `endpoint` (preferred — signal-specific) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `endpoint` (generic fallback) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `protocol` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `headers` (merged with yaml; env wins on key collision) |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | `timeout` (milliseconds) |
+| `OTEL_SERVICE_NAME` | `service_name` |
+| `OTEL_RESOURCE_ATTRIBUTES` | `resource_attrs` (merged with yaml) |
+| `OTEL_TRACES_SAMPLER` | `sampler` |
+| `OTEL_TRACES_SAMPLER_ARG` | `sampler_ratio` |
+
+### CLI flags
+
+Each flag detection uses `cmd.Flags().Changed(...)` rather than zero-value sentinels, because every "zero" is a legitimate explicit ask (`--otel-sampler-ratio 0` = drop everything, `--otel-enabled=false` = force off).
+
+| Flag | Type |
+|---|---|
+| `--otel-enabled` | bool |
+| `--otel-endpoint` | string |
+| `--otel-protocol` | string |
+| `--otel-sampler` | string |
+| `--otel-sampler-ratio` | float |
+| `--otel-timeout` | duration |
+| `--otel-service-name` | string |
+| `--otel-capture-content` | bool |
+| `--otel-redact` | bool |
+
+## Samplers
+
+The six standard `OTEL_TRACES_SAMPLER` names — Forge maps them to the OTel SDK directly:
+
+| Name | Behavior |
+|---|---|
+| `always_on` | Sample everything |
+| `always_off` | Drop everything |
+| `traceidratio` | Sample at `sampler_ratio` (0.0–1.0) by trace id |
+| `parentbased_always_on` (default) | Honor upstream sampled flag; sample everything when no parent |
+| `parentbased_always_off` | Honor upstream sampled flag; drop everything when no parent |
+| `parentbased_traceidratio` | Honor upstream sampled flag; ratio when no parent |
+
+Name parsing is case-insensitive and whitespace-tolerant. Unknown names error loudly at startup with the offending string named — a typo like `parent_based_always_on` is caught immediately rather than silently falling through to a default.
+
+## Span hierarchy
+
+```
+a2a.<method>                          [SpanKindServer; dispatcher]
+└── agent.execute                     [outer loop; root for the task]
+    ├── llm.completion (× N turns)    [per LLM provider call]
+    │   └── http.client (× outbound)  [auto via otelhttp on egress transport]
+    └── tool.<tool_name> (× M calls)  [per tool invocation]
+        └── http.client (if HTTP)
+```
+
+### Attribute conventions
+
+Forge mixes OTel GenAI semconv with Forge-specific `forge.*` namespaced attributes. Backends key dashboards by these:
+
+| Attribute | Where it appears | Source |
+|---|---|---|
+| `forge.a2a.method` | `a2a.<method>` | JSON-RPC method name |
+| `forge.workflow.id` / `.stage.id` / `.step.id` | `a2a.<method>` | FWS-2 `X-Workflow-*` headers |
+| `forge.task.id` | `agent.execute` | A2A `params.id` |
+| `forge.correlation_id` | `agent.execute` | inbound `X-Forge-Correlation-Id` |
+| `forge.loop.iteration` | `agent.execute` (set at End) | turn count |
+| `forge.task.final_state` | `agent.execute` (set at End) | `completed` / `failed` / `canceled` |
+| `gen_ai.system` | `agent.execute`, `llm.completion` | `"anthropic"`, `"openai"`, `"ollama"` |
+| `gen_ai.request.model` / `.response.model` | `llm.completion` | provider request/response model |
+| `gen_ai.usage.input_tokens` / `.output_tokens` | `llm.completion` | provider usage block |
+| `gen_ai.response.finish_reasons` | `llm.completion` | provider stop reason |
+| `forge.tool.name` | `tool.<tool_name>` | tool function name |
+| `forge.tool.error` | `tool.<tool_name>` | error message on failure |
+
+Tool errors do **not** fail the outer `agent.execute` span — they surface to the LLM as text and the loop continues. The tool span carries the failure detail so operators can pivot from a trace to the specific failed invocation.
+
+### Phase 3 is metadata-only
+
+Tool args / results, prompts, completions are **not** recorded as span attributes today. The `capture_content` + `redact` knobs are plumbed but not yet honored by the instrumentation — content capture is a follow-up that will reuse the FWS-8 audit redactor.
+
+## End-to-end propagation (Phase 5)
+
+Forge installs the W3C `tracecontext + baggage` composite propagator on the OTel global at startup. The JSON-RPC dispatcher extracts inbound `traceparent` + `baggage` headers before opening its own span, so multi-hop A2A flows show as one connected trace:
+
+```
+orchestrator
+    │  traceparent: 00-T-S1-01
+    ▼
+┌───────────────┐
+│  forge agent  │  span_id=S2, parent=S1   (a2a.tasks/send)
+│      ▼        │  span_id=S3, parent=S2   (agent.execute)
+│      ▼        │  span_id=S4, parent=S3   (llm.completion)
+└──────│────────┘
+       ▼  traceparent: 00-T-S2-01  ← otelhttp re-injects on outbound
+                                      via the egress-enforced transport
+┌───────────────┐
+│  downstream   │  span_id=S5, parent=S2   (a2a.tasks/send)
+│  forge agent  │
+└───────────────┘
+```
+
+All five spans share `trace_id = T` and chain by `parent_span_id`. The operator sees **one** connected flame graph.
+
+A malformed inbound `traceparent` returns `ctx` unchanged from the propagator — Forge then starts a fresh root rather than carrying a broken context forward.
+
+`baggage` (the other half of the composite) flows through to the handler ctx so application-level identifiers (tenant id, A/B bucket) travel with the trace.
+
+## Audit ↔ trace cross-link (Phase 4)
+
+Audit events emitted via `EmitFromContext` carry the active span's IDs:
+
+```json
+{
+  "event": "llm_call",
+  "task_id": "t-1234",
+  "trace_id": "4a8f95a0e1bedda42c9dd5350fb3b33a",
+  "span_id":  "ad8b2c91e44f0a72",
+  ...
+}
+```
+
+- **Pivot audit → trace:** paste the `trace_id` into your backend's search box → land on the matching trace tree. Paste the `span_id` → land directly on the `llm.completion` child carrying matching `gen_ai.usage.*` tokens.
+- **Pivot trace → audit:** copy the `trace_id` from Tempo / Jaeger / Honeycomb → grep the audit log for the matching row → get the FWS-8 payload metadata the trace doesn't carry.
+
+Both fields use `omitempty`. When tracing is disabled (the default), audit JSON is byte-identical to the pre-Phase-4 shape — backward-compatible by construction. See [Audit Logging](../security/audit-logging.md#trace-cross-link-fws-105) for full schema details.
+
+## Egress-enforced OTLP transport
+
+Forge wraps the OTLP HTTP exporter's transport with the same egress enforcer every other in-process HTTP client uses. The operator's egress allowlist therefore bounds where Forge can send spans — a misconfigured collector URL cannot exfiltrate span content to an unapproved destination.
+
+**`forge package` auto-injects the collector host into the build's egress allowlist** so the generated NetworkPolicy admits OTLP traffic. The same auto-merge fires at `forge run` time so dev mode matches prod. No second egress edit, no NetworkPolicy patch.
+
+```yaml
+# forge.yaml — this is sufficient. The collector is added automatically.
+egress:
+  mode: allowlist
+  allowed_domains:
+    - api.anthropic.com    # operator-declared
+observability:
+  tracing:
+    enabled: true
+    endpoint: https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+# → all_domains in egress_allowlist.json = [api.anthropic.com, otel-collector.monitoring.svc.cluster.local]
+```
+
+Disabled tracing produces no allowlist entry — turning tracing off in yaml does NOT leave a stale entry punched through the NetworkPolicy.
+
+### HTTP vs gRPC
+
+| Protocol | Egress enforcement |
+|---|---|
+| `http/protobuf` (default) | Enforced via the in-process `SafeTransport` wrap. Recommended. |
+| `grpc` | gRPC exporter dials directly; no in-process wrap. Relies on the build-time allowlist + NetworkPolicy. |
+
+## Disabled-path semantics
+
+When tracing is off (default, or `enabled: false`, or empty `endpoint`):
+
+- `forge-core/runtime.Tracer()` returns the no-op tracer; spans are non-recording and near-zero cost.
+- `EmitFromContext` does not stamp `trace_id` / `span_id`; audit JSON is byte-identical to pre-Phase-4.
+- `OTelDomain` returns nil; no entry in `egress_allowlist.json`.
+- `observability.WrapHTTPTransport` is a near pass-through (noop TracerProvider short-circuits span creation).
+
+**Telemetry failures never crash the agent.** A misconfigured endpoint, a malformed traceparent, an unreachable collector — every failure mode falls through to the noop tracer with a warning in the ops log. The cli's resolver is the single place that fails loudly on bad config at startup.
+
+## Verification
+
+Once configured:
+
+```sh
+# stub collector that prints every received span
+docker run --rm -p 4318:4318 \
+  otel/opentelemetry-collector-contrib:latest \
+  --config=/dev/stdin <<'YAML'
+receivers:
+  otlp:
+    protocols:
+      http: { endpoint: 0.0.0.0:4318 }
+exporters:
+  debug: { verbosity: detailed }
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+YAML
+
+# in another terminal
+forge run --otel-enabled \
+  --otel-endpoint http://localhost:4318/v1/traces \
+  --otel-sampler always_on
+
+# fire a task
+curl -H "Authorization: Bearer $(cat .forge/runtime.token)" \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send",
+          "params":{"id":"t-1","message":{"role":"user","parts":[{"kind":"text","text":"hi"}]}}}' \
+     http://localhost:8080/
+```
+
+The collector should print one trace with `a2a.tasks/send` → `agent.execute` → `llm.completion` (× N) → `tool.<name>` (× M). The `agent.execute` span carries `gen_ai.system`, `forge.task.id`, `forge.task.final_state`. Each `llm.completion` carries `gen_ai.usage.input_tokens` / `output_tokens`. Each audit row in stderr now carries `trace_id` / `span_id` matching the spans.
+
+## Cross-references
+
+- [forge.yaml schema](../reference/forge-yaml-schema.md) — the full schema reference including `observability:`.
+- [CLI reference](../reference/cli-reference.md#forge-run) — all `--otel-*` flags on `forge run`.
+- [Audit logging](../security/audit-logging.md) — schema including `trace_id` / `span_id`, complementary stream posture vs OTel.
+- [Egress control](../security/egress-control.md) — auto-merge mechanics including the OTel collector.
+- [Workflow correlation](../security/workflow-correlation.md) — FWS-2 `X-Workflow-*` headers surface on the dispatch span.
+- [Deployment monitoring](../deployment/monitoring.md) — operator-level integration with Tempo / Jaeger / Honeycomb.

--- a/docs/deployment/monitoring.md
+++ b/docs/deployment/monitoring.md
@@ -57,3 +57,38 @@ forge serve logs
 ```
 
 See [Audit Logging](/docs/security/audit-logging) for details on the event format and DB mode audit storage.
+
+## Distributed Tracing (OpenTelemetry)
+
+As of OTel Tracing v1 (#108), Forge exports OTLP spans for every A2A
+request — dispatcher, executor loop, LLM completions, tool calls, and
+outbound HTTP. Multi-hop A2A flows display as a single connected
+trace, and every audit row carries the active span's `trace_id` +
+`span_id` for cross-pipeline pivoting.
+
+Enable in `forge.yaml`:
+
+```yaml
+observability:
+  tracing:
+    enabled: true
+    endpoint: https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+    sampler: parentbased_always_on
+```
+
+Or via env / CLI:
+
+```bash
+forge run --otel-enabled \
+  --otel-endpoint http://localhost:4318/v1/traces \
+  --otel-sampler always_on
+```
+
+The collector hostname is auto-added to the egress allowlist at build
+time (`forge package`) and at runtime, so no second egress edit is
+needed. Compatible with any OTLP-aware backend (Tempo, Jaeger,
+Honeycomb, Datadog, Grafana Cloud).
+
+See [Observability — Tracing](/docs/core-concepts/observability-tracing)
+for the full reference (span hierarchy, attributes, propagation,
+audit cross-link, samplers).

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -215,6 +215,15 @@ forge run [flags]
 | `--with` | | Comma-separated channel adapters (e.g., `slack,telegram`) |
 | `--auth-url` | | External auth provider URL for token validation |
 | `--cors-origins` | localhost | Comma-separated CORS allowed origins (e.g., `https://app.example.com,https://admin.example.com`). Use `*` to allow all origins |
+| `--otel-enabled` | `false` | Enable OTLP tracing export. Falls back to `OTEL_SDK_DISABLED` env and `observability.tracing.enabled` in forge.yaml. See [Observability — Tracing](../core-concepts/observability-tracing.md). |
+| `--otel-endpoint` | | OTLP target URL. Falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| `--otel-protocol` | `http/protobuf` | OTLP protocol: `http/protobuf` or `grpc`. HTTP is recommended (the egress enforcer can wrap it). |
+| `--otel-sampler` | `parentbased_always_on` | Standard `OTEL_TRACES_SAMPLER` name. |
+| `--otel-sampler-ratio` | `1.0` | Ratio for `*traceidratio*` samplers (0.0–1.0). |
+| `--otel-timeout` | `10s` | Per-request exporter timeout. |
+| `--otel-service-name` | `agent_id` | OTel `service.name` resource attribute. |
+| `--otel-capture-content` | `false` | Reserved — enterprise opt-in for prompt/completion content on spans. Phase 3 ships metadata-only. |
+| `--otel-redact` | `true` | PII redaction posture flag. |
 
 ### Examples
 
@@ -236,6 +245,17 @@ forge run --enforce-guardrails --env .env.production
 
 # Run with custom CORS origins (for K8s ingress)
 forge run --cors-origins 'https://app.example.com,https://admin.example.com'
+
+# Run with OpenTelemetry tracing enabled (export to local collector)
+forge run --otel-enabled \
+  --otel-endpoint http://localhost:4318/v1/traces \
+  --otel-sampler always_on
+
+# Same, but service name + protocol override
+forge run --otel-enabled \
+  --otel-endpoint otel.example.com:4317 \
+  --otel-protocol grpc \
+  --otel-service-name my-agent-staging
 ```
 
 ---

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,3 +30,27 @@ order: 3
 | `FORGE_AGENT_ID` | Agent identifier for DB guardrails (falls back to `agent_id` in YAML) |
 | `FORGE_ORG_ID` | Organization identifier for DB guardrails |
 | `FORGE_PASSPHRASE` | Passphrase for encrypted secrets file |
+
+## OpenTelemetry tracing (OTel v1, #108)
+
+Forge honors the standard OpenTelemetry SDK environment variables for
+the `observability.tracing` subsystem. They sit between
+`forge.yaml` and `--otel-*` CLI flags in the precedence stack — env
+overrides yaml, flags override env. A set-but-empty env var does
+**not** wipe a non-empty yaml value (absence-of-value is "no override").
+
+See [Observability — Tracing](../core-concepts/observability-tracing.md)
+for the full reference.
+
+| Variable | Maps to |
+|---|---|
+| `OTEL_SDK_DISABLED` | inverted → `observability.tracing.enabled` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `endpoint` (preferred — signal-specific) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `endpoint` (generic fallback) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `protocol` (`http/protobuf` or `grpc`) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `headers` (merged with yaml; env wins on key collision) |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | `timeout` (milliseconds) |
+| `OTEL_SERVICE_NAME` | `service_name` |
+| `OTEL_RESOURCE_ATTRIBUTES` | `resource_attrs` (merged with yaml) |
+| `OTEL_TRACES_SAMPLER` | `sampler` (standard names) |
+| `OTEL_TRACES_SAMPLER_ARG` | `sampler_ratio` |

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -145,6 +145,22 @@ schedules:                          # Recurring scheduled tasks (optional)
     skill: ""                       # Optional skill to invoke
     channel: "telegram"             # Optional channel for delivery
     channel_target: "-100123456"    # Destination chat/channel ID
+
+observability:                      # OpenTelemetry tracing (off by default)
+  tracing:
+    enabled: true                   # Phase 0-6 / OTel Tracing v1 (#108)
+    endpoint: https://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+    protocol: "http/protobuf"       # or "grpc"
+    sampler: "parentbased_always_on"
+    sampler_ratio: 1.0              # only for *traceidratio* samplers
+    timeout: 10s                    # per-request exporter timeout
+    service_name: ""                # defaults to agent_id
+    headers:                        # OTLP request headers (auth tokens etc.)
+      x-tenant: demo
+    resource_attrs:                 # extra OTel resource attributes
+      deployment.environment: prod
+    redact: true                    # PII redaction posture flag
+    capture_content: false          # reserved — Phase 3 ships metadata-only
 ```
 
 ## `server.rate_limit` — per-IP A2A rate limits (FWS-10)
@@ -194,3 +210,45 @@ pods behind a single service IP share one bucket. If that becomes a
 practical problem, the right fix is auth-aware rate limiting (per-user
 buckets keyed by `auth.user_id`) — out of scope for FWS-10; file
 separately.
+
+## `observability.tracing` — OpenTelemetry distributed tracing
+
+Off by default. When enabled, Forge exports OTLP spans covering the
+A2A dispatcher, the executor loop, every LLM completion, every tool
+call, and every outbound HTTP request. See the dedicated
+[Observability — Tracing](../core-concepts/observability-tracing.md)
+doc for the full reference (span hierarchy, propagation, audit
+cross-link, build-time egress).
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Off by default per the OTel v1 initiative ruling. |
+| `endpoint` | — | Required when `enabled: true`. Empty endpoint collapses to "off." |
+| `protocol` | `http/protobuf` | Or `grpc`. HTTP is recommended (egress enforcer wraps it). |
+| `sampler` | `parentbased_always_on` | Standard `OTEL_TRACES_SAMPLER` name. See [tracing doc](../core-concepts/observability-tracing.md#samplers). |
+| `sampler_ratio` | `1.0` | Used by `traceidratio` variants. |
+| `timeout` | `10s` | Per-request exporter timeout. |
+| `service_name` | `agent_id` | `OTEL_SERVICE_NAME` env wins if set. |
+| `headers` | — | OTLP request headers; prefer env (`OTEL_EXPORTER_OTLP_HEADERS`) for secrets. |
+| `resource_attrs` | — | Merged with the auto-stamped `service.*` + `forge.runtime.version`. |
+| `redact` | `true` | PII redaction posture flag. |
+| `capture_content` | `false` | Reserved — Phase 3 ships metadata-only spans. |
+
+### Resolution order
+
+Same pattern as `server.rate_limit`:
+
+1. `--otel-*` CLI flags
+2. `OTEL_*` env vars (standard SDK names)
+3. `observability.tracing` block in this file
+4. Built-in defaults (the table above)
+
+A set-but-empty env var does NOT wipe a non-empty yaml field —
+absence-of-value is "no override," not "unset."
+
+### Egress auto-merge
+
+`forge package` and `forge run` both extract the endpoint hostname and
+auto-add it to `egress_allowlist.json`. No second egress edit needed.
+Disabled tracing produces no entry — turning tracing off in yaml does
+NOT leave a stale entry in the generated NetworkPolicy.

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -300,8 +300,35 @@ audit must continue, and vice versa.
 
 The two pipelines share signal sources in Forge — when something
 interesting happens, instrumentation emits to OTel **and** to audit at
-the same call site. They are deliberately not coupled: do not tap one
-from the other.
+the same call site. They are deliberately not coupled at the export
+level (one breaking does not break the other), but as of OTel v1
+(#108 / Phase 4) every audit event emitted from a request-scoped
+context carries the active span's `trace_id` + `span_id`. See
+[trace cross-link](#trace-cross-link-otel-v1-105) below for the
+join-key semantics.
+
+### Trace cross-link (OTel v1, #105)
+
+When OpenTelemetry tracing is enabled (see
+[Observability — Tracing](../core-concepts/observability-tracing.md)),
+`EmitFromContext` automatically stamps the active span's `trace_id`
+and `span_id` on every audit event. Operators paste either value
+directly into a trace backend's search box to pivot between the two
+streams:
+
+| Pivot direction | How |
+|---|---|
+| **audit row → trace** | Paste the row's `trace_id` into Tempo / Jaeger / Honeycomb to land on the matching trace. Paste the `span_id` to jump directly to the span (an `llm_call` row's `span_id` resolves to the `llm.completion` span carrying matching `gen_ai.usage.*` tokens). |
+| **trace → audit row** | Copy `trace_id` from a trace browser; grep the audit log for the corresponding row to get the FWS-8 payload metadata the trace does not carry. |
+
+Format: lowercase hex matching W3C `traceparent` semantics — 32-char
+(128-bit) `trace_id`, 16-char (64-bit) `span_id`.
+
+**Backward compatibility:** both fields use `omitempty`. When tracing
+is off (default), audit JSON is byte-identical to the pre-Phase-4
+shape — no `trace_id` / `span_id` keys appear. The
+`AuditSchemaVersion` is NOT bumped: adding optional fields is a
+schema-compatible change per the policy above.
 
 ## Streams (FWS-9)
 
@@ -351,6 +378,7 @@ Every emitted event carries:
 | `input_tokens` / `output_tokens` / `tokens_unavailable` | int / bool | optional | LLM call usage (FWS-3) |
 | `duration_ms` | int64 | optional | Wall-clock duration (FWS-3) |
 | `request_id` | string | optional | Provider-specific call identifier (FWS-3) |
+| `trace_id` / `span_id` | string | tracing-on only | W3C-format lowercase hex (32/16 chars) of the OTel span active at emit time. Pivots audit row ↔ trace tree. See [trace cross-link](#trace-cross-link-otel-v1-105). |
 | `fields` | map | optional | Per-event structured metadata (see each event type) |
 
 ### Sequence numbers

--- a/docs/security/egress-control.md
+++ b/docs/security/egress-control.md
@@ -234,6 +234,35 @@ to add `sts.us-east-1.amazonaws.com` themselves when they configure
 sees the full outbound surface for review in a single screen. See
 [Authentication](authentication.md) for the per-provider auth model.
 
+### MCP server domain auto-extension
+
+Configuring an `mcp.servers[]` entry with `transport: http` adds the host
+of the server `url` to the allowlist automatically — operators don't have
+to remember to add `mcp.linear.app` when they configure a Linear MCP
+server. See `security.MCPDomains` for the canonical mapping.
+
+### OTel collector domain auto-extension (OTel v1, #107)
+
+Configuring `observability.tracing` with an endpoint adds the
+collector's hostname to the allowlist automatically. Without this, a
+deployment with tracing enabled in `forge.yaml` would ship a
+NetworkPolicy that blocks OTLP traffic — spans accumulate in the
+batch processor and drop on shutdown timeout, leaving the operator
+with an inexplicably empty trace backend.
+
+| Source field | Host added |
+|---|---|
+| `observability.tracing.endpoint` (when `enabled: true`) | bare hostname (port stripped) |
+
+The auto-merge fires at **both** build time (`forge package` →
+`egress_allowlist.json` → generated NetworkPolicy) **and** runtime
+(`forge run` dev mode), so dev and prod behave identically. Disabled
+tracing produces no entry — turning tracing off in yaml does NOT
+leave a stale entry punched through. Malformed endpoints are silently
+skipped: the build never blocks on telemetry config. See
+[Observability — Tracing](../core-concepts/observability-tracing.md)
+for the full reference.
+
 ## Build Artifacts
 
 The `EgressStage` generates:


### PR DESCRIPTION
## Summary

Single docs-only PR documenting the **OpenTelemetry Tracing v1** initiative (#108) that shipped across PRs #122–#128 (issues #101–#107). No code changes — just the operator-facing surface for the 7 phases.

## New file

**`docs/core-concepts/observability-tracing.md`** — comprehensive reference (≈350 lines). Quick-start yaml + cli, full schema table, config precedence, every OTEL_* env var, the 6 standard samplers, ASCII span hierarchy diagram, GenAI semconv + `forge.*` attribute table, multi-hop propagation diagram, audit ↔ trace cross-link semantics, egress-enforced OTLP + build-time auto-merge, disabled-path semantics, runnable verification script, cross-reference block. Ordered 9 in the core-concepts nav, after `scheduling.md`.

## Updated docs

| File | What changed |
|---|---|
| `docs/reference/forge-yaml-schema.md` | `observability:` block in the schema example + dedicated section with field table + resolution-order recap + egress auto-merge note |
| `docs/reference/cli-reference.md` | Nine `--otel-*` flags on `forge run` + two new examples |
| `docs/reference/environment-variables.md` | New section: 10 standard `OTEL_*` env vars Forge honors + precedence note |
| `docs/security/audit-logging.md` | `trace_id` / `span_id` added to the schema field table; new "Trace cross-link (OTel v1, #105)" subsection documenting audit-row ↔ trace-tree pivots in both directions; softened the "separate path from OTel" framing (still failure-domain-isolated at export, but now share a join key) |
| `docs/security/egress-control.md` | New "OTel collector domain auto-extension (#107)" subsection alongside auth-provider + MCP-server auto-extensions; documents the build/runtime symmetric auto-merge and the disabled-tracing-no-stale-entry invariant |
| `docs/deployment/monitoring.md` | New "Distributed Tracing (OpenTelemetry)" section after Health Checks |
| `README.md` | Core Concepts row linking to the new tracing doc |
| `CHANGELOG.md` | "OpenTelemetry tracing v1" entry at the top of Unreleased > Added with per-issue / per-PR mapping for all 7 phases |
| `.claude/skills/forge.md` | New § 12.9 Observability subsection; § 13 CLI surface updated; § 14 yaml schema updated; § 17 audit-event reference notes `trace_id` / `span_id` auto-stamping; § 18 workstream recap gains an OTel v1 row; § 19 docs map gains the new doc; § 20 recipes gains three entries (enable tracing, pivot audit → trace, multi-hop propagation) |

## Cross-reference web

The new comprehensive doc is reachable from 8 places:

- `README.md` core concepts row
- `docs/reference/forge-yaml-schema.md` § `observability.tracing`
- `docs/reference/cli-reference.md` § `forge run` flag descriptions
- `docs/reference/environment-variables.md` § OTel section
- `docs/security/audit-logging.md` § Trace cross-link
- `docs/security/egress-control.md` § OTel collector auto-extension
- `docs/deployment/monitoring.md` § Distributed Tracing
- `.claude/skills/forge.md` § 12.9 + § 19 + § 20

## Validation

- [x] Broken-link grep against `README.md` + `docs/` + `.claude/skills/` returned no real broken links (3 false positives where the regex matched outer parenthetical text rather than `[text](url.md)` link syntax)
- [x] Every `observability-tracing.md` reference resolves to the new file path
- [x] `.claude/skills/forge.md` table-of-contents anchors stay synchronized with the section headings below
- [x] `CHANGELOG.md` style follows the existing Unreleased > Added pattern (issue references + PR mapping in the bullet body)

## Why one PR and not seven

The OTel initiative shipped as 7 separate code PRs (one per phase) per the user's "strict 7-PR plan" directive. Docs would naturally arrive in one sweep because the user-facing surface is interconnected — the schema doc references the CLI flags doc references the env-vars doc references the tracing doc. Splitting docs per phase would create cross-references between unmerged docs branches. The single sweep keeps every link resolvable at HEAD.

## Test plan

- [ ] Render `docs/core-concepts/observability-tracing.md` in your docs builder; confirm the ASCII span tree and propagation diagram render correctly
- [ ] Click every link in the cross-reference block — they should resolve to existing anchors and files
- [ ] Render `.claude/skills/forge.md` § 12.9 in Claude Code and confirm the table-of-contents anchor `#129-observability--opentelemetry-tracing-otel-v1-108` resolves
- [ ] Confirm `CHANGELOG.md` Unreleased > Added > OTel entry renders cleanly in release-notes preview

## Refs

- Documents #108 (initiative)
- Pairs with merged code PRs: #122 (Phase 0), #123 (Phase 1), #124 (Phase 2), #125 (Phase 3), #126 (Phase 4), #127 (Phase 5), #128 (Phase 6)