### PR TITLE
fix(runtime): stop persisting empty assistant turns on finish_reason=length (closes #131)

### DIFF
--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -15,6 +15,23 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+// emptyAssistantPlaceholder is the content substituted for an assistant
+// message that came back with both empty content AND no tool calls —
+// typically because the provider hit `finish_reason: length` (the
+// model's max output token cap). Without this substitution the
+// assistant turn would be invalid per the OpenAI chat-completions
+// schema, and strict providers (Moonshot, hosted OpenRouter, OpenAI
+// strict mode) reject every subsequent conversation that includes the
+// turn — silently breaking every followup message in long-running
+// channel threads via session recovery. See issue #131.
+//
+// The string is intentionally human-readable so an operator inspecting
+// `.forge/sessions/<task>.json` understands the truncation. It is
+// also the sentinel sanitizeMessages strips on session recovery, so
+// both the persisted shape and the recovery path agree on what an
+// "empty turn" looks like.
+const emptyAssistantPlaceholder = "(continuing — previous response was truncated by output token limit)"
+
 // ToolExecutor provides tool execution capabilities to the engine.
 // The tools.Registry satisfies this interface via Go structural typing.
 type ToolExecutor interface {
@@ -372,8 +389,32 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 			return nil, fmt.Errorf("after LLM call hook: %w", err)
 		}
 
-		// Append assistant message to memory
-		mem.Append(resp.Message)
+		// Append assistant message to memory.
+		//
+		// Issue #131 — when the LLM hits finish_reason=length (or otherwise
+		// returns empty content) AND made no tool calls, the assistant turn
+		// has neither content nor tool_calls. That shape is invalid per the
+		// OpenAI chat-completions schema; strict providers (Moonshot,
+		// hosted OpenRouter, OpenAI strict mode) reject any subsequent
+		// conversation that includes such a turn with HTTP 400. The in-loop
+		// recovery below at "If the LLM returned empty text after executing
+		// tools" papers over it for the current task, but `persistSession`
+		// at the end of Execute writes the polluted memory to disk — and
+		// the next request that recovers this session hits the strict
+		// validator and returns "something went wrong" to every followup.
+		//
+		// Substitute a placeholder content string instead of skipping the
+		// Append entirely. Skipping would break the assistant↔user turn
+		// pairing the empty-content recovery branch relies on (it appends
+		// a user nudge that must follow an assistant turn). The placeholder
+		// is non-empty so strict validators accept the message, and it
+		// names the failure mode so an operator scanning a recovered
+		// session understands what happened.
+		assistantMsg := resp.Message
+		if assistantMsg.Content == "" && len(assistantMsg.ToolCalls) == 0 {
+			assistantMsg.Content = emptyAssistantPlaceholder
+		}
+		mem.Append(assistantMsg)
 
 		// Check if we're done: the definitive signal is the absence of tool
 		// calls. FinishReason is unreliable — some providers return "stop"

--- a/forge-core/runtime/loop_session_recovery_test.go
+++ b/forge-core/runtime/loop_session_recovery_test.go
@@ -1,0 +1,353 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// TestExecute_EmptyAssistantTurn_NotPersistedAsInvalidShape is the
+// regression test for issue #131. When the LLM hits `finish_reason: length`
+// and returns an assistant message with empty content AND no tool calls,
+// the executor MUST NOT persist that invalid shape into memory. The
+// fix substitutes a placeholder content string so the assistant turn
+// remains a valid chat-completions message.
+//
+// Before the fix, memory ended with the sequence
+//
+//	... assistant(content="", tool_calls=[]) → user(nudge) → assistant(real)
+//
+// and persistSession wrote that verbatim to disk. The next request that
+// recovered the session sent the empty assistant turn to the provider,
+// which rejected the conversation with HTTP 400 — every Slack-thread
+// followup turned into "something went wrong while processing your
+// request, please try again."
+//
+// After the fix, the first turn is normalized to
+//
+//	... assistant(content=emptyAssistantPlaceholder, tool_calls=[]) → user(nudge) → assistant(real)
+//
+// which strict OpenAI-spec validators accept.
+func TestExecute_EmptyAssistantTurn_NotPersistedAsInvalidShape(t *testing.T) {
+	call := 0
+	client := &mockLLMClient{
+		chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+			call++
+			switch call {
+			case 1:
+				// Iteration 1: tool call. Produces a tool message that
+				// satisfies the "i > 0 → fire continuation nudge" gate
+				// on the next iteration's empty response.
+				return &llm.ChatResponse{
+					Message: llm.ChatMessage{
+						Role: llm.RoleAssistant,
+						ToolCalls: []llm.ToolCall{{
+							ID:       "tc-1",
+							Type:     "function",
+							Function: llm.FunctionCall{Name: "echo", Arguments: `{}`},
+						}},
+					},
+					FinishReason: "tool_calls",
+				}, nil
+			case 2:
+				// Iteration 2: empty content, no tool calls,
+				// finish_reason=length — the exact shape that causes
+				// session poisoning.
+				return &llm.ChatResponse{
+					Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: ""},
+					FinishReason: "length",
+				}, nil
+			default:
+				// Empty-response recovery retry: now produces real content.
+				return &llm.ChatResponse{
+					Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "here is the summary"},
+					FinishReason: "stop",
+				}, nil
+			}
+		},
+	}
+	tools := &mockToolExecutor{
+		executeFunc: func(_ context.Context, _ string, _ json.RawMessage) (string, error) {
+			return "echoed", nil
+		},
+	}
+	// Persist to a temp store so we can inspect the saved messages
+	// after Execute returns.
+	store, err := NewMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: client, Tools: tools, MaxIterations: 5,
+		ModelName: "test", Provider: "openai", Store: store,
+	})
+
+	task := &a2a.Task{ID: "task-empty-turn"}
+	msg := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{
+		{Kind: a2a.PartKindText, Text: "hi"},
+	}}
+	if _, err := exec.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	saved, err := store.Load(task.ID)
+	if err != nil || saved == nil {
+		t.Fatalf("Load: err=%v saved=%v", err, saved)
+	}
+
+	// Scan every persisted message: no assistant turn may have empty
+	// content AND no tool_calls — that is the invalid shape the bug
+	// produced.
+	for i, m := range saved.Messages {
+		if m.Role == llm.RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
+			t.Errorf("persisted message %d is an assistant with empty content + no tool_calls "+
+				"(the issue #131 shape); full sequence: %s", i, summarizeRoles(saved.Messages))
+		}
+	}
+
+	// Positive check: the placeholder substitution should have happened
+	// exactly once (the empty turn). Other assistant turns are unchanged.
+	placeholderHits := 0
+	for _, m := range saved.Messages {
+		if m.Role == llm.RoleAssistant && m.Content == emptyAssistantPlaceholder {
+			placeholderHits++
+		}
+	}
+	if placeholderHits != 1 {
+		t.Errorf("expected exactly 1 placeholder-substituted assistant turn; got %d. sequence: %s",
+			placeholderHits, summarizeRoles(saved.Messages))
+	}
+}
+
+// TestLoadFromStore_StripsLegacyEmptyAssistantTurns is the
+// defense-in-depth half of the fix: even a session written by a
+// pre-#131 build (which would have persisted the raw empty-content
+// assistant message) gets sanitized on recovery. No on-disk
+// migration is required — operators can upgrade without losing
+// long-running channel threads, and the bad shape never reaches the
+// provider.
+func TestLoadFromStore_StripsLegacyEmptyAssistantTurns(t *testing.T) {
+	// Construct a SessionData mirroring the persisted shape from the
+	// real Slack reproducer in issue #131:
+	//   user, assistant(tool_calls), tool, assistant(content="",tc=[]),
+	//   user(nudge), assistant(real)
+	saved := &SessionData{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "review PR #82"},
+			{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+				ID: "tc-1", Type: "function",
+				Function: llm.FunctionCall{Name: "gh_diff", Arguments: `{}`},
+			}}},
+			{Role: llm.RoleTool, ToolCallID: "tc-1", Content: "<diff>"},
+			// THE POISON — pre-#131 builds wrote this verbatim.
+			{Role: llm.RoleAssistant, Content: "", ToolCalls: nil},
+			{Role: llm.RoleUser, Content: "Your response was empty. Please provide a brief summary..."},
+			{Role: llm.RoleAssistant, Content: "Manual review of PR #82..."},
+		},
+	}
+
+	mem := NewMemory("system", 100_000, "test")
+	mem.LoadFromStore(saved)
+
+	// The poison must be gone.
+	for i, m := range mem.Messages() {
+		if m.Role == llm.RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
+			t.Errorf("recovered message %d still has the issue #131 shape; sequence: %s",
+				i, summarizeRoles(mem.Messages()))
+		}
+	}
+
+	// And the real content (both the tool-call assistant and the final
+	// summary assistant) must survive — sanitization must NOT be
+	// over-eager.
+	got := summarizeRoles(mem.Messages())
+	for _, want := range []string{"user(review PR", "assistant[tc:tc-1]", "tool", "user(Your response", "assistant(Manual review"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("recovered sequence missing %q; got %s", want, got)
+		}
+	}
+}
+
+// TestExecute_RecoveredSessionRoundTripsThroughStrictValidator pairs
+// the persistence-side fix and the recovery-side fix end-to-end. We
+// simulate a strict OpenAI-spec provider that returns HTTP 400 on
+// any assistant turn with empty content AND no tool calls. The
+// session from the first task gets persisted, the executor recovers
+// it for the second task, and the second task must succeed — which
+// it only does if NEITHER pipeline (persist or recover) lets the
+// empty turn reach the strict validator.
+func TestExecute_RecoveredSessionRoundTripsThroughStrictValidator(t *testing.T) {
+	store, err := NewMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+
+	// Strict provider: rejects conversations containing the bad turn.
+	strictClient := &mockLLMClient{
+		chatFunc: func(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			for i, m := range req.Messages {
+				if m.Role == llm.RoleAssistant && strings.TrimSpace(m.Content) == "" && len(m.ToolCalls) == 0 {
+					return nil, errStrictValidatorRejected(i)
+				}
+			}
+			return &llm.ChatResponse{
+				Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "ack"},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+
+	// First-task client: forces the empty-turn path so persistence has
+	// something to sanitize. After the in-loop recovery, it returns a
+	// real response.
+	first := 0
+	firstTaskClient := &mockLLMClient{
+		chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+			first++
+			switch first {
+			case 1:
+				return &llm.ChatResponse{Message: llm.ChatMessage{
+					Role: llm.RoleAssistant,
+					ToolCalls: []llm.ToolCall{{ID: "tc-1", Type: "function",
+						Function: llm.FunctionCall{Name: "noop", Arguments: `{}`}}},
+				}, FinishReason: "tool_calls"}, nil
+			case 2:
+				return &llm.ChatResponse{Message: llm.ChatMessage{
+					Role: llm.RoleAssistant, Content: "",
+				}, FinishReason: "length"}, nil
+			default:
+				return &llm.ChatResponse{Message: llm.ChatMessage{
+					Role: llm.RoleAssistant, Content: "first-task done",
+				}, FinishReason: "stop"}, nil
+			}
+		},
+	}
+	tools := &mockToolExecutor{executeFunc: func(_ context.Context, _ string, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	}}
+
+	// Task 1 — produces the empty-turn shape in-memory, recovers via
+	// the loop's existing empty-response branch, persists.
+	exec1 := NewLLMExecutor(LLMExecutorConfig{
+		Client: firstTaskClient, Tools: tools, MaxIterations: 5,
+		ModelName: "x", Provider: "openai", Store: store,
+	})
+	task := &a2a.Task{ID: "recovery-roundtrip"}
+	msg := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{
+		{Kind: a2a.PartKindText, Text: "hi"},
+	}}
+	if _, err := exec1.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+
+	// Task 2 — same task_id (Slack-thread-style continuation). The
+	// session is recovered from disk. The strict validator sees the
+	// recovered conversation; if either persistence (Option A2) or
+	// recovery (Option B) leaks the empty turn, this fails.
+	exec2 := NewLLMExecutor(LLMExecutorConfig{
+		Client: strictClient, Tools: tools, MaxIterations: 5,
+		ModelName: "x", Provider: "openai", Store: store,
+	})
+	followup := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{
+		{Kind: a2a.PartKindText, Text: "what about the unexported helper?"},
+	}}
+	if _, err := exec2.Execute(context.Background(), task, followup); err != nil {
+		t.Fatalf("recovered followup must succeed; got: %v", err)
+	}
+}
+
+// TestStripEmptyAssistantTurns_PreservesValidMessages confirms the
+// strip pass is surgical — it removes only the bad shape, not
+// adjacent legitimate turns.
+func TestStripEmptyAssistantTurns_PreservesValidMessages(t *testing.T) {
+	in := []llm.ChatMessage{
+		{Role: llm.RoleUser, Content: "hello"},
+		{Role: llm.RoleAssistant, Content: "hi there"},                     // valid — keep
+		{Role: llm.RoleAssistant, Content: "", ToolCalls: nil},             // poison — drop
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "tc-1"}}}, // valid — has tool_calls
+		{Role: llm.RoleTool, ToolCallID: "tc-1", Content: "result"},
+		{Role: llm.RoleAssistant, Content: emptyAssistantPlaceholder}, // post-Option-A2 placeholder — keep
+		{Role: llm.RoleUser, Content: "thanks"},
+	}
+	got := stripEmptyAssistantTurns(in)
+	if len(got) != 6 {
+		t.Errorf("expected 6 messages after strip, got %d: %s", len(got), summarizeRoles(got))
+	}
+	for _, m := range got {
+		if m.Role == llm.RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
+			t.Errorf("poison shape survived strip; sequence: %s", summarizeRoles(got))
+		}
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+func summarizeRoles(msgs []llm.ChatMessage) string {
+	var b strings.Builder
+	for i, m := range msgs {
+		if i > 0 {
+			b.WriteString(" → ")
+		}
+		switch m.Role {
+		case llm.RoleAssistant:
+			if len(m.ToolCalls) > 0 {
+				ids := make([]string, 0, len(m.ToolCalls))
+				for _, tc := range m.ToolCalls {
+					ids = append(ids, tc.ID)
+				}
+				b.WriteString("assistant[tc:" + strings.Join(ids, ",") + "]")
+			} else {
+				preview := m.Content
+				if len(preview) > 20 {
+					preview = preview[:20]
+				}
+				b.WriteString("assistant(" + preview + ")")
+			}
+		case llm.RoleUser:
+			preview := m.Content
+			if len(preview) > 20 {
+				preview = preview[:20]
+			}
+			b.WriteString("user(" + preview + ")")
+		case llm.RoleTool:
+			b.WriteString("tool")
+		default:
+			b.WriteString(string(m.Role))
+		}
+	}
+	return b.String()
+}
+
+func errStrictValidatorRejected(idx int) error {
+	return errors.New("strict validator: message at index " + strconvItoa(idx) +
+		" is an assistant turn with empty content and no tool_calls (HTTP 400)")
+}
+
+// Local helper to avoid colliding with audit_payload_capture.go's itoa
+// while keeping this test file zero-import beyond what's already used.
+func strconvItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/forge-core/runtime/memory.go
+++ b/forge-core/runtime/memory.go
@@ -119,15 +119,37 @@ func (m *Memory) Messages() []llm.ChatMessage {
 }
 
 // LoadFromStore restores memory state from a persisted SessionData.
-// It sanitizes the loaded messages by stripping orphaned tool calls —
-// assistant messages whose tool_calls have no matching tool result.
-// This prevents the Responses API from rejecting recovered sessions
-// with "No tool output found for function call".
+// It runs the loaded messages through sanitizeMessages, which strips
+// the two known kinds of corruption that cause strict providers to
+// reject the recovered conversation:
+//
+//  1. Orphaned tool_calls — assistant messages whose tool_calls have
+//     no matching tool result (Responses API: "No tool output found
+//     for function call").
+//  2. Empty assistant turns — assistant messages with both empty
+//     content AND no tool_calls (issue #131). The OpenAI
+//     chat-completions schema considers that shape invalid; Moonshot,
+//     hosted OpenRouter, and OpenAI strict mode return HTTP 400 if a
+//     recovered conversation contains one. Such turns appear when the
+//     provider hits `finish_reason: length` and the in-loop empty-
+//     response recovery fires — pre-#131 builds persisted the empty
+//     turn alongside the recovered real response. Stripping on load
+//     rescues sessions written by those builds without a migration.
 func (m *Memory) LoadFromStore(data *SessionData) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.messages = sanitizeToolCalls(data.Messages)
+	m.messages = sanitizeMessages(data.Messages)
 	m.existingSummary = data.Summary
+}
+
+// sanitizeMessages strips the two known kinds of corruption from a
+// loaded message slice (see LoadFromStore). The two passes are kept
+// separate so a future caller that only needs one (or wants to add a
+// third) can compose them individually.
+func sanitizeMessages(msgs []llm.ChatMessage) []llm.ChatMessage {
+	msgs = sanitizeToolCalls(msgs)
+	msgs = stripEmptyAssistantTurns(msgs)
+	return msgs
 }
 
 // sanitizeToolCalls removes tool calls from assistant messages that have
@@ -157,6 +179,25 @@ func sanitizeToolCalls(msgs []llm.ChatMessage) []llm.ChatMessage {
 		}
 	}
 	return msgs
+}
+
+// stripEmptyAssistantTurns drops assistant messages that have both
+// empty content AND no tool_calls. See LoadFromStore for the full
+// rationale (issue #131). This is the defense-in-depth half of the
+// fix — the Execute loop now substitutes a placeholder content
+// string before persisting so newly-written sessions never contain
+// the bad shape, but sessions already on disk from pre-#131 builds
+// (and any future regression of the source-side guard) still get
+// rescued on load.
+func stripEmptyAssistantTurns(msgs []llm.ChatMessage) []llm.ChatMessage {
+	out := msgs[:0]
+	for _, m := range msgs {
+		if m.Role == llm.RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // Reset clears the conversation history (keeps the system prompt).


### PR DESCRIPTION
## Summary

Closes #131.

Long-running channel threads (the reproducer was a real Slack PR-review session) succeeded on the **first** message and then returned `"something went wrong while processing your request, please try again"` on **every followup**. The audit log told the operator nothing — the failed turns produced no `llm_call` event because the executor errored out before emitting one.

## Root cause

`forge-core/runtime/loop.go:376` wrote the LLM's assistant message into memory **unconditionally**, before checking content:

```go
// Append assistant message to memory
mem.Append(resp.Message)
```

When the LLM hit `finish_reason: length` (output token cap) and returned an assistant message with **empty content AND no tool_calls**, that invalid-per-OpenAI-spec turn landed in memory. The in-loop empty-response recovery branch at `loop.go:492` papered over it for the **current** task (nudge + retry → real response), but `persistSession` at the end of `Execute` wrote the polluted memory to `.forge/sessions/<task_id>.json`. The next request that recovered the session sent the empty turn straight to the provider; strict OpenAI-spec gateways (Moonshot, hosted OpenRouter, OpenAI strict mode) returned HTTP 400; the executor caught the error and returned the canned fallback.

Every subsequent message in the same thread kept replaying the same poisoned history and kept failing.

## Fix — both halves

### Option A2 — source-side substitution (`loop.go`)

```go
assistantMsg := resp.Message
if assistantMsg.Content == "" && len(assistantMsg.ToolCalls) == 0 {
    assistantMsg.Content = emptyAssistantPlaceholder
}
mem.Append(assistantMsg)
```

Substitutes `"(continuing — previous response was truncated by output token limit)"` for the empty content. **Skipping the append entirely would break** the assistant ↔ user turn pairing the existing empty-response recovery branch needs. The placeholder preserves turn structure, is non-empty so strict validators accept it, and names the failure mode so an operator inspecting a recovered session sees what happened.

### Option B — defense-in-depth on recovery (`memory.go`)

`LoadFromStore` now runs loaded messages through a new `sanitizeMessages` umbrella that composes the pre-existing `sanitizeToolCalls` pass (strips orphaned tool_calls) with a new `stripEmptyAssistantTurns` pass:

```go
func stripEmptyAssistantTurns(msgs []llm.ChatMessage) []llm.ChatMessage {
    out := msgs[:0]
    for _, m := range msgs {
        if m.Role == llm.RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
            continue
        }
        out = append(out, m)
    }
    return out
}
```

**Rescues sessions on disk from pre-fix builds with no migration script.** Operators upgrade and long-running channel threads keep working. Also catches any future regression of the source-side guard.

## Why ship both

- **Option A2** prevents the bug source — new sessions written by this build never contain the bad shape.
- **Option B** is the safety net — sessions already corrupted on disk get rescued on load, no `rm` workaround required after upgrade.

## Coverage — 4 new tests in `forge-core/runtime/loop_session_recovery_test.go`

| Test | What it pins |
|---|---|
| `TestExecute_EmptyAssistantTurn_NotPersistedAsInvalidShape` | Drives a single iteration where LLM returns `Content:"", ToolCalls:nil, FinishReason:"length"`; asserts the persisted `SessionData` contains **no** assistant turn with the issue #131 shape AND **exactly one** placeholder-substituted turn |
| `TestLoadFromStore_StripsLegacyEmptyAssistantTurns` | Constructs a `SessionData` mirroring the real Slack reproducer (`user → assistant(tool_calls) → tool → assistant(empty) → user(nudge) → assistant(real)`); asserts poison is gone AND every legitimate turn survives. Pins "sanitization must not be over-eager" |
| `TestExecute_RecoveredSessionRoundTripsThroughStrictValidator` | End-to-end pairing. Task 1 persists; Task 2 (same `task_id`) loads through a mock strict-validator provider that returns HTTP 400 on the bad shape. Task 2 must succeed — which it only does if neither pipeline leaks the empty turn |
| `TestStripEmptyAssistantTurns_PreservesValidMessages` | Surgical-strip check. The new pass removes only the bad shape; valid messages, tool-call-bearing assistants, and the placeholder-substituted assistant from Option A2 all survive |

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean in `forge-core/` (all packages)
- [x] `go test -race ./...` clean in `forge-cli/` (all packages — no downstream behavior change)
- [x] `golangci-lint run ./forge-core/...` → **0 issues**
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## Test plan (post-merge smoke)

The original reproducer:

```sh
# 1. Spin up a long-running Slack thread on an agent with a model that
#    hits finish_reason: length (e.g. moonshotai/Kimi-K2.6 via openai
#    provider, output_tokens cap 2048).
# 2. Trigger a response long enough to cap.
# 3. Send a followup in the same thread.
#
# Pre-fix: followup returns "something went wrong..."
# Post-fix: followup succeeds.
```

For operators with existing corrupted sessions on disk: just upgrade and try the followup. Option B sanitizes on load — no `rm` needed.

## Refs

- Closes #131
- Original v0.14.0 release where the masked symptom was discoverable: https://github.com/initializ/forge/releases/tag/v0.14.0
- Real Slack reproducer in issue body