### PR TITLE
fix(skills/code-review): provider routing + OpenAI-compatible endpoint (closes #133)

### DIFF
--- a/forge-skills/local/embedded/code-review/SKILL.md
+++ b/forge-skills/local/embedded/code-review/SKILL.md
@@ -22,10 +22,13 @@ metadata:
           - ANTHROPIC_API_KEY
           - OPENAI_API_KEY
         optional:
+          - REVIEW_PROVIDER
           - REVIEW_MODEL
           - REVIEW_MAX_DIFF_BYTES
           - GH_TOKEN
           - FORGE_REVIEW_STANDARDS_DIR
+          - OPENAI_BASE_URL
+          - OPENAI_USE_RESPONSES_API
     egress_domains:
       - api.anthropic.com
       - api.openai.com
@@ -45,15 +48,28 @@ AI-powered code review that analyzes diffs and individual files for bugs, securi
 Set at least one LLM API key:
 
 ```bash
-# Option A: Anthropic (preferred)
+# Option A: Anthropic
 export ANTHROPIC_API_KEY="sk-ant-..."
 
-# Option B: OpenAI
+# Option B: OpenAI or any OpenAI-compatible provider (Together, OpenRouter, Groq, ...)
 export OPENAI_API_KEY="sk-..."
+export OPENAI_BASE_URL="https://api.together.ai/v1"   # only when not using openai.com
 
 # Optional: override the model (defaults: claude-sonnet-4-20250514 / gpt-4o)
-export REVIEW_MODEL="claude-sonnet-4-20250514"
+export REVIEW_MODEL="moonshotai/Kimi-K2.6"
+
+# Optional: force a specific provider when both keys are set
+export REVIEW_PROVIDER="openai"   # or "anthropic"
 ```
+
+**Provider selection** (auto-detected when `REVIEW_PROVIDER` is unset):
+
+1. If `REVIEW_PROVIDER` is set, it wins.
+2. Else if `REVIEW_MODEL` starts with `claude-` or `anthropic/`, use Anthropic.
+3. Else if only one API key is set, use that provider.
+4. Else (both keys, no model hint): use OpenAI.
+
+This precedence fixes the common deployment where both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` live in `.forge/secrets.enc` (one is stale or for a different skill). Pre-fix the skill always preferred Anthropic and returned 401 against the stale key.
 
 For GitHub PR review, also set:
 
@@ -73,12 +89,15 @@ This skill only reads diffs — it never posts comments, applies labels, or merg
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| ANTHROPIC_API_KEY | one-of | Anthropic API key (preferred) |
-| OPENAI_API_KEY | one-of | OpenAI API key (fallback) |
-| REVIEW_MODEL | no | Override LLM model name |
+| ANTHROPIC_API_KEY | one-of | Anthropic API key |
+| OPENAI_API_KEY | one-of | OpenAI or OpenAI-compatible (Together, OpenRouter, Groq, ...) API key |
+| REVIEW_PROVIDER | no | Explicit provider override: `anthropic` or `openai`. When unset, auto-detected from `REVIEW_MODEL` prefix, then by which key is set. Prefers `openai` when both keys exist and no model hint disambiguates |
+| REVIEW_MODEL | no | Override LLM model name. Default: `claude-sonnet-4-20250514` (anthropic) / `gpt-5.4` (openai) |
 | REVIEW_MAX_DIFF_BYTES | no | Max diff size before truncation (default: 100000) |
 | GH_TOKEN | no | GitHub token for PR diffs — read-only access is sufficient |
 | FORGE_REVIEW_STANDARDS_DIR | no | Path to `.forge-review/standards/` directory for custom rules |
+| OPENAI_BASE_URL | no | Base URL for OpenAI-compatible providers (default: `https://api.openai.com/v1`). Always uses `/chat/completions` — see `OPENAI_USE_RESPONSES_API` for the proprietary Responses API |
+| OPENAI_USE_RESPONSES_API | no | Set to `1` to use OpenAI's proprietary `/responses` endpoint (Codex/OAuth flow). Default off. Only relevant when `OPENAI_BASE_URL` points at `api.openai.com` |
 
 ## Tool: code_review_diff
 

--- a/forge-skills/local/embedded/code-review/scripts/code-review-diff.sh
+++ b/forge-skills/local/embedded/code-review/scripts/code-review-diff.sh
@@ -4,7 +4,26 @@
 #
 # Requires: curl, jq, git
 # Env: ANTHROPIC_API_KEY or OPENAI_API_KEY (at least one)
-# Optional: REVIEW_MODEL, REVIEW_MAX_DIFF_BYTES, GH_TOKEN, FORGE_REVIEW_STANDARDS_DIR
+# Optional:
+#   REVIEW_PROVIDER          — "anthropic" or "openai"; explicit operator override.
+#                              When unset, auto-detected from REVIEW_MODEL prefix
+#                              ("claude-*" → anthropic) then by which API key is
+#                              present, then prefers openai when both are set
+#                              (fixes #133: Anthropic-first was wrong when both
+#                              keys exist, e.g. via .forge/secrets.enc).
+#   REVIEW_MODEL             — provider-specific model name; falls back per provider.
+#   REVIEW_MAX_DIFF_BYTES    — cap on diff size; default 100000.
+#   GH_TOKEN                 — GitHub token for `gh pr diff` / API fallback.
+#   FORGE_REVIEW_STANDARDS_DIR — directory of *.md standards to inject as context.
+#   OPENAI_BASE_URL          — base URL for OpenAI-compatible providers
+#                              (Together.ai, OpenRouter, Groq, Fireworks, ...).
+#                              Default: https://api.openai.com/v1. Uses
+#                              /chat/completions regardless of value — see
+#                              OPENAI_USE_RESPONSES_API to opt into the
+#                              proprietary Responses API.
+#   OPENAI_USE_RESPONSES_API — set to "1" to use OpenAI's proprietary /responses
+#                              endpoint (Codex/OAuth flow). Default off. Only
+#                              relevant when OPENAI_BASE_URL points at openai.com.
 set -euo pipefail
 
 # --- Read and validate input first (agent can fix these) ---
@@ -267,8 +286,59 @@ if [ "$TRUNCATED" = "true" ]; then
 [NOTE: Diff was truncated at ${MAX_DIFF_BYTES} bytes. Some files may be missing from the review.]"
 fi
 
+# --- Select provider ---
+#
+# Precedence (closes #133):
+#   1. REVIEW_PROVIDER if set — explicit operator override, wins always.
+#   2. REVIEW_MODEL prefix — "claude-*" → anthropic, otherwise → openai.
+#      Most operators set REVIEW_MODEL when they care which provider; the
+#      model name carries the signal.
+#   3. If only one of the two API keys is set, use that one.
+#   4. If both keys are set with no other signal, prefer openai.
+#      (Pre-#133 default was anthropic-first, which broke every operator
+#      who had a stale ANTHROPIC_API_KEY co-resident with a live
+#      OPENAI_API_KEY in .forge/secrets.enc.)
+PROVIDER="${REVIEW_PROVIDER:-}"
+if [ -z "$PROVIDER" ]; then
+  if [ -n "${REVIEW_MODEL:-}" ]; then
+    case "$REVIEW_MODEL" in
+      claude-*|anthropic/*) PROVIDER="anthropic" ;;
+      *)                    PROVIDER="openai"    ;;
+    esac
+  elif [ -n "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+    PROVIDER="anthropic"
+  elif [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    PROVIDER="openai"
+  else
+    # Both present (or neither, which fails the key check below). Default
+    # to openai — see precedence comment above.
+    PROVIDER="openai"
+  fi
+fi
+
+# Validate the selected provider has its key. Fail with a clear message
+# instead of letting the curl call return a confusing 401.
+case "$PROVIDER" in
+  anthropic)
+    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+      echo '{"error": "REVIEW_PROVIDER=anthropic (or REVIEW_MODEL inferred Anthropic) but ANTHROPIC_API_KEY is not set"}' >&2
+      exit 1
+    fi
+    ;;
+  openai)
+    if [ -z "${OPENAI_API_KEY:-}" ]; then
+      echo '{"error": "REVIEW_PROVIDER=openai (or REVIEW_MODEL inferred OpenAI) but OPENAI_API_KEY is not set"}' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "{\"error\": \"REVIEW_PROVIDER must be 'anthropic' or 'openai'; got: $PROVIDER\"}" >&2
+    exit 1
+    ;;
+esac
+
 # --- Route to LLM API ---
-if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+if [ "$PROVIDER" = "anthropic" ]; then
   # Anthropic Claude API
   MODEL="${REVIEW_MODEL:-claude-sonnet-4-20250514}"
 
@@ -311,8 +381,27 @@ if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
   # Extract text content from Anthropic response
   REVIEW_TEXT=$(echo "$BODY" | jq -r '.content[0].text // empty')
 
-elif [ -n "${OPENAI_API_KEY:-}" ]; then
-  # OpenAI API — supports both Chat Completions and Responses API (OAuth)
+elif [ "$PROVIDER" = "openai" ]; then
+  # OpenAI / OpenAI-compatible API.
+  #
+  # Endpoint shape selection (closes #133 Bug 2):
+  #
+  # OPENAI_BASE_URL is a base URL pointer. It is set by operators using
+  # OpenAI-compatible providers (Together.ai, OpenRouter, Groq,
+  # Fireworks, Anyscale, vLLM, llama.cpp's server, ...) — none of which
+  # implement OpenAI's proprietary /responses endpoint. They all
+  # implement /chat/completions only.
+  #
+  # The pre-#133 logic used "OPENAI_BASE_URL is set" as the Responses
+  # API toggle, which was exactly backwards: the variable is
+  # NEGATIVELY correlated with wanting the Responses API. Operators
+  # who set OPENAI_BASE_URL=https://api.together.ai/v1 silently got
+  # POST .../v1/responses → 404.
+  #
+  # Post-fix: always use /chat/completions, regardless of
+  # OPENAI_BASE_URL value. Operators who genuinely need the OpenAI
+  # Responses API (the Codex OAuth flow) opt in explicitly via
+  # OPENAI_USE_RESPONSES_API=1.
   MODEL="${REVIEW_MODEL:-gpt-5.4}"
   OPENAI_BASE="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
 
@@ -322,8 +411,8 @@ elif [ -n "${OPENAI_API_KEY:-}" ]; then
   printf '%s' "$SYSTEM_PROMPT" > "$TEMP_SYSTEM"
   printf '%s' "$USER_PROMPT" > "$TEMP_USER"
 
-  if [ -n "${OPENAI_BASE_URL:-}" ]; then
-    # Responses API (OAuth/Codex flow) — requires streaming
+  if [ "${OPENAI_USE_RESPONSES_API:-0}" = "1" ]; then
+    # OpenAI proprietary Responses API (Codex/OAuth flow) — requires streaming
     API_PAYLOAD=$(jq -n \
       --arg model "$MODEL" \
       --rawfile instructions "$TEMP_SYSTEM" \

--- a/forge-skills/local/embedded/code-review/scripts/code-review-file.sh
+++ b/forge-skills/local/embedded/code-review/scripts/code-review-file.sh
@@ -4,7 +4,17 @@
 #
 # Requires: curl, jq
 # Env: ANTHROPIC_API_KEY or OPENAI_API_KEY (at least one)
-# Optional: REVIEW_MODEL, GH_TOKEN, FORGE_REVIEW_STANDARDS_DIR
+# Optional:
+#   REVIEW_PROVIDER          — "anthropic" or "openai"; explicit override.
+#                              Auto-detected when unset (see #133).
+#   REVIEW_MODEL             — provider-specific model name.
+#   GH_TOKEN                 — GitHub token.
+#   FORGE_REVIEW_STANDARDS_DIR — custom standards dir.
+#   OPENAI_BASE_URL          — base URL for OpenAI-compatible providers.
+#                              Always uses /chat/completions; see
+#                              OPENAI_USE_RESPONSES_API to opt into
+#                              OpenAI's proprietary Responses API.
+#   OPENAI_USE_RESPONSES_API — set to "1" for OpenAI Responses API.
 set -euo pipefail
 
 # --- Read and validate input first (agent can fix these) ---
@@ -182,8 +192,44 @@ USER_PROMPT="${USER_PROMPT}:
 
 ${FILE_CONTENT}"
 
+# --- Select provider (see code-review-diff.sh and #133 for rationale) ---
+PROVIDER="${REVIEW_PROVIDER:-}"
+if [ -z "$PROVIDER" ]; then
+  if [ -n "${REVIEW_MODEL:-}" ]; then
+    case "$REVIEW_MODEL" in
+      claude-*|anthropic/*) PROVIDER="anthropic" ;;
+      *)                    PROVIDER="openai"    ;;
+    esac
+  elif [ -n "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+    PROVIDER="anthropic"
+  elif [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    PROVIDER="openai"
+  else
+    PROVIDER="openai"
+  fi
+fi
+
+case "$PROVIDER" in
+  anthropic)
+    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+      echo '{"error": "REVIEW_PROVIDER=anthropic (or REVIEW_MODEL inferred Anthropic) but ANTHROPIC_API_KEY is not set"}' >&2
+      exit 1
+    fi
+    ;;
+  openai)
+    if [ -z "${OPENAI_API_KEY:-}" ]; then
+      echo '{"error": "REVIEW_PROVIDER=openai (or REVIEW_MODEL inferred OpenAI) but OPENAI_API_KEY is not set"}' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "{\"error\": \"REVIEW_PROVIDER must be 'anthropic' or 'openai'; got: $PROVIDER\"}" >&2
+    exit 1
+    ;;
+esac
+
 # --- Route to LLM API ---
-if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+if [ "$PROVIDER" = "anthropic" ]; then
   MODEL="${REVIEW_MODEL:-claude-sonnet-4-20250514}"
 
   TEMP_SYSTEM=$(mktemp)
@@ -223,8 +269,10 @@ if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
 
   REVIEW_TEXT=$(echo "$BODY" | jq -r '.content[0].text // empty')
 
-elif [ -n "${OPENAI_API_KEY:-}" ]; then
-  # OpenAI API — supports both Chat Completions and Responses API (OAuth)
+elif [ "$PROVIDER" = "openai" ]; then
+  # OpenAI / OpenAI-compatible API. See code-review-diff.sh for the
+  # full rationale on the OPENAI_BASE_URL vs OPENAI_USE_RESPONSES_API
+  # decoupling (closes #133 Bug 2).
   MODEL="${REVIEW_MODEL:-gpt-5.4}"
   OPENAI_BASE="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
 
@@ -234,8 +282,8 @@ elif [ -n "${OPENAI_API_KEY:-}" ]; then
   printf '%s' "$SYSTEM_PROMPT" > "$TEMP_SYSTEM"
   printf '%s' "$USER_PROMPT" > "$TEMP_USER"
 
-  if [ -n "${OPENAI_BASE_URL:-}" ]; then
-    # Responses API (OAuth/Codex flow) — requires streaming
+  if [ "${OPENAI_USE_RESPONSES_API:-0}" = "1" ]; then
+    # OpenAI proprietary Responses API (Codex/OAuth flow) — requires streaming
     API_PAYLOAD=$(jq -n \
       --arg model "$MODEL" \
       --rawfile instructions "$TEMP_SYSTEM" \


### PR DESCRIPTION
## Summary

Closes #133.

Two structural bugs in the `code-review` skill scripts made it unusable for operators who run it against **OpenAI-compatible providers** (Together.ai, OpenRouter, Groq, Fireworks, Anyscale, ...). Both bugs affect `code-review-diff.sh` AND `code-review-file.sh` — same routing pattern in each.

## Bug 1 — strict Anthropic-first routing with no override

```sh
if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
  # Anthropic Claude API
elif [ -n "${OPENAI_API_KEY:-}" ]; then
  # OpenAI API
fi
```

The script picked Anthropic whenever `ANTHROPIC_API_KEY` was non-empty — **even when** `OPENAI_BASE_URL` pointed at an OpenAI-compatible provider, `REVIEW_MODEL` was clearly a non-Anthropic model, or the key was stale (e.g. encrypted in `.forge/secrets.enc` alongside the live OpenAI key for a different skill). Operators saw `Anthropic API returned status 401` and assumed the skill was broken.

## Bug 2 — `OPENAI_BASE_URL` incorrectly triggered the OpenAI Responses API

```sh
if [ -n "${OPENAI_BASE_URL:-}" ]; then
  -X POST "${OPENAI_BASE}/responses"   # ← OpenAI proprietary
else
  -X POST "${OPENAI_BASE}/chat/completions"
fi
```

The Responses API is OpenAI-proprietary (Codex/OAuth flow). Every OpenAI-compatible provider implements `/chat/completions` only. The script's `OPENAI_BASE_URL is set` gate was **negatively correlated** with "operator wants the Responses API": setting `OPENAI_BASE_URL=https://api.together.ai/v1` silently produced `POST .../v1/responses → 404`.

## Fix

### Bug 1 — `REVIEW_PROVIDER` explicit override + smarter auto-detect

```sh
PROVIDER="${REVIEW_PROVIDER:-}"
if [ -z "$PROVIDER" ]; then
  if [ -n "${REVIEW_MODEL:-}" ]; then
    case "$REVIEW_MODEL" in
      claude-*|anthropic/*) PROVIDER="anthropic" ;;
      *)                    PROVIDER="openai"    ;;
    esac
  elif [ -n "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
    PROVIDER="anthropic"
  elif [ -n "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
    PROVIDER="openai"
  else
    PROVIDER="openai"   # both keys, no hint → prefer openai
  fi
fi
```

Precedence: `REVIEW_PROVIDER` > `REVIEW_MODEL` prefix > sole API key > both-keys-default-openai.

Then validate the selected provider has its matching API key with a **clear error** instead of a confusing 401:

```
{"error": "REVIEW_PROVIDER=anthropic (or REVIEW_MODEL inferred Anthropic) but ANTHROPIC_API_KEY is not set"}
```

### Bug 2 — decouple `OPENAI_BASE_URL` from Responses API

Always use `/chat/completions`, regardless of `OPENAI_BASE_URL` value. Operators who genuinely need the OpenAI Responses API opt in explicitly via a new env var:

```sh
if [ "${OPENAI_USE_RESPONSES_API:-0}" = "1" ]; then
  -X POST "${OPENAI_BASE}/responses"
else
  -X POST "${OPENAI_BASE}/chat/completions"
fi
```

## Verification — 5 routing scenarios on both scripts

Smoke-tested with a stub `curl` that records the POST URL:

| # | Setup | Hits | Status |
|---|---|---|---|
| 1 (the bug) | both keys + `REVIEW_MODEL=moonshotai/Kimi-K2.6` + `OPENAI_BASE_URL=together.ai` | `api.together.ai/v1/chat/completions` | ✓ fixed (was `anthropic.com`) |
| 2 | both keys + `REVIEW_PROVIDER=anthropic` | `api.anthropic.com/v1/messages` | ✓ explicit override |
| 3 | `OPENAI_USE_RESPONSES_API=1` | `api.openai.com/v1/responses` | ✓ opt-in works |
| 4 | `REVIEW_MODEL=claude-sonnet-4-…` (no `REVIEW_PROVIDER`) | `api.anthropic.com/v1/messages` | ✓ heuristic works |
| 5 | `REVIEW_PROVIDER=anthropic` + no `ANTHROPIC_API_KEY` | clear error, no curl | ✓ actionable failure |

All five verified on `code-review-diff.sh` AND `code-review-file.sh`. `bash -n` syntax check passes on both. `go test ./...` clean in `forge-core` + `forge-cli` (no Go code touched; confirms SKILL.md edits don't break the validator).

## Documentation updates

`SKILL.md`:
- `env.optional` list gains `REVIEW_PROVIDER`, `OPENAI_BASE_URL`, `OPENAI_USE_RESPONSES_API`.
- Authentication section documents the new provider-selection precedence with a Together.ai example.
- Environment Variables table gets four new rows + clarifies that `OPENAI_BASE_URL` no longer toggles the Responses API.

## Sibling skills

`code-review-github` and `code-review-standards` are `SKILL.md`-only — no scripts that hit LLM APIs. Not affected.

`code-review-file.sh` in the same skill **did** share the bug verbatim and is fixed in this PR with the same patch.

## Migration note

This is a behavior change for operators currently relying on the implicit Anthropic-first preference:

- If you had both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` set and **wanted** the Anthropic path, now set `REVIEW_PROVIDER=anthropic` to keep the same behavior.
- If you had `OPENAI_BASE_URL=https://api.openai.com/v1` and were relying on the Responses API path implicitly, now set `OPENAI_USE_RESPONSES_API=1` to keep it.

Both migrations are one-line env-var additions. The defaults serve the common case (operators on OpenAI-compatible providers) correctly out of the box.

## Refs

- Closes #133
- Real-world reproducer: agent at `/Users/.../agentdemo/pr-reviewer` with `forge.yaml` model `moonshotai/Kimi-K2.6` via `provider: openai` and `OPENAI_BASE_URL=https://api.together.ai/v1` — main loop succeeded against Together.ai, but `code_review_diff` tool subprocess 401'd against `api.anthropic.com`.