### PR TITLE
fix(skills): always pass OPENAI_BASE_URL / ANTHROPIC_BASE_URL / OLLAMA_BASE_URL / GEMINI_BASE_URL to skill subprocesses (closes #137)

### DIFF
--- a/forge-cli/tools/exec.go
+++ b/forge-cli/tools/exec.go
@@ -82,6 +82,27 @@ func (e *SkillCommandExecutor) Run(ctx context.Context, command string, args []s
 	if orgID := os.Getenv("OPENAI_ORG_ID"); orgID != "" {
 		env = append(env, "OPENAI_ORG_ID="+orgID)
 	}
+	// Issue #137 — always-pass standard provider base URL env vars when
+	// present in the parent env. These are the canonical SDK-recognized
+	// variables operators use to redirect provider-shape API calls to a
+	// compatible host (Together.ai, OpenRouter, Groq, Fireworks,
+	// Anyscale via OPENAI_BASE_URL; Bedrock proxy via
+	// ANTHROPIC_BASE_URL; remotely-served Ollama via OLLAMA_BASE_URL).
+	// Treating them like OPENAI_ORG_ID above means every skill that
+	// calls an LLM API directly just works for compatible-provider
+	// deployments without each SKILL.md author having to remember to
+	// declare them in env.optional. Pre-fix every such skill silently
+	// hit the wrong (default-OpenAI) endpoint.
+	for _, name := range []string{
+		"OPENAI_BASE_URL",
+		"ANTHROPIC_BASE_URL",
+		"OLLAMA_BASE_URL",
+		"GEMINI_BASE_URL",
+	} {
+		if v := os.Getenv(name); v != "" {
+			env = append(env, name+"="+v)
+		}
+	}
 	// Pass configured model to skill scripts (e.g., code-review uses REVIEW_MODEL).
 	// This ensures OAuth/Codex users get a compatible model instead of the
 	// script's default (gpt-4o) which may not be supported.

--- a/forge-cli/tools/exec_test.go
+++ b/forge-cli/tools/exec_test.go
@@ -39,3 +39,79 @@ func TestSkillCommandExecutor_NoOrgIDWhenUnset(t *testing.T) {
 		t.Errorf("expected no OPENAI_ORG_ID in env output, got: %s", out)
 	}
 }
+
+// TestSkillCommandExecutor_ProviderBaseURLs_AlwaysPassed pins the
+// Issue #137 invariant: the standard provider base URL env vars
+// (OPENAI_BASE_URL, ANTHROPIC_BASE_URL, OLLAMA_BASE_URL,
+// GEMINI_BASE_URL) MUST flow to every skill subprocess when they
+// are set in the parent env — without each skill having to declare
+// them in its SKILL.md env.optional. These are SDK-recognized
+// standard variables for redirecting provider-shape API calls to
+// compatible hosts (Together.ai, OpenRouter, Groq, Fireworks,
+// Anyscale, remote Ollama, etc.). Pre-fix every such skill silently
+// hit the wrong (default-OpenAI) endpoint.
+//
+// Why one test, not four: the always-passed surface is a single
+// allowlist; running env-print once with all four set covers the
+// invariant without needing a process spawn per variable.
+func TestSkillCommandExecutor_ProviderBaseURLs_AlwaysPassed(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://api.together.ai/v1")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://anthropic-proxy.internal/v1")
+	t.Setenv("OLLAMA_BASE_URL", "http://ollama.svc.cluster.local:11434")
+	t.Setenv("GEMINI_BASE_URL", "https://gemini-proxy.internal/v1")
+
+	// Empty EnvVars whitelist — the skill did NOT declare these in its
+	// SKILL.md env.optional. The fix must pass them through anyway.
+	e := &SkillCommandExecutor{}
+
+	out, err := e.Run(context.Background(), "env", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"OPENAI_BASE_URL=https://api.together.ai/v1",
+		"ANTHROPIC_BASE_URL=https://anthropic-proxy.internal/v1",
+		"OLLAMA_BASE_URL=http://ollama.svc.cluster.local:11434",
+		"GEMINI_BASE_URL=https://gemini-proxy.internal/v1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in skill subprocess env (issue #137); got:\n%s", want, out)
+		}
+	}
+}
+
+// TestSkillCommandExecutor_ProviderBaseURLs_NotEmittedWhenUnset
+// confirms the omit-when-empty semantic: if the parent env doesn't
+// have one of these vars set, the subprocess env doesn't gain an
+// empty-value line for it. Matches the OPENAI_ORG_ID precedent
+// above. The fix must be an allowlist, not a hardcoded forward.
+func TestSkillCommandExecutor_ProviderBaseURLs_NotEmittedWhenUnset(t *testing.T) {
+	os.Unsetenv("OPENAI_BASE_URL")    //nolint:errcheck
+	os.Unsetenv("ANTHROPIC_BASE_URL") //nolint:errcheck
+	os.Unsetenv("OLLAMA_BASE_URL")    //nolint:errcheck
+	os.Unsetenv("GEMINI_BASE_URL")    //nolint:errcheck
+
+	e := &SkillCommandExecutor{}
+
+	out, err := e.Run(context.Background(), "env", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, forbidden := range []string{
+		"OPENAI_BASE_URL=",
+		"ANTHROPIC_BASE_URL=",
+		"OLLAMA_BASE_URL=",
+		"GEMINI_BASE_URL=",
+	} {
+		// Use a line-anchored check via newline boundaries so we don't
+		// false-positive on a substring that appears inside a value.
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, forbidden) {
+				t.Errorf("unset provider base URL %s leaked into subprocess env as %q",
+					forbidden, line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #137. Orthogonal Forge-side fix to #134. Pairs with #136 (wizard env validation).

`SkillCommandExecutor` builds a whitelist-only env for skill subprocesses (`forge-cli/tools/exec.go:62`). `OPENAI_ORG_ID` is special-cased to always-pass when present in the parent env — but the standard provider base URL pointers (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, `OLLAMA_BASE_URL`, `GEMINI_BASE_URL`) get no equivalent treatment.

## The bug

An operator's main agent loop hits Together.ai correctly (`OPENAI_API_KEY` + `OPENAI_BASE_URL=https://api.together.ai/v1`). A skill subprocess that calls the LLM API directly (e.g. `code-review/code-review-diff.sh`) falls back to the script's default `https://api.openai.com/v1`, POSTs the Together.ai key to OpenAI, and returns:

```
"OpenAI API returned status 401 — Incorrect API key provided: d00ccf9e****6706.
You can find your API key at https://platform.openai.com/account/api-keys."
```

The OpenAI hostname in the error message confirms the request actually reached OpenAI, not Together. The key flowed through (`OPENAI_API_KEY` is declared in SKILL.md `env.one_of` so it's in the whitelist); the base URL did not.

## Root cause

`e.EnvVars` (the per-skill whitelist) is populated at `runner.go:2682` from the skill's declared `Required` + `OneOf` + `Optional` lists. Unless a SKILL.md explicitly declares `OPENAI_BASE_URL` in `env.optional`, it never reaches the subprocess. Every skill that talks to an LLM directly has to remember to enumerate the variable — and any skill that doesn't silently breaks for OpenAI-compatible deployments.

## Fix

Extend the always-pass block at `exec.go:82`:

```go
if orgID := os.Getenv("OPENAI_ORG_ID"); orgID != "" {
    env = append(env, "OPENAI_ORG_ID="+orgID)
}
// Issue #137 — same treatment for provider base URLs.
for _, name := range []string{
    "OPENAI_BASE_URL",
    "ANTHROPIC_BASE_URL",
    "OLLAMA_BASE_URL",
    "GEMINI_BASE_URL",
} {
    if v := os.Getenv(name); v != "" {
        env = append(env, name+"="+v)
    }
}
```

These are SDK-recognized standard variables for redirecting provider-shape API calls to compatible hosts. Treating them like `OPENAI_ORG_ID` means every skill that calls an LLM API just works for compatible-provider deployments without each SKILL.md author having to remember.

**Omit-when-empty semantic preserved:** no empty-value lines appear in the subprocess env for unset variables.

## Coverage — 2 new tests in `exec_test.go`

| Test | What it pins |
|---|---|
| `ProviderBaseURLs_AlwaysPassed` | All 4 base URL vars set in parent env, skill has empty `EnvVars` whitelist (did NOT declare them in SKILL.md), subprocess env contains each with the expected value |
| `ProviderBaseURLs_NotEmittedWhenUnset` | None set in parent env, subprocess env doesn't gain empty-value lines. Mirrors the existing `NoOrgIDWhenUnset` precedent |

The two pre-existing `OPENAI_ORG_ID` tests still pass — the special-case precedent's shape is preserved exactly.

## Why one Forge-side fix, not per-skill

`OPENAI_BASE_URL` is the canonical OpenAI-SDK env var for compatible-provider deployments (Together.ai, OpenRouter, Groq, Fireworks, Anyscale, vLLM, llama.cpp's server). Same for `ANTHROPIC_BASE_URL`, `OLLAMA_BASE_URL`, `GEMINI_BASE_URL`. They aren't Forge-specific knobs — they're industry conventions.

Per-skill declaration (as in PR #134 for `code-review` specifically) works once but doesn't generalize. Every new LLM-calling skill repeats the same trap. Centralizing in `SkillCommandExecutor` lands once and protects every future skill, including third-party / out-of-tree ones.

## Verification

- [x] `gofmt -l` clean on `forge-cli`
- [x] `go test -race ./...` clean across all `forge-cli` packages
- [x] `golangci-lint run ./forge-cli/...` → **0 issues**

## Test plan (post-merge smoke)

```sh
cd <agent-with-OPENAI_BASE_URL=together.ai>
# fire a skill that calls the LLM API directly (code-review's code_review_diff is the canonical case)
# expected: subprocess hits api.together.ai/v1/chat/completions, not api.openai.com
```

## Refs

- Closes #137
- Pairs with #134 (script-side routing fix for `code-review` specifically) and #136 (wizard env validation fix)