### PR TITLE
fix(security): auto-add LLM provider base URL to egress allowlist at build + runtime (closes #139)

### DIFF
--- a/forge-cli/build/egress_stage.go
+++ b/forge-cli/build/egress_stage.go
@@ -43,6 +43,13 @@ func (s *EgressStage) Execute(ctx context.Context, bc *pipeline.BuildContext) er
 	allowed = append(allowed, security.AuthDomains(bc.Config.Auth)...)
 	allowed = append(allowed, security.MCPDomains(bc.Config.MCP)...)
 	allowed = append(allowed, security.OTelDomain(bc.Config.Observability.Tracing)...)
+	// Issue #139 — auto-merge LLM provider base URLs declared on
+	// model.base_url (and on each fallback). Without this an agent
+	// configured against an OpenAI-compatible provider (Together.ai,
+	// OpenRouter, Groq, ...) ships a NetworkPolicy that blocks the
+	// provider's hostname, and the deployed agent's LLM calls 401 /
+	// time out depending on which side notices first.
+	allowed = append(allowed, security.LLMProviderDomains(bc.Config)...)
 
 	resolved, err := security.Resolve(cfg.Profile, cfg.Mode, allowed, toolNames, cfg.Capabilities)
 	if err != nil {

--- a/forge-cli/build/egress_stage_llm_test.go
+++ b/forge-cli/build/egress_stage_llm_test.go
@@ -1,0 +1,118 @@
+package build
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// TestEgressStage_LLMProviderBaseURL_InAllowlist is the issue #139
+// end-to-end invariant: a forge.yaml with model.base_url declared
+// produces an egress_allowlist.json whose all_domains carries the
+// provider's hostname. Without this the generated Kubernetes
+// NetworkPolicy blocks every LLM call to that host — the operator
+// learns this only after deploy, when the agent times out or 401s.
+func TestEgressStage_LLMProviderBaseURL_InAllowlist(t *testing.T) {
+	tmpDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: tmpDir, WorkDir: tmpDir})
+	bc.Config = &types.ForgeConfig{
+		AgentID:    "test-together",
+		Version:    "1.0.0",
+		Entrypoint: "python main.py",
+		Egress: types.EgressRef{
+			Profile:        "standard",
+			Mode:           "allowlist",
+			AllowedDomains: []string{"api.github.com"}, // operator's explicit entry survives
+		},
+		Model: types.ModelRef{
+			Provider: "openai",
+			Name:     "moonshotai/Kimi-K2.6",
+			BaseURL:  "https://api.together.ai/v1",
+			Fallbacks: []types.ModelFallback{
+				{Provider: "anthropic", Name: "claude-sonnet-4", BaseURL: "https://anthropic-proxy.internal/v1"},
+			},
+		},
+	}
+	bc.Spec = &agentspec.AgentSpec{AgentID: "test-together"}
+
+	stage := &EgressStage{}
+	if err := stage.Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "compiled", "egress_allowlist.json"))
+	if err != nil {
+		t.Fatalf("read egress_allowlist.json: %v", err)
+	}
+	var got struct {
+		AllDomains []string `json:"all_domains"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode allowlist: %v", err)
+	}
+
+	// Both primary and fallback hosts must be present, plus the
+	// operator's explicit entry. Order doesn't matter.
+	wantHosts := []string{
+		"api.github.com",           // operator-declared
+		"api.together.ai",          // model.base_url
+		"anthropic-proxy.internal", // fallback.base_url
+	}
+	for _, want := range wantHosts {
+		if !contains(got.AllDomains, want) {
+			t.Errorf("all_domains missing %q; got %v", want, got.AllDomains)
+		}
+	}
+}
+
+// TestEgressStage_NoBaseURL_AllowlistUnchanged confirms the
+// backward-compat invariant: a forge.yaml without model.base_url
+// produces an allowlist containing only what the operator declared
+// + the existing AuthDomains/MCPDomains/OTelDomain auto-merges. No
+// LLM provider hostname appears spuriously.
+func TestEgressStage_NoBaseURL_AllowlistUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: tmpDir, WorkDir: tmpDir})
+	bc.Config = &types.ForgeConfig{
+		AgentID:    "test-no-baseurl",
+		Version:    "1.0.0",
+		Entrypoint: "python main.py",
+		Egress: types.EgressRef{
+			Profile:        "standard",
+			Mode:           "allowlist",
+			AllowedDomains: []string{"api.openai.com"},
+		},
+		Model: types.ModelRef{
+			Provider: "openai",
+			Name:     "gpt-4o",
+			// no BaseURL
+		},
+	}
+	bc.Spec = &agentspec.AgentSpec{AgentID: "test-no-baseurl"}
+
+	stage := &EgressStage{}
+	if err := stage.Execute(context.Background(), bc); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmpDir, "compiled", "egress_allowlist.json"))
+	var got struct {
+		AllDomains []string `json:"all_domains"`
+	}
+	_ = json.Unmarshal(data, &got)
+
+	// api.openai.com (operator-declared) must be present.
+	if !contains(got.AllDomains, "api.openai.com") {
+		t.Errorf("operator-declared api.openai.com missing; got %v", got.AllDomains)
+	}
+	// api.together.ai must NOT be there — nothing in the config referenced it.
+	if contains(got.AllDomains, "api.together.ai") {
+		t.Errorf("api.together.ai must not appear when no base_url is configured; got %v", got.AllDomains)
+	}
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -401,6 +401,21 @@ func (r *Runner) Run(ctx context.Context) error {
 	// `forge package`-then-deploy behave identically on the
 	// allowlist surface.
 	egressDomains = append(egressDomains, security.OTelDomain(r.cfg.Config.Observability.Tracing)...)
+	// Issue #139 — auto-merge LLM provider base URLs. Two sources:
+	//   1. The new ModelRef.BaseURL field (the durable signal that
+	//      also flows through `forge package` to the deployed
+	//      NetworkPolicy). This is the canonical path going forward.
+	//   2. The standard SDK base-URL env vars (OPENAI_BASE_URL /
+	//      ANTHROPIC_BASE_URL / OLLAMA_BASE_URL / GEMINI_BASE_URL).
+	//      Safety-net for deployments that haven't migrated to the
+	//      schema field yet — `envVars` already carries the resolved
+	//      .env + .forge/secrets.enc state at this point.
+	// Both are deduped via the helper. Without these merges, an agent
+	// using a custom OpenAI-compatible / Anthropic-compatible /
+	// remote-Ollama endpoint would be silently blocked by the egress
+	// enforcer at runtime.
+	egressDomains = append(egressDomains, security.LLMProviderDomains(r.cfg.Config)...)
+	egressDomains = append(egressDomains, security.LLMProviderEnvDomains(envVars)...)
 	egressCfg, egressErr := security.Resolve(
 		r.cfg.Config.Egress.Profile,
 		r.cfg.Config.Egress.Mode,

--- a/forge-core/security/llm_provider_domains.go
+++ b/forge-core/security/llm_provider_domains.go
@@ -1,0 +1,101 @@
+package security
+
+import "github.com/initializ/forge/forge-core/types"
+
+// LLMProviderDomains returns the hostnames of every custom base URL
+// declared on the agent's primary model and its fallbacks. Used by the
+// build pipeline (forge-cli/build/egress_stage.go) and the runner
+// (forge-cli/runtime/runner.go) to auto-merge LLM provider hosts into
+// the egress allowlist alongside AuthDomains, MCPDomains, and
+// OTelDomain.
+//
+// Why this exists (issue #139):
+//
+//	Without this, an agent configured against an OpenAI-compatible
+//	provider (Together.ai, OpenRouter, Groq, Fireworks, Anyscale,
+//	vLLM, llama.cpp's server) ships a NetworkPolicy that blocks the
+//	provider's hostname — the build pipeline only sees what's in
+//	forge.yaml, and the operator's env-driven OPENAI_BASE_URL doesn't
+//	flow through. Same trap Phase 6 of OTel Tracing v1 (#107) fixed
+//	for the OTLP collector; this is the symmetric fix for the LLM
+//	provider.
+//
+// Returns nil when neither the primary nor any fallback declares a
+// base URL — backward-compatible with deployments that rely on the
+// vendor's default host (api.openai.com, api.anthropic.com, etc.)
+// already covered by the operator's explicit egress.allowed_domains.
+//
+// Malformed URLs are silently skipped (same posture as AuthDomains /
+// MCPDomains / OTelDomain): the build pipeline must never block a
+// deployment over LLM config; the runtime config resolver is the
+// single place that fails loudly on bad URLs.
+//
+// Port stripping follows the cross-package contract documented on
+// hostFromURL — every egress matcher callsite strips the port before
+// checking the allowlist, so a hostname-only entry suffices.
+func LLMProviderDomains(cfg *types.ForgeConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(raw string) {
+		if raw == "" {
+			return
+		}
+		host := hostFromURL(raw)
+		if host == "" || seen[host] {
+			return
+		}
+		seen[host] = true
+		out = append(out, host)
+	}
+	add(cfg.Model.BaseURL)
+	for _, fb := range cfg.Model.Fallbacks {
+		add(fb.BaseURL)
+	}
+	return out
+}
+
+// LLMProviderEnvDomains returns the hostnames extracted from the four
+// canonical SDK base-URL env vars when present in the supplied env
+// map. Used by the runner to auto-merge env-driven LLM provider hosts
+// into the egress allowlist for deployments that haven't yet migrated
+// to the new ModelRef.BaseURL field.
+//
+// Why two helpers, not one:
+//
+//	LLMProviderDomains is the build-time signal (read from forge.yaml,
+//	the only source the build pipeline can see). LLMProviderEnvDomains
+//	is the runtime safety-net (read from the resolved env). Most
+//	operators will populate forge.yaml going forward; the env-based
+//	helper rescues existing deployments that point at a custom
+//	provider via OPENAI_BASE_URL only.
+//
+// The env vars consulted are the standard SDK conventions every
+// OpenAI/Anthropic/Ollama/Gemini-compatible provider documents.
+// Forge does not invent any Forge-specific FORGE_*_BASE_URL variant.
+//
+// Returns nil when none are set. Malformed URLs are silently
+// skipped (same posture as the cfg-side helper).
+func LLMProviderEnvDomains(envVars map[string]string) []string {
+	if len(envVars) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, key := range []string{
+		"OPENAI_BASE_URL",
+		"ANTHROPIC_BASE_URL",
+		"OLLAMA_BASE_URL",
+		"GEMINI_BASE_URL",
+	} {
+		host := hostFromURL(envVars[key])
+		if host == "" || seen[host] {
+			continue
+		}
+		seen[host] = true
+		out = append(out, host)
+	}
+	return out
+}

--- a/forge-core/security/llm_provider_domains_test.go
+++ b/forge-core/security/llm_provider_domains_test.go
@@ -1,0 +1,184 @@
+package security_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/security"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// ─── LLMProviderDomains (cfg-side) ───────────────────────────────────
+
+func TestLLMProviderDomains_NilCfg(t *testing.T) {
+	if got := security.LLMProviderDomains(nil); got != nil {
+		t.Errorf("nil cfg → nil; got %v", got)
+	}
+}
+
+func TestLLMProviderDomains_NoBaseURL(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{Provider: "openai", Name: "gpt-4o"},
+	}
+	if got := security.LLMProviderDomains(cfg); got != nil {
+		t.Errorf("model with no base_url must contribute no allowlist entry; got %v", got)
+	}
+}
+
+// TestLLMProviderDomains_PrimaryBaseURL is the load-bearing case for
+// issue #139: an OpenAI-compatible provider configured via base_url
+// must land in the egress allowlist by hostname (port stripped).
+func TestLLMProviderDomains_PrimaryBaseURL(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{
+			Provider: "openai",
+			Name:     "moonshotai/Kimi-K2.6",
+			BaseURL:  "https://api.together.ai/v1",
+		},
+	}
+	got := security.LLMProviderDomains(cfg)
+	want := []string{"api.together.ai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LLMProviderDomains = %v; want %v", got, want)
+	}
+}
+
+func TestLLMProviderDomains_IncludesFallbacks(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{
+			Provider: "openai",
+			Name:     "moonshotai/Kimi-K2.6",
+			BaseURL:  "https://api.together.ai/v1",
+			Fallbacks: []types.ModelFallback{
+				{Provider: "anthropic", Name: "claude-sonnet-4", BaseURL: "https://anthropic-proxy.internal/v1"},
+				{Provider: "openai", Name: "gpt-4o", BaseURL: "https://openrouter.ai/api/v1"},
+			},
+		},
+	}
+	got := security.LLMProviderDomains(cfg)
+	sort.Strings(got)
+	want := []string{"anthropic-proxy.internal", "api.together.ai", "openrouter.ai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LLMProviderDomains = %v; want %v", got, want)
+	}
+}
+
+// TestLLMProviderDomains_PortStripped pins the cross-package contract
+// the matcher relies on: allowlist entries are hostnames only, no
+// ports. See auth_domains.go hostFromURL comment for the full rationale.
+func TestLLMProviderDomains_PortStripped(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{BaseURL: "https://vllm.svc.cluster.local:8000/v1"},
+	}
+	got := security.LLMProviderDomains(cfg)
+	want := []string{"vllm.svc.cluster.local"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("port not stripped; got %v want %v", got, want)
+	}
+}
+
+func TestLLMProviderDomains_DedupesPrimaryAndFallback(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{
+			BaseURL: "https://api.together.ai/v1",
+			Fallbacks: []types.ModelFallback{
+				// Same host as primary — should not double up.
+				{BaseURL: "https://api.together.ai/v1"},
+			},
+		},
+	}
+	got := security.LLMProviderDomains(cfg)
+	want := []string{"api.together.ai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("duplicate not deduped; got %v want %v", got, want)
+	}
+}
+
+func TestLLMProviderDomains_MalformedURL_NoEntry(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{BaseURL: "::::not-a-url::::"},
+	}
+	if got := security.LLMProviderDomains(cfg); got != nil {
+		t.Errorf("malformed URL must produce no entry; got %v", got)
+	}
+}
+
+// ─── LLMProviderEnvDomains (runtime safety-net) ─────────────────────
+
+func TestLLMProviderEnvDomains_EmptyMap(t *testing.T) {
+	if got := security.LLMProviderEnvDomains(nil); got != nil {
+		t.Errorf("nil envVars → nil; got %v", got)
+	}
+	if got := security.LLMProviderEnvDomains(map[string]string{}); got != nil {
+		t.Errorf("empty envVars → nil; got %v", got)
+	}
+}
+
+// TestLLMProviderEnvDomains_AllFourVarsExtracted confirms the runtime
+// safety-net picks up every standard SDK base-URL env var even when
+// the operator hasn't yet migrated to ModelRef.BaseURL. Order is the
+// extraction order (OPENAI / ANTHROPIC / OLLAMA / GEMINI).
+func TestLLMProviderEnvDomains_AllFourVarsExtracted(t *testing.T) {
+	envVars := map[string]string{
+		"OPENAI_BASE_URL":    "https://api.together.ai/v1",
+		"ANTHROPIC_BASE_URL": "https://anthropic-proxy.internal/v1",
+		"OLLAMA_BASE_URL":    "http://ollama.svc.cluster.local:11434",
+		"GEMINI_BASE_URL":    "https://gemini-proxy.internal/v1beta",
+		"UNRELATED":          "https://nope.example.com", // must NOT be picked up
+	}
+	got := security.LLMProviderEnvDomains(envVars)
+	want := []string{
+		"api.together.ai",
+		"anthropic-proxy.internal",
+		"ollama.svc.cluster.local",
+		"gemini-proxy.internal",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LLMProviderEnvDomains = %v; want %v", got, want)
+	}
+}
+
+func TestLLMProviderEnvDomains_OnlyOneSet(t *testing.T) {
+	envVars := map[string]string{
+		"OPENAI_BASE_URL": "https://api.together.ai/v1",
+	}
+	got := security.LLMProviderEnvDomains(envVars)
+	want := []string{"api.together.ai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("single-var case: got %v want %v", got, want)
+	}
+}
+
+func TestLLMProviderEnvDomains_EmptyValueSkipped(t *testing.T) {
+	envVars := map[string]string{
+		"OPENAI_BASE_URL":    "",
+		"ANTHROPIC_BASE_URL": "https://anthropic-proxy.internal",
+	}
+	got := security.LLMProviderEnvDomains(envVars)
+	want := []string{"anthropic-proxy.internal"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty value must skip; got %v want %v", got, want)
+	}
+}
+
+func TestLLMProviderEnvDomains_DedupesSameHost(t *testing.T) {
+	envVars := map[string]string{
+		"OPENAI_BASE_URL":    "https://api.together.ai/v1",
+		"ANTHROPIC_BASE_URL": "https://api.together.ai/anthropic-shim", // same host
+	}
+	got := security.LLMProviderEnvDomains(envVars)
+	want := []string{"api.together.ai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("same-host dedup: got %v want %v", got, want)
+	}
+}
+
+func TestLLMProviderEnvDomains_MalformedURL_NoEntry(t *testing.T) {
+	envVars := map[string]string{
+		"OPENAI_BASE_URL": "::::not-a-url::::",
+	}
+	if got := security.LLMProviderEnvDomains(envVars); got != nil {
+		t.Errorf("malformed env URL must produce no entry; got %v", got)
+	}
+}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -312,8 +312,21 @@ type SkillsRef struct {
 
 // ModelRef identifies the model an agent uses.
 type ModelRef struct {
-	Provider       string          `yaml:"provider"`
-	Name           string          `yaml:"name"`
+	Provider string `yaml:"provider"`
+	Name     string `yaml:"name"`
+
+	// BaseURL overrides the provider's default API host. Operators
+	// configure this when running against an OpenAI-compatible
+	// (Together.ai, OpenRouter, Groq, Fireworks, Anyscale, vLLM,
+	// llama.cpp's server), Anthropic-compatible (Bedrock proxy,
+	// custom gateway), or remotely-served Ollama endpoint. The
+	// canonical env vars (OPENAI_BASE_URL / ANTHROPIC_BASE_URL /
+	// OLLAMA_BASE_URL / GEMINI_BASE_URL) still take precedence at
+	// runtime — this field exists so the build pipeline can
+	// auto-merge the hostname into egress_allowlist.json + the
+	// generated NetworkPolicy. See issue #139.
+	BaseURL string `yaml:"base_url,omitempty"`
+
 	Version        string          `yaml:"version,omitempty"`
 	OrganizationID string          `yaml:"organization_id,omitempty"`
 	Fallbacks      []ModelFallback `yaml:"fallbacks,omitempty"`
@@ -321,8 +334,14 @@ type ModelRef struct {
 
 // ModelFallback identifies an alternative LLM provider for fallback.
 type ModelFallback struct {
-	Provider       string `yaml:"provider"`
-	Name           string `yaml:"name,omitempty"`
+	Provider string `yaml:"provider"`
+	Name     string `yaml:"name,omitempty"`
+
+	// BaseURL — same semantics as ModelRef.BaseURL. Fallback
+	// providers commonly run on a different base URL than the
+	// primary; both need to make it into the egress allowlist.
+	BaseURL string `yaml:"base_url,omitempty"`
+
 	OrganizationID string `yaml:"organization_id,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Closes #139. The fourth and final auto-merge contributor for the egress allowlist, alongside `AuthDomains`, `MCPDomains`, and `OTelDomain`. Pairs with #134 / #136 / #138 — together they close the chain of "I configured an OpenAI-compatible provider, why is the agent acting like I configured raw OpenAI?" symptoms across script, wizard, runtime subprocess env, and now egress allowlist.

## The bug

An agent configured against an OpenAI-compatible provider (Together.ai, OpenRouter, Groq, Fireworks, Anyscale, vLLM, llama.cpp's server) ships a NetworkPolicy that **blocks the provider's hostname**. Deployed agents' LLM calls 401 or time out depending on which side notices first.

The build pipeline at `forge-cli/build/egress_stage.go` already auto-merges:

- `security.AuthDomains(cfg.Auth)` — OIDC issuer / http_verifier
- `security.MCPDomains(cfg.MCP)` — MCP server URLs
- `security.OTelDomain(cfg.Observability.Tracing)` — OTLP collector (Phase 6)

But there was **no equivalent for the LLM provider** because `types.ModelRef` had no `BaseURL` field. Operators express the override via env (`OPENAI_BASE_URL` etc.) which the build pipeline cannot see. The runtime had no env-reading equivalent either, so even `forge run` with `mode=allowlist` silently missed the provider host unless the operator manually added it.

## Fix — three layers, all wired

### 1. New schema field

```go
type ModelRef struct {
    Provider string
    Name     string
    BaseURL  string `yaml:"base_url,omitempty"`   // ← new
    ...
    Fallbacks []ModelFallback
}

type ModelFallback struct {
    Provider string
    Name     string
    BaseURL  string `yaml:"base_url,omitempty"`   // ← new
    ...
}
```

### 2. Two new security helpers

`forge-core/security/llm_provider_domains.go`:

- `LLMProviderDomains(cfg)` — extracts hostnames from `cfg.Model.BaseURL` + `cfg.Model.Fallbacks[].BaseURL`. Deduped. Used by **both** build and runtime.
- `LLMProviderEnvDomains(envVars)` — extracts hostnames from the four canonical SDK base-URL env vars in the resolved env map (`.env` + `.forge/secrets.enc`). Used **only at runtime**, as a safety net for deployments that haven't migrated to the schema field.

Both reuse the package-private `hostFromURL` helper for the same port-agnostic extraction every other auto-merge uses. Malformed URLs silently skip — the build pipeline must never block a deployment over LLM config.

### 3. Wiring

`forge-cli/build/egress_stage.go` — adds the cfg-driven helper to the existing Auth/MCP/OTel merge block.

`forge-cli/runtime/runner.go` — adds **both** helpers (cfg-driven + env-driven) right after the OTel merge. Belt and suspenders: the cfg field is the canonical signal; the env helper rescues operators who haven't updated `forge.yaml`.

## Operator path going forward

Declare the provider URL in `forge.yaml` ONCE:

```yaml
model:
  provider: openai
  name: moonshotai/Kimi-K2.6
  base_url: https://api.together.ai/v1
  fallbacks:
    - provider: anthropic
      name: claude-sonnet-4
      base_url: https://anthropic-proxy.internal/v1
```

…and `forge build && forge package && kubectl apply` produces a NetworkPolicy that admits `api.together.ai` and `anthropic-proxy.internal` automatically. No second egress edit. No NetworkPolicy patch.

## Coverage — 14 new tests

**`forge-core/security/llm_provider_domains_test.go`** (12 unit tests):

| Test | What it pins |
|---|---|
| `NilCfg` / `NoBaseURL` | nil → no entry |
| `PrimaryBaseURL` | `model.base_url=together.ai` → `["api.together.ai"]` |
| `IncludesFallbacks` | primary + 2 fallback URLs → 3 distinct hosts, sorted |
| `PortStripped` | `vllm.svc.cluster.local:8000` → bare host |
| `DedupesPrimaryAndFallback` | same host on primary + fallback → emitted once |
| `MalformedURL_NoEntry` | bad URL → silently skipped |
| `EnvDomains_EmptyMap` | empty env → nil |
| `EnvDomains_AllFourVarsExtracted` | OPENAI / ANTHROPIC / OLLAMA / GEMINI all present → all 4 extracted; unrelated env vars NOT picked up |
| `EnvDomains_OnlyOneSet` | single var works |
| `EnvDomains_EmptyValueSkipped` | `OPENAI_BASE_URL=""` → skipped |
| `EnvDomains_DedupesSameHost` | same host on two env vars → emitted once |
| `EnvDomains_MalformedURL_NoEntry` | bad env URL → silently skipped |

**`forge-cli/build/egress_stage_llm_test.go`** (2 end-to-end tests):

| Test | What it pins |
|---|---|
| `LLMProviderBaseURL_InAllowlist` | `forge.yaml` with `model.base_url` + `fallback.base_url` → `egress_allowlist.json` `all_domains` contains BOTH hosts AND operator's explicit entry (added, not replacing) |
| `NoBaseURL_AllowlistUnchanged` | no `base_url` → no LLM provider host leaks into `all_domains` (backward compat) |

## Verification

- [x] `gofmt -l` clean on both modules
- [x] `go test -race ./...` clean across all packages in `forge-core` and `forge-cli`
- [x] `golangci-lint run ./...` → **0 issues** in both modules

## Test plan (post-merge smoke)

```sh
cat > forge.yaml <<EOF
agent_id: test-together
version: 0.1.0
framework: forge
model:
  provider: openai
  name: moonshotai/Kimi-K2.6
  base_url: https://api.together.ai/v1
egress:
  mode: allowlist
EOF

forge build
jq -r '.all_domains' .forge-output/compiled/egress_allowlist.json
# expected: ["api.together.ai"] alongside any other auto-merged entries

forge run --no-auth
# the egress enforcer admits api.together.ai automatically;
# no manual edit to egress.allowed_domains needed
```

## The complete fix chain

| PR | Layer | What it fixes |
|---|---|---|
| **#134** | Script (in `code-review`) | Provider routing inside the script |
| **#136** | Wizard | Stop misleading `ANTHROPIC_API_KEY=` placeholder |
| **#138** | Skill subprocess env | Always pass base URLs to skill subprocesses |
| **#139 (this PR)** | Build + runtime egress | Auto-add provider host to allowlist + NetworkPolicy |

All four touch independent files — can merge in any order. With all four merged, the operator path is:

1. `model.base_url` in `forge.yaml` (or `OPENAI_BASE_URL` in env for runtime-only).
2. `forge build && forge package && kubectl apply`.
3. Everything works — main loop, code-review skill subprocess, NetworkPolicy.

## Refs

- Closes #139
- Pairs with #134, #136, #138
- Follows the Phase 6 OTel auto-merge precedent (#107)