### PR TITLE
fix(runtime): stop duplicating the inbound user message at the start of every fresh session (closes #143)

### DIFF
--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -217,8 +217,28 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 	}
 
 	// Load task history only if not recovered from disk.
+	//
+	// Issue #143 — the runner pre-appends params.Message to
+	// task.History at the three tasks/send entry points
+	// (runner.go:1174 / 1410 / 1672) so SSE observers see the
+	// in-flight task with the inbound user message visible before
+	// Execute completes. Execute treats task.History as PRIOR history
+	// and *msg as the NEW message separately, so we strip the
+	// trailing duplicate here to avoid emitting two consecutive
+	// identical user turns into the LLM. Strict-mode providers
+	// (gpt-5-nano and the other OpenAI reasoning models, Together's
+	// Kimi gateway, ...) reject that shape and the executor returns
+	// the canned "something went wrong" fallback.
+	//
+	// The `recovered` branch below has its own dedup logic against
+	// the persisted memory; this is the symmetric guard for the
+	// first-interaction path.
 	if !recovered {
-		for _, histMsg := range task.History {
+		historyToLoad := task.History
+		if n := len(historyToLoad); n > 0 && a2aMessagesEqual(historyToLoad[n-1], *msg) {
+			historyToLoad = historyToLoad[:n-1]
+		}
+		for _, histMsg := range historyToLoad {
 			mem.Append(a2aMessageToLLM(histMsg))
 		}
 	}
@@ -796,6 +816,22 @@ func a2aMessageToLLM(msg a2a.Message) llm.ChatMessage {
 		Role:    role,
 		Content: strings.Join(textParts, "\n"),
 	}
+}
+
+// a2aMessagesEqual reports whether two A2A messages have the same role
+// and the same concatenated text content. Used by Execute's history-
+// load path (issue #143) to detect the runner's pre-appended
+// params.Message in task.History and avoid emitting it as a duplicate
+// alongside the *msg argument.
+//
+// Only the LLM-visible projection matters here (role + text content) —
+// the message envelope's part-kind enumeration and metadata are
+// irrelevant to whether the LLM sees a duplicate user turn.
+func a2aMessagesEqual(a, b a2a.Message) bool {
+	if a.Role != b.Role {
+		return false
+	}
+	return a2aMessageToLLM(a).Content == a2aMessageToLLM(b).Content
 }
 
 // detectFileType inspects tool output content and returns an appropriate

--- a/forge-core/runtime/loop_history_dedup_test.go
+++ b/forge-core/runtime/loop_history_dedup_test.go
@@ -1,0 +1,249 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// TestExecute_FirstInteraction_DoesNotDuplicateMessageFromTaskHistory
+// is the regression test for issue #143. The runner pre-appends
+// params.Message to task.History at the three tasks/send entry points
+// before calling Execute, so the executor must skip that trailing
+// entry when loading prior history — otherwise the LLM sees two
+// consecutive identical user turns and strict-mode providers
+// (gpt-5-nano, Together's Kimi gateway) reject the conversation with
+// HTTP 400, surfacing as the canned "something went wrong" fallback
+// in the channel UI.
+func TestExecute_FirstInteraction_DoesNotDuplicateMessageFromTaskHistory(t *testing.T) {
+	var capturedMessages []llm.ChatMessage
+	client := &mockLLMClient{
+		chatFunc: func(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			capturedMessages = req.Messages
+			return &llm.ChatResponse{
+				Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "ok"},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client:        client,
+		Tools:         &mockToolExecutor{},
+		MaxIterations: 3,
+		ModelName:     "test",
+		Provider:      "openai",
+	})
+
+	// Simulate the runner's pre-append: task.History contains the same
+	// message instance that gets passed as *msg.
+	msg := &a2a.Message{
+		Role: a2a.MessageRoleUser,
+		Parts: []a2a.Part{{
+			Kind: a2a.PartKindText,
+			Text: "[channel:slack channel_target:C123]\nreview PR #82",
+		}},
+	}
+	task := &a2a.Task{
+		ID:      "task-history-dedup",
+		History: []a2a.Message{*msg}, // ← runner-style pre-append
+	}
+
+	if _, err := exec.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Count user-role messages with the exact prefix from the test
+	// message. Pre-fix there were 2 (one from task.History, one from
+	// *msg). Post-fix there must be exactly 1.
+	userCount := 0
+	for _, m := range capturedMessages {
+		if m.Role == llm.RoleUser && strings.Contains(m.Content, "review PR #82") {
+			userCount++
+		}
+	}
+	if userCount != 1 {
+		t.Errorf("expected exactly 1 user message matching the runner-pre-appended one (issue #143); "+
+			"got %d. captured roles: %v", userCount, summarizeMessages(capturedMessages))
+	}
+}
+
+// TestExecute_FirstInteraction_HistoryWithPriorTurnsPreserved pins the
+// non-regression invariant: when task.History contains real prior
+// turns followed by a runner-pre-appended duplicate of *msg, the
+// prior turns survive intact and only the trailing duplicate gets
+// stripped.
+func TestExecute_FirstInteraction_HistoryWithPriorTurnsPreserved(t *testing.T) {
+	var capturedMessages []llm.ChatMessage
+	client := &mockLLMClient{
+		chatFunc: func(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+			capturedMessages = req.Messages
+			return &llm.ChatResponse{
+				Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "ok"},
+				FinishReason: "stop",
+			}, nil
+		},
+	}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client:        client,
+		Tools:         &mockToolExecutor{},
+		MaxIterations: 3,
+		ModelName:     "test",
+		Provider:      "openai",
+	})
+
+	priorUser := a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "first question"}}}
+	priorAgent := a2a.Message{Role: a2a.MessageRoleAgent, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "first answer"}}}
+	currentUser := a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "followup question"}}}
+
+	task := &a2a.Task{
+		ID: "task-prior-turns",
+		// Runner-style: prior turns + the just-received user message.
+		History: []a2a.Message{priorUser, priorAgent, currentUser},
+	}
+
+	if _, err := exec.Execute(context.Background(), task, &currentUser); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Expected memory shape (after system prompt):
+	//   user(first question) → assistant(first answer) → user(followup question)
+	// NOT
+	//   user(first question) → assistant(first answer) → user(followup) → user(followup)
+	var userTexts, agentTexts []string
+	for _, m := range capturedMessages {
+		switch m.Role {
+		case llm.RoleUser:
+			userTexts = append(userTexts, m.Content)
+		case llm.RoleAssistant:
+			agentTexts = append(agentTexts, m.Content)
+		}
+	}
+	if len(userTexts) != 2 {
+		t.Errorf("expected 2 user messages (first question + followup); got %d: %v",
+			len(userTexts), userTexts)
+	}
+	if len(agentTexts) != 1 || agentTexts[0] != "first answer" {
+		t.Errorf("prior agent turn lost or mangled; got %v", agentTexts)
+	}
+	if len(userTexts) >= 2 && (userTexts[0] != "first question" || userTexts[1] != "followup question") {
+		t.Errorf("user-turn order corrupted; got %v", userTexts)
+	}
+}
+
+// TestLoadFromStore_CollapsesConsecutiveDuplicateUserMessages is the
+// defense-in-depth half of the fix. A session written by a pre-#143
+// build (containing the runner-pre-append duplicate) gets sanitized
+// on load — operators upgrading don't need to `rm` their session
+// files to recover working channel threads.
+func TestLoadFromStore_CollapsesConsecutiveDuplicateUserMessages(t *testing.T) {
+	saved := &SessionData{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "review PR #82"},
+			{Role: llm.RoleUser, Content: "review PR #82"}, // duplicate — the issue #143 shape
+			{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+				ID: "tc-1", Type: "function",
+				Function: llm.FunctionCall{Name: "code_review_diff", Arguments: `{}`},
+			}}},
+			{Role: llm.RoleTool, ToolCallID: "tc-1", Content: "<review>"},
+			{Role: llm.RoleAssistant, Content: "Here is the review..."},
+		},
+	}
+
+	mem := NewMemory("system", 100_000, "test")
+	mem.LoadFromStore(saved)
+
+	got := mem.Messages()
+	// Expected: the duplicate-user pair collapses to one; everything else preserved.
+	userMessages := 0
+	for _, m := range got {
+		if m.Role == llm.RoleUser && m.Content == "review PR #82" {
+			userMessages++
+		}
+	}
+	if userMessages != 1 {
+		t.Errorf("expected exactly 1 user(review PR #82) after collapse; got %d. sequence: %v",
+			userMessages, summarizeMessagesShort(got))
+	}
+	// The downstream conversation must survive untouched.
+	if len(got) < 4 {
+		t.Errorf("collapse removed too much; expected user → assistant(tc) → tool → assistant, got %v",
+			summarizeMessagesShort(got))
+	}
+}
+
+// TestSanitizeMessages_LeavesDistinctConsecutiveUserMessagesAlone is
+// the over-collapse guard: a legitimate user → user sequence (e.g.
+// the workflow tracker's "Your response was empty" nudge appearing
+// after a real user turn) must NOT get merged. Only EXACT
+// content-identical adjacent duplicates collapse.
+func TestSanitizeMessages_LeavesDistinctConsecutiveUserMessagesAlone(t *testing.T) {
+	saved := &SessionData{
+		Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: "first message"},
+			{Role: llm.RoleUser, Content: "Your response was empty. Please provide a brief summary..."},
+			{Role: llm.RoleAssistant, Content: "ok"},
+		},
+	}
+	mem := NewMemory("system", 100_000, "test")
+	mem.LoadFromStore(saved)
+	got := mem.Messages()
+
+	userCount := 0
+	for _, m := range got {
+		if m.Role == llm.RoleUser {
+			userCount++
+		}
+	}
+	if userCount != 2 {
+		t.Errorf("distinct consecutive user messages must survive; got %d user turns: %v",
+			userCount, summarizeMessagesShort(got))
+	}
+}
+
+// TestCollapseConsecutiveDuplicates_DoesNotMergeToolBoundaryMatches
+// guards a corner case: a user message whose Content happens to equal
+// the previous tool message's Content must not be dropped (different
+// roles).
+func TestCollapseConsecutiveDuplicates_DoesNotMergeToolBoundaryMatches(t *testing.T) {
+	in := []llm.ChatMessage{
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "tc-1"}}},
+		{Role: llm.RoleTool, ToolCallID: "tc-1", Content: "result"},
+		{Role: llm.RoleUser, Content: "result"}, // same content as tool but role-distinct
+	}
+	got := collapseConsecutiveDuplicates(in)
+	if len(got) != 3 {
+		t.Errorf("role-distinct adjacent same-content messages must not collapse; got %d, want 3", len(got))
+	}
+}
+
+func summarizeMessages(msgs []llm.ChatMessage) string {
+	var b strings.Builder
+	for i, m := range msgs {
+		if i > 0 {
+			b.WriteString(" → ")
+		}
+		preview := m.Content
+		if len(preview) > 30 {
+			preview = preview[:30]
+		}
+		b.WriteString(string(m.Role) + "(" + preview + ")")
+	}
+	return b.String()
+}
+
+func summarizeMessagesShort(msgs []llm.ChatMessage) string {
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		parts = append(parts, string(m.Role))
+	}
+	return "[" + strings.Join(parts, " → ") + "]"
+}
+
+// Sanity check: silence unused-import for json/encoding (the test
+// file may not call json directly today but the convention in this
+// package keeps imports stable across edits).
+var _ = json.RawMessage{}

--- a/forge-core/runtime/memory.go
+++ b/forge-core/runtime/memory.go
@@ -142,13 +142,14 @@ func (m *Memory) LoadFromStore(data *SessionData) {
 	m.existingSummary = data.Summary
 }
 
-// sanitizeMessages strips the two known kinds of corruption from a
-// loaded message slice (see LoadFromStore). The two passes are kept
-// separate so a future caller that only needs one (or wants to add a
-// third) can compose them individually.
+// sanitizeMessages strips the known kinds of corruption from a loaded
+// message slice (see LoadFromStore). The passes are kept separate so
+// a future caller that only needs one (or wants to add another) can
+// compose them individually.
 func sanitizeMessages(msgs []llm.ChatMessage) []llm.ChatMessage {
 	msgs = sanitizeToolCalls(msgs)
 	msgs = stripEmptyAssistantTurns(msgs)
+	msgs = collapseConsecutiveDuplicates(msgs)
 	return msgs
 }
 
@@ -196,6 +197,49 @@ func stripEmptyAssistantTurns(msgs []llm.ChatMessage) []llm.ChatMessage {
 			continue
 		}
 		out = append(out, m)
+	}
+	return out
+}
+
+// collapseConsecutiveDuplicates drops adjacent same-role messages with
+// identical content (issue #143). Pre-fix the runner pre-appended
+// params.Message to task.History before calling Execute, and the
+// !recovered path of Execute then also appended *msg — producing two
+// consecutive identical user turns at the start of every fresh
+// session. Strict-mode providers (gpt-5-nano and other OpenAI
+// reasoning models, Together's Kimi gateway) reject consecutive
+// same-role messages.
+//
+// The source-side fix lives at loop.go's Execute; this is the
+// defense-in-depth pass that rescues sessions already on disk from
+// pre-fix builds without an `rm` workaround.
+//
+// Surgical by design — only drops EXACT same-role + same-content
+// pairs. Legitimate consecutive same-role sequences (workflow nudges
+// where the loop appends a user-role nudge after an existing user
+// message; assistant follow-on turns from finish_reason=length
+// recoveries) have DIFFERENT content and are preserved.
+//
+// Messages with tool_calls (assistant) or tool_call_id (tool) are
+// never collapsed — those are structurally distinct turns even when
+// content matches superficially.
+func collapseConsecutiveDuplicates(msgs []llm.ChatMessage) []llm.ChatMessage {
+	if len(msgs) < 2 {
+		return msgs
+	}
+	out := msgs[:1]
+	for i := 1; i < len(msgs); i++ {
+		prev := out[len(out)-1]
+		cur := msgs[i]
+		if prev.Role == cur.Role &&
+			prev.Content == cur.Content &&
+			len(prev.ToolCalls) == 0 && len(cur.ToolCalls) == 0 &&
+			prev.ToolCallID == "" && cur.ToolCallID == "" {
+			// Adjacent same-role + same-content + tool-call-free
+			// pair → drop the second.
+			continue
+		}
+		out = append(out, cur)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Closes #143. Pairs with the previously-merged PR #132 (empty assistant turn fix for #131) — same symptom, different root cause, same fix shape (source-side guard + LoadFromStore defense-in-depth).

Persistent-channel agents (Slack threads, Telegram conversations, anything with a stable `task_id`) failed with the canned `"something went wrong while processing your request, please try again"` on followup messages. First message succeeded; followup failed.

## The bug

Inspecting the persisted session for a failing agent revealed **two consecutive identical user messages at the start of every fresh conversation**:

```
[0] user      — "review the code for the PR ..."   (114 chars)
[1] user      — "review the code for the PR ..."   (114 chars, IDENTICAL)
[2] assistant — tool_calls=1, content=""
[3] tool      — code review summary
[4] assistant — agent's text response
```

Strict-mode providers (`gpt-5-nano` and other OpenAI reasoning models, Together's Kimi gateway) reject consecutive same-role messages with HTTP 400. The first turn happened to tolerate the duplicate; the followup turn adds another user message and the combined shape trips the validator. The executor catches the error at `loop.go:311` and returns the canned fallback.

## Root cause

`forge-cli/runtime/runner.go:1410` (and parallel sites at 1174 and 1672 — the three `tasks/send` entry points):

```go
task.History = append(task.History, params.Message)   // ← pre-append for SSE observability
task.Status = a2a.TaskStatus{State: a2a.TaskStateWorking}
store.Put(task)
respMsg, err := executor.Execute(ctx, task, &params.Message)
```

The runner pre-appends `params.Message` to `task.History` so SSE clients see the inbound user message in the in-flight task before `Execute` completes. The pre-append itself is correct.

But `forge-core/runtime/loop.go`'s `Execute`, when `!recovered`:

```go
if !recovered {
    for _, histMsg := range task.History {
        mem.Append(a2aMessageToLLM(histMsg))    // includes the pre-appended params.Message
    }
}
// ...
mem.Append(newMsg)                               // appends params.Message AGAIN
```

The history loop iterates `task.History` (which **already includes** `params.Message`) and then `mem.Append(newMsg)` appends it a **second** time. Two adjacent identical user turns at the start.

The `recovered` branch handles this correctly via its own dedup at `loop.go:230-242`. The bug is only on the `!recovered` first-interaction path.

## Fix — two complementary changes

### Fix 1: `loop.go` — strip the trailing duplicate from `task.History`

```go
if !recovered {
    historyToLoad := task.History
    if n := len(historyToLoad); n > 0 && a2aMessagesEqual(historyToLoad[n-1], *msg) {
        historyToLoad = historyToLoad[:n-1]
    }
    for _, histMsg := range historyToLoad {
        mem.Append(a2aMessageToLLM(histMsg))
    }
}
```

New `a2aMessagesEqual` helper compares `Role` + the LLM-projected content (concatenated text parts) — the only projection the LLM actually sees.

### Fix 2: `memory.go` — defense-in-depth via `sanitizeMessages`

Extends the existing sanitize pipeline (which already drops orphaned tool calls and empty assistant turns) with a third pass: `collapseConsecutiveDuplicates`. Drops adjacent same-role + same-content + tool-call-free duplicates on `LoadFromStore`. Rescues sessions already on disk from pre-fix builds without an `rm` workaround.

Surgical by design — only **exact** pairs collapse. Workflow nudges (`"Your response was empty..."`) have different content and are preserved. Tool-bearing assistant turns and tool messages are never collapsed (structurally distinct).

## Why both — same reasoning as PR #132

- **Fix 1** prevents the bug source: new sessions never write the duplicate.
- **Fix 2** is the safety net: sessions already on disk (the user's existing Slack threads) keep working after upgrade.

## Coverage — 5 new tests

| Test | What it pins |
|---|---|
| `Execute_FirstInteraction_DoesNotDuplicateMessageFromTaskHistory` | `task.History=[msg]`, pass `*msg`; the captured LLM request contains **exactly one** user message |
| `Execute_FirstInteraction_HistoryWithPriorTurnsPreserved` | `[prior_user, prior_agent, current_user]` + `*msg=current_user`; prior turns survive, current_user appears exactly once at end |
| `LoadFromStore_CollapsesConsecutiveDuplicateUserMessages` | Pre-fix session shape (`[user(X), user(X), assistant(tc), tool, assistant]`) sanitizes on load to exactly one `user(X)` with every other turn preserved |
| `SanitizeMessages_LeavesDistinctConsecutiveUserMessagesAlone` | Legitimate workflow-nudge sequence (`user(prompt) → user(nudge)`) MUST survive — pin "not over-eager" |
| `CollapseConsecutiveDuplicates_DoesNotMergeToolBoundaryMatches` | Role-distinct adjacent same-content messages don't collapse |

The existing PR #132 tests (empty-assistant-turn handling) still pass, confirming the new collapse pass composes cleanly.

## Verification

- [x] `gofmt -l` clean on `forge-core`
- [x] `go test -race ./...` clean in `forge-core` (all packages) and `forge-cli` (all packages)
- [x] `golangci-lint run ./...` → **0 issues** in both modules

## Operator-facing workaround (now superseded by Fix 2)

Pre-fix sessions could be recovered by:

```sh
rm <agent-dir>/.forge/sessions/<task-id>.json
```

With this fix shipped, the rm is unnecessary — sessions sanitize themselves on load.

## Test plan (post-merge smoke)

The `agentdemo/npr` reproducer:

```sh
# Without rm'ing the session — Fix 2 should rescue it on load.
# Just send the followup in Slack: "yes Submit the inline comments now"
# Expected (pre-fix): "something went wrong..."
# Expected (post-fix): actual agent response
```

## The complete fix chain (issue → PR)

| Issue | PR | Layer | Bug |
|---|---|---|---|
| #131 | #132 (merged) | Runtime (session persistence) | Empty assistant turn poisons followup |
| #133 | #134 | Script (`code-review` provider routing) | Anthropic-first + Responses-API misgate |
| #135 | #136 | Wizard (env validation) | Misleading `ANTHROPIC_API_KEY=` placeholder |
| #137 | #138 | Runtime (subprocess env) | Lost `OPENAI_BASE_URL` to skills |
| #139 | #140 | Build + runtime (egress) | LLM provider host missing from NetworkPolicy |
| #141 | #142 | Script (`code-review` payload) | `max_tokens` rejected by Kimi/o-series |
| **#143** | **#144 (this)** | **Runtime (history dedup)** | **Duplicate user message rejected by strict providers** |

## Refs

- Closes #143
- Pairs with #132 (same shape, different root cause)