### PR TITLE
feat(build): forge package emits CronJob/Secret-template/Role manifests for schedules (closes #162)

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -351,7 +351,29 @@ audit trail (`schedule_fire`, `schedule_complete`, `schedule_skip`,
 also be created at runtime via the A2A API and managed with
 `forge schedule`.
 
-**Read**: `docs/core-concepts/scheduling.md`.
+**Hybrid backend (#162)**. Two implementations behind one
+`scheduler.Backend` interface, selected at startup:
+
+| `scheduler.backend` | Storage | Timing |
+|---------------------|---------|--------|
+| `file` | `<WorkDir>/.forge/memory/SCHEDULES.md` | 30s in-process goroutine ticker |
+| `kubernetes` | K8s `CronJob` resources (etcd) | Cluster's CronJob controller |
+| `auto` (default) | Resolves to `kubernetes` when in-cluster (`/var/run/secrets/kubernetes.io/serviceaccount/token` present), `file` otherwise | — |
+
+```yaml
+scheduler:
+  backend: auto
+  kubernetes:
+    namespace: ""             # defaults to pod's own namespace
+    service_url: ""           # in-cluster URL CronJob trigger pods POST to
+    allow_dynamic: false      # whether the LLM (schedule_set) can create CronJobs
+    trigger_image: ""         # default: curlimages/curl:8.10.1
+    auth_secret_name: ""      # default: <agent_id>-internal-token
+```
+
+`scheduler.InCluster()` is the detection helper. `FORGE_IN_CLUSTER=true|false` overrides for testing. `KubernetesBackend.Sync` reconciles CronJobs against the declared yaml entries — creates missing, updates on spec drift, prunes dropped yaml entries, **preserves LLM-sourced** (label `forge.schedule.source=llm`) entries unconditionally. `AllowDynamic: false` (default) keeps the LLM from creating CronJobs at runtime; `forge package` materializes yaml entries at build time instead (see § 11).
+
+**Read**: `docs/core-concepts/scheduling.md`, `docs/deployment/scheduler-kubernetes.md`.
 
 ---
 
@@ -397,6 +419,7 @@ forge secret delete OPENAI_API_KEY
 | 4 | **ToolsStage** | Enumerates registered tools (builtins + skill tools + MCP) |
 | 5 | **EgressStage** | Resolves capability bundles, validates against platform policy, writes `egress_allowlist.json` |
 | 6 | **PackageStage** | Generates `Dockerfile` + Kubernetes manifests (`deployment.yaml` with `FORGE_PLATFORM_POLICY` env + `optional: true` ConfigMap volume) |
+| 6a | **ScheduleManifestStage** | When `forge.yaml schedules[]` is non-empty AND `scheduler.backend ≠ file`, emits one `k8s/cronjob-<id>.yaml` per schedule, a credential-less `k8s/internal-token-secret.yaml` template, and a `k8s/scheduler-role.yaml` + `k8s/scheduler-rolebinding.yaml` pair scoped to the agent's namespace. RBAC verbs are gated by `scheduler.kubernetes.allow_dynamic`. Operator populates the Secret out-of-band via `forge auth secret-yaml` — see § 13 (#162 part 3) |
 | 7 | **SigningStage** (opt-in) | Ed25519 signature of every artifact; `checksums.json` with SHA-256s |
 
 Artifacts land in `.forge-output/`. `forge run` from a built directory
@@ -701,6 +724,7 @@ Full reference: `docs/reference/cli-reference.md`.
 | `forge tool list \| describe` | Enumerate registered tools, show schemas | |
 | `forge channel add \| list \| status \| serve \| disable \| enable` | Channel adapters; disable/enable edit the user policy layer by default; `--system` retargets `/etc/forge/policy.yaml` | `--with`, `--system` |
 | `forge secret set \| get \| list \| delete` | Encrypted secrets | |
+| `forge auth show-token \| mint-token \| secret-yaml` | Operator UX for the internal bearer token at `<root>/.forge/runtime.token` (same token channel adapters + K8s CronJob trigger pods use). `secret-yaml` prints a ready-to-apply K8s Secret manifest sourced from the local token; `mint-token` is for first-deploy bootstrap. `forge.agent.id` label always tracks `forge.yaml` `agent_id`, never the `--name` override. (#162 part 1, PR #168) | `--namespace`, `--name` |
 | `forge key generate \| sign \| verify` | Ed25519 build artifact signing | |
 | `forge skills add \| list \| validate \| audit` | Registry: install, search, validate binary/env deps, security audit `--embedded` | `--category`, `--tags`, `--embedded` |
 | `forge mcp list \| test \| login \| logout` | Manage MCP servers + OAuth tokens | `--call <tool>`, `--args '<json>'` |
@@ -783,6 +807,15 @@ schedules:
     task: "Generate yesterday's summary"
     channel: telegram
     channel_target: "-100123456"
+
+scheduler:                           # Backend selection (#162)
+  backend: auto                      # auto (default) | file | kubernetes
+  kubernetes:
+    namespace: ""                    # defaults to pod's own namespace
+    service_url: ""                  # in-cluster URL CronJob trigger pods POST to
+    allow_dynamic: false             # whether schedule_set can create CronJobs at runtime
+    trigger_image: ""                # default: curlimages/curl:8.10.1
+    auth_secret_name: ""             # default: <agent_id>-internal-token
 
 package:
   alpine: false
@@ -980,6 +1013,9 @@ Every event also carries `schema_version: "1.0"` (FWS-8) and `seq`
 | **FWS-9** | #100 | Ops logger output stream separation — stdout for `JSONLogger`, stderr stays for audit NDJSON | `docs/security/audit-logging.md` § Streams |
 | **FWS-10** | #110 | Rate-limit configurability + orchestration-friendly defaults + cancel exemption — `server.rate_limit:` yaml block + CLI flags + env; `tasks/cancel` exempt from the write bucket by default | `docs/reference/forge-yaml-schema.md` § `server.rate_limit` |
 | **OTel v1** | #108 | OpenTelemetry tracing — shipped across phases #101-#107 (PRs #122-#128). Tracer seam → OTLP provider → config resolver + CLI flags → span instrumentation across A2A/executor/LLM/tool → audit ↔ trace cross-link → end-to-end A2A propagation → build-time egress merge. Off by default; reuses the egress-enforced transport. | `docs/core-concepts/observability-tracing.md` |
+| **Guardrails audit** | #155, #159, #161 | `guardrail_check` audit emission at all 5 library gates (`input` / `context` / `tool_call` / `output` / `stream`), unified on the library `gate` vocabulary (PR #160 replaced the early `direction` field); opt-in `fields.evidence` via `FORGE_GUARDRAIL_CAPTURE_EVIDENCE`; OTel `guardrail.<gate>` spans symmetric to the audit event with `forge.guardrail.*` attributes and `Error` status on block decisions (PR #167) | `docs/security/guardrails.md`, `docs/core-concepts/observability-tracing.md` § Guardrail spans |
+| **Tenancy + entity stamping** | #157, #164 | Top-level `org_id` / `workspace_id` (env + per-request header layer) and `entity_id` / `entity_type=agent` (env / forge.yaml) stamped on every audit event so SIEM filters `(org_id, workspace_id, entity_id)` uniquely identify a deploy. Field names match the guardrails library's MongoDB columns 1:1. | `docs/security/tenancy.md`, `docs/security/audit-logging.md` § Entity stamping |
+| **K8s scheduler** | #162 | Hybrid scheduler backend: `scheduler.Backend` interface, `FileBackend` (existing behavior), `KubernetesBackend` (`k8s.io/client-go`, CronJob CRUD), `InCluster()` detection, `forge package` emits `cronjob-*.yaml` + credential-less Secret template + Role/RoleBinding. `forge auth` subcommand for operator token UX. | `docs/deployment/scheduler-kubernetes.md`, `docs/core-concepts/scheduling.md` |
 
 Side issues filed during this run: FWS-9 was filed as a companion to
 FWS-7's "stream separation would be cleaner" callout; FWS-10 was filed
@@ -1017,9 +1053,10 @@ docs/
 │   ├── egress-control.md
 │   ├── secret-management.md
 │   ├── build-signing.md
-│   ├── guardrails.md
+│   ├── guardrails.md             ← incl. guardrail_check audit + capture-evidence (#155/#159)
 │   ├── platform-policy.md        ← FWS-5 / FWS-6
-│   ├── audit-logging.md          ← FWS-3 / FWS-7 / FWS-8 / FWS-9
+│   ├── audit-logging.md          ← FWS-3 / FWS-7 / FWS-8 / FWS-9 + entity stamping (#164)
+│   ├── tenancy.md                ← org_id / workspace_id / entity_id stamping (#157 / #164)
 │   └── workflow-correlation.md   ← FWS-2
 ├── reference/
 │   ├── cli-reference.md          ← every subcommand
@@ -1038,6 +1075,7 @@ docs/
 ├── deployment/
 │   ├── docker.md
 │   ├── kubernetes.md
+│   ├── scheduler-kubernetes.md   ← hybrid scheduler backend (#162) — CronJobs, RBAC, token plumbing
 │   ├── monitoring.md
 │   └── production-checklist.md
 ├── mcp/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You write a `SKILL.md`. Forge compiles it into a secure, runnable agent with egr
 | [Configuration](docs/reference/forge-yaml-schema.md) | `forge.yaml` schema and environment variables |
 | [Dashboard](docs/reference/web-dashboard.md) | Web UI features and architecture |
 | [Deployment](docs/deployment/kubernetes.md) | Container packaging, Kubernetes, air-gap |
+| [Scheduler — Kubernetes](docs/deployment/scheduler-kubernetes.md) | Hybrid file/CronJob scheduler backend, RBAC, token plumbing |
 | [Hooks](docs/core-concepts/hooks.md) | Agent loop hook system |
 | [Library Modules](docs/reference/library-modules.md) | Import `forge-core`, `forge-skills`, `forge-plugins` as Go libraries — tag scheme, release pipeline, embedder API |
 | [Plugins](docs/reference/framework-plugins.md) | Framework plugin system |

--- a/docs/core-concepts/scheduling.md
+++ b/docs/core-concepts/scheduling.md
@@ -48,10 +48,35 @@ forge schedule list
 
 When a schedule includes `channel` and `channel_target`, the agent's response is automatically delivered to the specified channel after each execution. When schedules are created from channel conversations (Slack, Telegram), the channel context is automatically available so the agent can capture the delivery target.
 
+## Scheduler backend
+
+Forge picks one of two scheduler backends at startup based on the `scheduler` block in `forge.yaml` and whether the process is running inside a Kubernetes pod (issue #162).
+
+| Backend | When used | Persistence | Timing |
+|---------|-----------|-------------|--------|
+| `file` | Outside a Kubernetes pod | `<WorkDir>/.forge/memory/SCHEDULES.md` | 30s in-process goroutine ticker |
+| `kubernetes` | Inside a pod with `scheduler.backend: auto` or `kubernetes` | K8s `CronJob` resources (etcd) | Cluster's CronJob controller |
+
+```yaml
+scheduler:
+  backend: auto              # auto (default) | file | kubernetes
+  kubernetes:
+    namespace: ""            # defaults to the agent pod's own namespace
+    service_url: ""          # in-cluster URL CronJob trigger pods POST to
+    allow_dynamic: false     # whether schedule_set can create CronJobs at runtime
+    trigger_image: ""        # default: curlimages/curl:8.10.1
+    auth_secret_name: ""     # default: <agent_id>-internal-token
+```
+
+`auto` resolves to `kubernetes` when `/var/run/secrets/kubernetes.io/serviceaccount/token` is present; otherwise `file`. The escape hatch `FORGE_IN_CLUSTER=true|false` overrides for testing.
+
+When `forge package` runs with `schedules[]` populated, it emits one `cronjob-<id>.yaml` per entry plus a credential-less Secret template plus a Role/RoleBinding into the `k8s/` output directory — see [Scheduler — Kubernetes](../deployment/scheduler-kubernetes.md) for the full deploy playbook, including the token-provisioning workflow that pairs with [`forge auth secret-yaml`](../reference/cli-reference.md#forge-auth).
+
 ## Execution Details
 
-- **Tick interval**: 30 seconds
-- **Overlap prevention**: A schedule won't fire again if its previous run is still in progress
-- **Persistence**: Schedules are stored in `.forge/memory/SCHEDULES.md` and survive restarts
-- **History**: The last 50 executions are recorded with status, duration, and correlation IDs
-- **Audit events**: `schedule_fire`, `schedule_complete`, `schedule_skip`, `schedule_modify`
+- **File backend tick interval**: 30 seconds. The Kubernetes backend delegates timing to the cluster's CronJob controller — no in-process ticker.
+- **Overlap prevention**: File backend skips a fire when the previous run is still in flight. The Kubernetes backend sets `concurrencyPolicy: Forbid` on each CronJob — the K8s-native equivalent.
+- **Persistence (file mode)**: `<WorkDir>/.forge/memory/SCHEDULES.md`. LLM-created schedules survive restarts only when this path is mounted (PVC in containers).
+- **Persistence (Kubernetes mode)**: CronJob resources in etcd — durable across pod restarts without a PVC.
+- **History**: File backend keeps the last 50 executions per schedule. Kubernetes backend defers to the audit stream's `schedule_complete` events.
+- **Audit events**: `schedule_fire`, `schedule_complete`, `schedule_skip`, `schedule_modify`.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -498,6 +498,35 @@ forge secret set API_KEY --local
 
 ---
 
+## `forge auth`
+
+Manage the runtime bearer token Forge mints at agent startup (issue #162 part 1, PR #168). The token is stored at `<agent-root>/.forge/runtime.token` (0600 permissions) and is the same token channel adapters use to call back into the A2A endpoint. Scheduled CronJobs deployed via `forge package` also consume this token through a Kubernetes Secret the operator populates out-of-band — `forge package` never bakes the token into the generated manifests.
+
+```bash
+# Print the stored token to stdout. Exits 1 with an actionable error
+# when the file is absent.
+forge auth show-token
+
+# Generate a fresh 256-bit token, store it (overwriting any existing
+# value), and print to stdout. Use for first-deploy bootstrap from a
+# clean checkout.
+forge auth mint-token
+
+# Print a ready-to-apply Kubernetes Secret YAML containing the token.
+# Default name and namespace match what `forge package` emits.
+forge auth secret-yaml
+forge auth secret-yaml --namespace prod
+forge auth secret-yaml --name custom-secret-name
+
+# Common one-liner: populate the Secret a `forge package` deploy
+# expects from the local runtime.token.
+forge auth secret-yaml | kubectl apply -f -
+```
+
+The `forge.agent.id` label on the generated Secret is always sourced from `forge.yaml`'s `agent_id` (or the `"forge-agent"` fallback), never from the `--name` override — so operators using `--name` to match an existing cluster convention still see telemetry and label-selectors keyed on the real agent ID.
+
+---
+
 ## `forge key`
 
 Manage Ed25519 signing keys.

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -148,6 +148,15 @@ schedules:                          # Recurring scheduled tasks (optional)
     channel: "telegram"             # Optional channel for delivery
     channel_target: "-100123456"    # Destination chat/channel ID
 
+scheduler:                          # Scheduler backend selection (#162)
+  backend: "auto"                   # auto (default) | file | kubernetes
+  kubernetes:                       # Tuning for backend=kubernetes (or auto-resolved)
+    namespace: ""                   # Defaults to the agent pod's own namespace
+    service_url: ""                 # In-cluster URL CronJob trigger pods POST to
+    allow_dynamic: false            # Whether schedule_set can create CronJobs at runtime
+    trigger_image: ""               # Default: curlimages/curl:8.10.1
+    auth_secret_name: ""            # Default: <agent_id>-internal-token
+
 observability:                      # OpenTelemetry tracing (off by default)
   tracing:
     enabled: true                   # Phase 0-6 / OTel Tracing v1 (#108)

--- a/forge-cli/build/schedule_manifest_stage.go
+++ b/forge-cli/build/schedule_manifest_stage.go
@@ -1,0 +1,245 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/scheduler"
+)
+
+// ScheduleManifestStage emits Kubernetes CronJob manifests, a
+// credential-less Secret template, and a Role/RoleBinding pair for
+// every entry in forge.yaml `schedules[]` when the scheduler block
+// requests a Kubernetes-aware deploy. Issue #162 part 3.
+//
+// Output files land in <output>/k8s/:
+//
+//	cronjob-<schedule-id>.yaml     (one per schedule)
+//	internal-token-secret.yaml     (credential-less template)
+//	scheduler-role.yaml            (Role with verbs gated by allow_dynamic)
+//	scheduler-rolebinding.yaml     (binds the Role to the agent's SA)
+//
+// The Secret manifest deliberately ships WITHOUT a `data:` field so
+// the artifact is safe to commit. Operators populate it out-of-band
+// via `forge auth secret-yaml | kubectl apply -f -` (#162 part 1) or
+// their preferred secret manager. Applying the Deployment before the
+// Secret is populated leaves the agent pod NotReady with a clear
+// `secret "..." not found` event — failure is loud, not silent.
+//
+// This stage runs unconditionally; when forge.yaml has no schedules
+// or no scheduler block, Execute is a no-op. When the scheduler
+// block requests the file backend explicitly (`backend: file`),
+// CronJobs are not emitted — operators using file mode in production
+// would be a misconfiguration we don't want to encourage.
+type ScheduleManifestStage struct{}
+
+func (s *ScheduleManifestStage) Name() string { return "generate-schedule-manifests" }
+
+func (s *ScheduleManifestStage) Execute(_ context.Context, bc *pipeline.BuildContext) error {
+	if bc.Config == nil {
+		return nil
+	}
+	cfg := bc.Config
+	if len(cfg.Schedules) == 0 {
+		return nil
+	}
+	// "file" explicitly opts out; "kubernetes" and "auto" (default)
+	// both emit manifests so the manifests are usable whether the
+	// runtime resolves to file or k8s.
+	if cfg.Scheduler.Backend == "file" {
+		return nil
+	}
+
+	k8sDir := filepath.Join(bc.Opts.OutputDir, "k8s")
+	if err := os.MkdirAll(k8sDir, 0755); err != nil {
+		return fmt.Errorf("creating k8s directory: %w", err)
+	}
+
+	agentID := cfg.AgentID
+	if agentID == "" {
+		return fmt.Errorf("schedule manifest stage: forge.yaml agent_id is required")
+	}
+	ns := cfg.Scheduler.Kubernetes.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	serviceURL := cfg.Scheduler.Kubernetes.ServiceURL
+	if serviceURL == "" {
+		// Best-effort default: in-cluster Service DNS for the agent
+		// on the standard A2A port. Operators should set
+		// scheduler.kubernetes.service_url explicitly when the agent
+		// pod listens on a non-default port or in a non-default
+		// namespace (or behind an Ingress / Gateway).
+		port := 8080
+		if bc.Spec != nil && bc.Spec.Runtime != nil && bc.Spec.Runtime.Port != 0 {
+			port = bc.Spec.Runtime.Port
+		}
+		serviceURL = fmt.Sprintf("http://%s.%s.svc:%d/", agentID, ns, port)
+	}
+	authSecret := cfg.Scheduler.Kubernetes.AuthSecretName
+	if authSecret == "" {
+		authSecret = agentID + "-internal-token"
+	}
+
+	// One CronJob per declared schedule.
+	for _, sc := range cfg.Schedules {
+		yaml := scheduler.CronJobYAML(scheduler.CronJobManifestInput{
+			AgentID:        agentID,
+			Namespace:      ns,
+			ServiceURL:     serviceURL,
+			AuthSecretName: authSecret,
+			TriggerImage:   cfg.Scheduler.Kubernetes.TriggerImage,
+			Schedule: scheduler.Schedule{
+				ID:            sc.ID,
+				Cron:          sc.Cron,
+				Task:          sc.Task,
+				Skill:         sc.Skill,
+				Channel:       sc.Channel,
+				ChannelTarget: sc.ChannelTarget,
+				Source:        scheduler.SourceYAML,
+				Enabled:       true,
+			},
+		})
+		name := "cronjob-" + safeFileName(sc.ID) + ".yaml"
+		path := filepath.Join(k8sDir, name)
+		if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", name, err)
+		}
+		bc.AddFile(filepath.Join("k8s", name), path)
+	}
+
+	// Credential-less Secret template (operator populates out-of-band).
+	secretYAML := buildInternalTokenSecretTemplate(authSecret, ns, agentID)
+	secretPath := filepath.Join(k8sDir, "internal-token-secret.yaml")
+	if err := os.WriteFile(secretPath, []byte(secretYAML), 0644); err != nil {
+		return fmt.Errorf("writing internal-token-secret.yaml: %w", err)
+	}
+	bc.AddFile(filepath.Join("k8s", "internal-token-secret.yaml"), secretPath)
+
+	// RBAC: Role with verbs gated by allow_dynamic, plus the binding.
+	allowDynamic := cfg.Scheduler.Kubernetes.AllowDynamic
+	rolePath := filepath.Join(k8sDir, "scheduler-role.yaml")
+	if err := os.WriteFile(rolePath, []byte(buildSchedulerRole(agentID, ns, allowDynamic)), 0644); err != nil {
+		return fmt.Errorf("writing scheduler-role.yaml: %w", err)
+	}
+	bc.AddFile(filepath.Join("k8s", "scheduler-role.yaml"), rolePath)
+
+	rbPath := filepath.Join(k8sDir, "scheduler-rolebinding.yaml")
+	if err := os.WriteFile(rbPath, []byte(buildSchedulerRoleBinding(agentID, ns)), 0644); err != nil {
+		return fmt.Errorf("writing scheduler-rolebinding.yaml: %w", err)
+	}
+	bc.AddFile(filepath.Join("k8s", "scheduler-rolebinding.yaml"), rbPath)
+
+	return nil
+}
+
+// buildInternalTokenSecretTemplate returns a Secret manifest WITHOUT
+// the `data:` field. The commented block documents the three out-of-
+// band populate paths so an operator inspecting the file knows how to
+// fill it in without reading the docs separately.
+func buildInternalTokenSecretTemplate(name, namespace, agentID string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    forge.agent.id: %s
+type: Opaque
+# data:
+#   token: <BASE64-OF-RUNTIME-TOKEN>
+#
+# This Secret is intentionally generated WITHOUT a `+"`data`"+` field.
+# The token is a security credential and must NOT be checked into
+# version control. Populate it once per deployment via one of:
+#
+#   1. forge auth secret-yaml | kubectl apply -f -
+#      (one-liner using the local <agent-root>/.forge/runtime.token)
+#
+#   2. ExternalSecrets / Sealed Secrets / SOPS / Vault Agent Injector
+#      with a manifest pointing at this Secret name.
+#
+#   3. From a clean-checkout first deploy:
+#        forge auth mint-token > /dev/null
+#        forge auth secret-yaml | kubectl apply -f -
+#
+# The Deployment references this Secret by name; applying it before
+# the Secret is populated leaves the pod NotReady with a clear
+# 'secret "%s" not found' event.
+`, name, namespace, agentID, name)
+}
+
+// buildSchedulerRole returns the Role manifest scoped to the agent's
+// namespace. Verbs are split: get/list always present (powers the
+// schedule_list builtin tool), create/update/delete gated by
+// allow_dynamic to keep operators from inadvertently granting the
+// LLM CronJob CRUD authority.
+func buildSchedulerRole(agentID, namespace string, allowDynamic bool) string {
+	verbs := `["get", "list", "watch"]`
+	if allowDynamic {
+		verbs = `["get", "list", "watch", "create", "update", "patch", "delete"]`
+	}
+	return fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: %s-scheduler
+  namespace: %s
+  labels:
+    forge.agent.id: %s
+# Allow the agent pod to read its own CronJobs (powers the
+# schedule_list / schedule_history tools). create/update/delete verbs
+# are present only when scheduler.kubernetes.allow_dynamic=true, which
+# lets the LLM-driven schedule_set / schedule_delete builtin tools
+# materialize CronJobs at runtime. Grant carefully.
+rules:
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: %s
+`, agentID, namespace, agentID, verbs)
+}
+
+// buildSchedulerRoleBinding binds the scheduler-role to the agent's
+// ServiceAccount. Assumes the Deployment uses a ServiceAccount named
+// after the agent_id (matches the convention forge package's
+// deployment template established).
+func buildSchedulerRoleBinding(agentID, namespace string) string {
+	return fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: %s-scheduler
+  namespace: %s
+  labels:
+    forge.agent.id: %s
+subjects:
+  - kind: ServiceAccount
+    name: %s
+    namespace: %s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: %s-scheduler
+`, agentID, namespace, agentID, agentID, namespace, agentID)
+}
+
+// safeFileName replaces characters that are valid in schedule IDs
+// (per the cron parser) but unfriendly in shell-completed paths.
+// Lowercase and substitute everything outside the K8s name set with
+// '-' — matches what scheduler.CronJobName does for the K8s resource
+// name, but applied to the on-disk filename so `ls k8s/` is readable.
+func safeFileName(id string) string {
+	var b strings.Builder
+	b.Grow(len(id))
+	for _, r := range strings.ToLower(id) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-_")
+}

--- a/forge-cli/build/schedule_manifest_stage_test.go
+++ b/forge-cli/build/schedule_manifest_stage_test.go
@@ -1,0 +1,251 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// newScheduleStageBC builds a BuildContext with the minimum surface
+// area the ScheduleManifestStage reads: a Config with Schedules,
+// optional Scheduler block, and a Spec with Runtime.Port for the
+// service-URL default.
+func newScheduleStageBC(t *testing.T, cfg *types.ForgeConfig) *pipeline.BuildContext {
+	t.Helper()
+	out := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: out})
+	bc.Config = cfg
+	bc.Spec = &agentspec.AgentSpec{
+		AgentID: cfg.AgentID,
+		Runtime: &agentspec.RuntimeConfig{Port: 8080},
+	}
+	return bc
+}
+
+// TestScheduleManifestStage_NoOpWhenNoSchedules verifies the stage is
+// a no-op when forge.yaml has no schedules[] block. No k8s/ files for
+// scheduler should appear in the output.
+func TestScheduleManifestStage_NoOpWhenNoSchedules(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{AgentID: "agent"})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(bc.Opts.OutputDir, "k8s"))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "cronjob-") {
+			t.Errorf("unexpected cronjob file emitted: %s", e.Name())
+		}
+	}
+}
+
+// TestScheduleManifestStage_NoOpWhenBackendFile verifies that
+// explicitly setting scheduler.backend=file opts out of CronJob
+// emission. Operators forcing file mode in a packaged deploy
+// shouldn't get manifests that conflict with their runtime choice.
+func TestScheduleManifestStage_NoOpWhenBackendFile(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{
+		AgentID:   "agent",
+		Schedules: []types.ScheduleConfig{{ID: "s1", Cron: "@hourly", Task: "t"}},
+		Scheduler: types.SchedulerConfig{Backend: "file"},
+	})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, name := range []string{"cronjob-s1.yaml", "internal-token-secret.yaml", "scheduler-role.yaml"} {
+		path := filepath.Join(bc.Opts.OutputDir, "k8s", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("backend=file should not emit %s; file exists", name)
+		}
+	}
+}
+
+// TestScheduleManifestStage_EmitsCronJobPerSchedule verifies the
+// happy path: each forge.yaml schedule gets its own CronJob manifest
+// with the right labels, the Secret template lands credential-less,
+// and the Role/RoleBinding are scoped to the agent's namespace.
+func TestScheduleManifestStage_EmitsCronJobPerSchedule(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{
+		AgentID: "aibuilderdemo",
+		Schedules: []types.ScheduleConfig{
+			{ID: "daily", Cron: "0 9 * * *", Task: "Send daily summary"},
+			{ID: "hourly", Cron: "@hourly", Task: "Ping channel"},
+		},
+	})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, id := range []string{"daily", "hourly"} {
+		path := filepath.Join(bc.Opts.OutputDir, "k8s", "cronjob-"+id+".yaml")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("cronjob-%s.yaml not emitted: %v", id, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, "kind: CronJob") {
+			t.Errorf("cronjob-%s.yaml not a CronJob:\n%s", id, body)
+		}
+		if !strings.Contains(body, "forge.agent.id: aibuilderdemo") {
+			t.Errorf("cronjob-%s.yaml missing forge.agent.id label", id)
+		}
+		if !strings.Contains(body, "forge.schedule.id: "+id) {
+			t.Errorf("cronjob-%s.yaml missing schedule.id label", id)
+		}
+		if !strings.Contains(body, "concurrencyPolicy: Forbid") {
+			t.Errorf("cronjob-%s.yaml missing concurrencyPolicy", id)
+		}
+	}
+
+	// Default service URL when scheduler.kubernetes.service_url unset.
+	cronjobDaily, _ := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "cronjob-daily.yaml"))
+	if !strings.Contains(string(cronjobDaily), "http://aibuilderdemo.default.svc:8080/") {
+		t.Errorf("default service URL missing from cronjob-daily.yaml:\n%s", cronjobDaily)
+	}
+}
+
+// TestScheduleManifestStage_SecretTemplateHasNoDataField is the
+// security-critical invariant: the generated Secret manifest MUST NOT
+// carry a populated `data:` field. The artifact ends up in version
+// control and container images; embedding a credential there would
+// be a leak even if the value is "placeholder."
+func TestScheduleManifestStage_SecretTemplateHasNoDataField(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{
+		AgentID:   "agent",
+		Schedules: []types.ScheduleConfig{{ID: "x", Cron: "@hourly", Task: "t"}},
+	})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "internal-token-secret.yaml"))
+	if err != nil {
+		t.Fatalf("read secret template: %v", err)
+	}
+	body := string(data)
+	// The literal "data:" line MUST be commented or absent. A
+	// non-commented top-level data field would be a token leak path
+	// even if its value were a placeholder.
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "data:") {
+			t.Errorf("Secret template contains uncommented data: line — DO NOT EMBED CREDENTIALS\n%s", body)
+		}
+	}
+	if !strings.Contains(body, "type: Opaque") {
+		t.Errorf("Secret template missing type: Opaque\n%s", body)
+	}
+	if !strings.Contains(body, "forge auth secret-yaml") {
+		t.Errorf("Secret template should document the forge auth secret-yaml populate path\n%s", body)
+	}
+}
+
+// TestScheduleManifestStage_RoleVerbsGatedByAllowDynamic pins the
+// privilege-gating invariant: with allow_dynamic=false (the
+// production default), the Role grants get/list/watch only. Flipping
+// allow_dynamic=true grants create/update/delete/patch on top.
+func TestScheduleManifestStage_RoleVerbsGatedByAllowDynamic(t *testing.T) {
+	// verbsLine extracts the `verbs: [...]` line from the Role
+	// manifest. We assert against ONLY this line (not the full
+	// document) because the surrounding prose comment legitimately
+	// references "create/update/delete" as documentation — checking
+	// the whole document for those tokens would catch the comment as
+	// a false positive.
+	verbsLine := func(body string) string {
+		for _, line := range strings.Split(body, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "verbs:") {
+				return trimmed
+			}
+		}
+		return ""
+	}
+
+	t.Run("default disallows write verbs", func(t *testing.T) {
+		bc := newScheduleStageBC(t, &types.ForgeConfig{
+			AgentID:   "agent",
+			Schedules: []types.ScheduleConfig{{ID: "x", Cron: "@hourly", Task: "t"}},
+		})
+		if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		data, _ := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "scheduler-role.yaml"))
+		line := verbsLine(string(data))
+		if line != `verbs: ["get", "list", "watch"]` {
+			t.Errorf("default Role verbs line = %q, want only get/list/watch", line)
+		}
+	})
+	t.Run("allow_dynamic grants write verbs", func(t *testing.T) {
+		bc := newScheduleStageBC(t, &types.ForgeConfig{
+			AgentID:   "agent",
+			Schedules: []types.ScheduleConfig{{ID: "x", Cron: "@hourly", Task: "t"}},
+			Scheduler: types.SchedulerConfig{
+				Kubernetes: types.K8sSchedulerConfig{AllowDynamic: true},
+			},
+		})
+		if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		data, _ := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "scheduler-role.yaml"))
+		line := verbsLine(string(data))
+		for _, verb := range []string{"create", "update", "patch", "delete"} {
+			if !strings.Contains(line, verb) {
+				t.Errorf("allow_dynamic Role verbs line should contain %q; got %q", verb, line)
+			}
+		}
+	})
+}
+
+// TestScheduleManifestStage_RoleBindingTargetsAgentSA verifies the
+// binding points at the ServiceAccount named after the agent_id —
+// the convention forge package's deployment template uses.
+func TestScheduleManifestStage_RoleBindingTargetsAgentSA(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{
+		AgentID:   "my-agent",
+		Schedules: []types.ScheduleConfig{{ID: "x", Cron: "@hourly", Task: "t"}},
+	})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "scheduler-rolebinding.yaml"))
+	body := string(data)
+	if !strings.Contains(body, "kind: ServiceAccount") {
+		t.Errorf("RoleBinding subject must be a ServiceAccount; got:\n%s", body)
+	}
+	if !strings.Contains(body, "name: my-agent") {
+		t.Errorf("RoleBinding must target ServiceAccount named %q; got:\n%s", "my-agent", body)
+	}
+	if !strings.Contains(body, "name: my-agent-scheduler") {
+		t.Errorf("RoleBinding must reference Role %q; got:\n%s", "my-agent-scheduler", body)
+	}
+}
+
+// TestScheduleManifestStage_HonorsExplicitServiceURL confirms an
+// operator-supplied service_url overrides the in-cluster Service DNS
+// default. Used for non-default port / namespace / Ingress deploys.
+func TestScheduleManifestStage_HonorsExplicitServiceURL(t *testing.T) {
+	bc := newScheduleStageBC(t, &types.ForgeConfig{
+		AgentID:   "agent",
+		Schedules: []types.ScheduleConfig{{ID: "x", Cron: "@hourly", Task: "t"}},
+		Scheduler: types.SchedulerConfig{
+			Kubernetes: types.K8sSchedulerConfig{
+				ServiceURL: "https://agent.example.com/",
+			},
+		},
+	})
+	if err := (&ScheduleManifestStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(bc.Opts.OutputDir, "k8s", "cronjob-x.yaml"))
+	if !strings.Contains(string(data), "https://agent.example.com/") {
+		t.Errorf("explicit service_url not honored in cronjob-x.yaml:\n%s", data)
+	}
+	// Default in-cluster DNS must NOT appear.
+	if strings.Contains(string(data), "agent.default.svc") {
+		t.Errorf("default in-cluster DNS leaked despite explicit service_url:\n%s", data)
+	}
+}

--- a/forge-cli/cmd/build.go
+++ b/forge-cli/cmd/build.go
@@ -123,6 +123,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		&build.DockerfileStage{},
 		&build.SecretSafetyStage{},
 		&build.K8sStage{},
+		&build.ScheduleManifestStage{},
 		&build.ValidateStage{},
 		&build.ManifestStage{},
 		&build.SigningStage{},


### PR DESCRIPTION
## Summary

Final piece of the #162 stack. Adds \`ScheduleManifestStage\` to the \`forge package\` build pipeline so packaging an agent with \`forge.yaml schedules[]\` produces the full K8s deploy surface — one CronJob per schedule, a credential-less Secret template, and a Role/RoleBinding pair scoped to the agent's namespace.

Stacked on #170 (\`feat/issue-162-k8s-backend\`). After #169 and #170 merge I'll rebase to main.

## The full #162 stack

| Part | PR | Scope |
|------|----|-------|
| 1 | #168 ✅ merged | \`forge auth\` subcommand (operator UX) |
| 2 | #169 (open) | \`ScheduleBackend\` interface + \`FileBackend\` refactor + manifest helpers |
| 2b | #170 (open) | \`KubernetesBackend\` with client-go for runtime CronJob CRUD |
| **3 (this)** | this PR | \`forge package\` build-pipeline integration |

This PR closes #162. After all four land, \`forge package && kubectl apply -k ./k8s\` produces an end-to-end K8s-native scheduled agent deploy.

## Output

For \`forge.yaml schedules[]\` non-empty, the stage writes into \`<output>/k8s/\`:

| File | Purpose |
|------|---------|
| \`cronjob-<id>.yaml\` (one per schedule) | CronJob built from \`scheduler.CronJobYAML\`; byte-equivalent to what the runtime KubernetesBackend writes via client-go so the reconcile loop doesn't churn against the manifests |
| \`internal-token-secret.yaml\` | **Secret with no \`data\` field.** Operator populates via \`forge auth secret-yaml\` (#162 part 1), ExternalSecrets / Sealed Secrets / SOPS / Vault. Inline comment block documents all three populate paths |
| \`scheduler-role.yaml\` | Namespaced Role. \`get/list/watch\` always present (powers \`schedule_list\` builtin). \`create/update/patch/delete\` gated by \`scheduler.kubernetes.allow_dynamic\` |
| \`scheduler-rolebinding.yaml\` | Binds Role to the ServiceAccount named after \`agent_id\` |

## The security-critical invariant

\`internal-token-secret.yaml\` MUST NOT carry an uncommented \`data:\` field. \`TestScheduleManifestStage_SecretTemplateHasNoDataField\` parses the generated manifest line-by-line and fails if any uncommented \`data:\` appears. Operators get a manifest safe to commit + a documented populate path; embedding the token (even base64'd) would be a credential in version control.

## Behavior matrix

| forge.yaml condition | Stage behavior |
|----------------------|----------------|
| No \`schedules[]\` | No-op |
| \`scheduler.backend: file\` | No-op (operator explicitly opted out) |
| \`scheduler.backend: auto\` (default) or \`kubernetes\` | Emit manifests |
| \`scheduler.kubernetes.service_url\` unset | Default to \`http://<agent>.<ns>.svc:<port>/\` using \`Spec.Runtime.Port\` or 8080 |
| \`scheduler.kubernetes.service_url\` set | Use the explicit value (Ingress / Gateway / non-default port) |
| \`scheduler.kubernetes.allow_dynamic: false\` (default) | Role grants get/list/watch only |
| \`scheduler.kubernetes.allow_dynamic: true\` | Role grants get/list/watch + create/update/patch/delete |

## Files

| File | Change |
|------|--------|
| \`forge-cli/build/schedule_manifest_stage.go\` (new) | \`ScheduleManifestStage\` + Secret-template builder + Role/RoleBinding builders + \`safeFileName\` helper |
| \`forge-cli/build/schedule_manifest_stage_test.go\` (new) | 7 tests covering no-op paths, happy path, credential safety invariant, RBAC gating, RoleBinding correctness, explicit-service-URL override |
| \`forge-cli/cmd/build.go\` | Register \`ScheduleManifestStage\` between \`K8sStage\` and \`ValidateStage\` so validation catches manifest issues before signing |

## Test plan

- [x] \`go test -count=1 ./...\` clean in forge-core and forge-cli
- [x] \`golangci-lint run ./...\` → 0 issues in both modules
- [x] \`gofmt -w\` applied
- [x] 7 new tests pass:
  - \`NoOpWhenNoSchedules\` — guard against unwanted manifest emission
  - \`NoOpWhenBackendFile\` — operator opt-out honored
  - \`EmitsCronJobPerSchedule\` — labels + concurrencyPolicy + default service URL
  - \`SecretTemplateHasNoDataField\` — **security invariant** pinned
  - \`RoleVerbsGatedByAllowDynamic\` — privilege gating; asserts only the \`verbs:\` line (the prose comment legitimately mentions write verbs)
  - \`RoleBindingTargetsAgentSA\` — RBAC wiring
  - \`HonorsExplicitServiceURL\` — Ingress / Gateway path
- [ ] End-to-end smoke (deferred to manual verification post-merge):
  - \`forge package\` an agent with \`schedules[]\`, confirm \`k8s/\` contents match the docs
  - \`forge auth mint-token && forge auth secret-yaml | kubectl apply -f -\` populates the Secret
  - \`kubectl apply -k ./k8s\` brings up the agent + CronJobs
  - Tail \`FORGE_AUDIT_SOCKET\` and confirm \`schedule_fire\` / \`schedule_complete\` events when the CronJob ticks

Closes #162