### PR TITLE
fix(audit): install SequenceCounter before auth so auth_verify lands seq=1 (closes #174)

### DIFF
--- a/forge-cli/runtime/auth_audit_seq_test.go
+++ b/forge-cli/runtime/auth_audit_seq_test.go
@@ -1,0 +1,127 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/auth"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// TestAuthAudit_SeqStampedWhenCounterInstalled is the #174 regression
+// pin: when the request's ctx carries a SequenceCounter (as it does
+// after installSequenceCounterMiddleware wraps the auth chain),
+// makeAuthAuditCallback's emit picks the counter up via
+// EmitFromContext and stamps seq=1 on auth_verify.
+//
+// Pre-fix the callback used plain Emit and lost seq entirely.
+func TestAuthAudit_SeqStampedWhenCounterInstalled(t *testing.T) {
+	var buf bytes.Buffer
+	cb := makeAuthAuditCallback(coreruntime.NewAuditLogger(&buf))
+
+	req := httptest.NewRequest(http.MethodPost, "/tasks", nil)
+	// Simulate the wrapper: install a fresh counter on req.Context().
+	ctx := coreruntime.WithSequenceCounter(req.Context(), new(coreruntime.SequenceCounter))
+	req = req.WithContext(ctx)
+
+	id := &auth.Identity{UserID: "alice", Source: "oidc"}
+	cb(req, id, nil, "jwt")
+
+	var ev coreruntime.AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Event != coreruntime.EventAuthVerify {
+		t.Fatalf("Event = %q, want auth_verify", ev.Event)
+	}
+	if ev.Sequence != 1 {
+		t.Errorf("auth_verify seq = %d, want 1 (counter installed pre-auth)", ev.Sequence)
+	}
+}
+
+// TestAuthAudit_NoSeqWhenCounterAbsent confirms the no-counter path
+// stays valid: when nothing installed a counter on ctx, the emit
+// produces an event with seq=0 (and the omitempty JSON tag drops the
+// field). This pins backward-compat for legacy embedders that wire
+// their own server.Server without the wrapper.
+func TestAuthAudit_NoSeqWhenCounterAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	cb := makeAuthAuditCallback(coreruntime.NewAuditLogger(&buf))
+
+	req := httptest.NewRequest(http.MethodPost, "/tasks", nil) // no counter on ctx
+	cb(req, &auth.Identity{UserID: "alice", Source: "oidc"}, nil, "jwt")
+
+	body := strings.TrimSpace(buf.String())
+	if strings.Contains(body, `"seq"`) {
+		t.Errorf("seq field must be omitted when no counter is on ctx; got: %s", body)
+	}
+}
+
+// TestSequenceCounterMiddleware_InstallsCounterBeforeNext verifies the
+// wrapper installs the counter on r.Context() before delegating to
+// the wrapped middleware (and through to the next handler). The next
+// handler reads the counter off the context to confirm.
+func TestSequenceCounterMiddleware_InstallsCounterBeforeNext(t *testing.T) {
+	// A passthrough auth middleware — just calls next.
+	passthroughAuth := func(next http.Handler) http.Handler { return next }
+
+	var observed *coreruntime.SequenceCounter
+	terminal := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed = coreruntime.SequenceCounterFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := installSequenceCounterMiddleware(passthroughAuth)(terminal)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if observed == nil {
+		t.Fatal("terminal handler saw no SequenceCounter on ctx")
+	}
+	// Counter starts at 0 and increments to 1 on first NextSequence call.
+	if got := coreruntime.NextSequence(coreruntime.WithSequenceCounter(context.Background(), observed)); got != 1 {
+		t.Errorf("first NextSequence on wrapper-installed counter = %d, want 1", got)
+	}
+}
+
+// TestEnsureSequenceCounter_ReusesExisting pins the runner-side
+// invariant: the per-A2A-request setup must NOT clobber a counter
+// already installed by the auth wrapper. EnsureSequenceCounter
+// returns ctx unchanged when the counter is already present.
+func TestEnsureSequenceCounter_ReusesExisting(t *testing.T) {
+	original := new(coreruntime.SequenceCounter)
+	ctx := coreruntime.WithSequenceCounter(context.Background(), original)
+	// Advance the counter once so we can detect a reset.
+	_ = coreruntime.NextSequence(ctx)
+
+	ctx2 := coreruntime.EnsureSequenceCounter(ctx)
+
+	got := coreruntime.SequenceCounterFromContext(ctx2)
+	if got != original {
+		t.Errorf("EnsureSequenceCounter replaced the existing counter; want pointer-equality")
+	}
+	// The counter must continue from where it left off (seq=2 next).
+	if next := coreruntime.NextSequence(ctx2); next != 2 {
+		t.Errorf("counter reset by EnsureSequenceCounter; got next=%d, want 2", next)
+	}
+}
+
+// TestEnsureSequenceCounter_InstallsFresh covers the --no-auth path
+// where the wrapper never ran: EnsureSequenceCounter installs a
+// fresh counter so per-A2A-request audit emit still gets seq stamped.
+func TestEnsureSequenceCounter_InstallsFresh(t *testing.T) {
+	ctx := coreruntime.EnsureSequenceCounter(context.Background())
+	if coreruntime.SequenceCounterFromContext(ctx) == nil {
+		t.Fatal("EnsureSequenceCounter on empty ctx should install a counter")
+	}
+	if next := coreruntime.NextSequence(ctx); next != 1 {
+		t.Errorf("fresh counter's first NextSequence = %d, want 1", next)
+	}
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1051,7 +1051,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		Host:            r.cfg.Host,
 		ShutdownTimeout: r.cfg.ShutdownTimeout,
 		AgentCard:       card,
-		AuthMiddleware:  auth.Middleware(authCfg),
+		AuthMiddleware:  installSequenceCounterMiddleware(auth.Middleware(authCfg)),
 		AllowedOrigins:  corsOrigins,
 		RateLimit:       rateLimit,
 	})
@@ -1189,8 +1189,12 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		// FWS-8: per-invocation sequence counter so every audit event
 		// emitted on behalf of this request carries a monotonically
 		// increasing `seq` field — consumers detect gaps + ordering
-		// at the export side.
-		ctx = coreruntime.WithSequenceCounter(ctx, new(coreruntime.SequenceCounter))
+		// at the export side. Reuse the counter
+		// installSequenceCounterMiddleware put on ctx before auth ran
+		// (so auth_verify=seq=1 and session_start=seq=2) — see #174.
+		// EnsureSequenceCounter installs a fresh one if missing
+		// (--no-auth path / direct test invocations).
+		ctx = coreruntime.EnsureSequenceCounter(ctx)
 		sseAcc := coreruntime.NewLLMUsageAccumulator()
 		ctx = coreruntime.WithLLMUsageAccumulator(ctx, sseAcc)
 		defer func() {
@@ -1403,7 +1407,11 @@ func (r *Runner) executeTask(
 	ctx = coreruntime.WithCorrelationID(ctx, correlationID)
 	ctx = coreruntime.WithTaskID(ctx, params.ID)
 	// FWS-8: per-invocation sequence counter (see issue #91 / FWS-8).
-	ctx = coreruntime.WithSequenceCounter(ctx, new(coreruntime.SequenceCounter))
+	// EnsureSequenceCounter reuses the counter the auth middleware
+	// wrapper installed pre-auth so auth_verify lands seq=1 and
+	// session_start lands seq=2 (#174); installs a fresh one when
+	// missing (--no-auth path / direct test invocations).
+	ctx = coreruntime.EnsureSequenceCounter(ctx)
 	// Per-invocation usage accumulator so AfterLLMCall hooks can fold
 	// each call's tokens/duration into running totals the response
 	// handler reads back for X-Forge-* headers + the
@@ -1686,8 +1694,10 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 		// FWS-8: per-invocation sequence counter so every audit event
 		// emitted on behalf of this request carries a monotonically
 		// increasing `seq` field — consumers detect gaps + ordering
-		// at the export side.
-		ctx = coreruntime.WithSequenceCounter(ctx, new(coreruntime.SequenceCounter))
+		// at the export side. Reuse the counter
+		// installSequenceCounterMiddleware put on ctx before auth ran
+		// (#174); install fresh on the --no-auth path.
+		ctx = coreruntime.EnsureSequenceCounter(ctx)
 		// Pull workflow correlation headers (issue #86 / FWS-2) before
 		// the accumulator setup so invocation_complete inherits workflow
 		// tagging via EmitFromContext.
@@ -2526,10 +2536,17 @@ func makeAuthAuditCallback(auditLogger *coreruntime.AuditLogger) func(*http.Requ
 		wc := coreruntime.WorkflowContextFromHTTPHeaders(req.Header)
 		// Same for the per-request tenancy override (#157). When
 		// absent, the AuditLogger's static deployment-time stamp still
-		// kicks in via plain Emit so auth events match the rest of
-		// the stream's org_id / workspace_id columns.
+		// kicks in so auth events match the rest of the stream's
+		// org_id / workspace_id columns.
 		tc := coreruntime.TenancyContextFromHTTPHeaders(req.Header)
 
+		// EmitFromContext stamps `seq` from the SequenceCounter the
+		// installSequenceCounterMiddleware wrapper installed on
+		// req.Context() before the auth chain ran (#174). The
+		// runner's per-A2A-request setup downstream calls
+		// EnsureSequenceCounter and reuses this counter, so
+		// session_start lands at seq=2 and the per-correlation_id
+		// sequence is gap-free for FWS-8 consumers.
 		if err == nil && id != nil {
 			// Success → auth_verify.
 			fields := map[string]any{
@@ -2542,7 +2559,7 @@ func makeAuthAuditCallback(auditLogger *coreruntime.AuditLogger) func(*http.Requ
 				"path":         req.URL.Path,
 				"remote_addr":  req.RemoteAddr,
 			}
-			auditLogger.Emit(coreruntime.AuditEvent{
+			auditLogger.EmitFromContext(req.Context(), coreruntime.AuditEvent{
 				Event:            coreruntime.EventAuthVerify,
 				CorrelationID:    correlationID,
 				WorkflowID:       wc.WorkflowID,
@@ -2557,7 +2574,7 @@ func makeAuthAuditCallback(auditLogger *coreruntime.AuditLogger) func(*http.Requ
 		}
 
 		// Failure → auth_fail with reason code.
-		auditLogger.Emit(coreruntime.AuditEvent{
+		auditLogger.EmitFromContext(req.Context(), coreruntime.AuditEvent{
 			Event:            coreruntime.EventAuthFail,
 			CorrelationID:    correlationID,
 			WorkflowID:       wc.WorkflowID,

--- a/forge-cli/runtime/sequence_counter_middleware.go
+++ b/forge-cli/runtime/sequence_counter_middleware.go
@@ -1,0 +1,43 @@
+package runtime
+
+import (
+	"net/http"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// installSequenceCounterMiddleware wraps the auth middleware so the
+// per-invocation SequenceCounter is installed on the request context
+// BEFORE the auth chain runs. The auth chain's OnAuth callback (which
+// emits auth_verify / auth_fail) then sees a counter on its
+// req.Context() and stamps seq=1 on the first event. The runner's
+// per-A2A-request setup further downstream calls
+// coreruntime.EnsureSequenceCounter, which detects the existing
+// counter and reuses it — so session_start lands at seq=2, llm_call
+// at seq=3, and the per-correlation_id sequence is gap-free for
+// FWS-8 consumers.
+//
+// Before this wrapper, the runner's setup installed the counter at
+// the JSON-RPC / REST handler entry, which is downstream of auth.
+// The auth callback's audit emits had to use plain Emit() and lost
+// seq + trace_id + workflow-correlation tags. See issue #174.
+//
+// Cost: ~24 bytes per request for the SequenceCounter allocation.
+// The wrapper runs even on auth-skipped paths
+// (/.well-known/agent-card.json, /healthz). Those paths don't emit
+// per-request audit events, so the counter is unused — but allocating
+// unconditionally is simpler than threading skip-path knowledge into
+// the wrapper, and the allocation is in the same ballpark as the
+// request struct itself.
+func installSequenceCounterMiddleware(authMW func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// Compose once: the auth middleware wraps next; we wrap THAT
+		// composition so the seq counter is installed before auth sees
+		// the request.
+		composed := authMW(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := coreruntime.EnsureSequenceCounter(r.Context())
+			composed.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/forge-core/runtime/audit_schema.go
+++ b/forge-core/runtime/audit_schema.go
@@ -71,3 +71,17 @@ func NextSequence(ctx context.Context) int64 {
 	}
 	return c.Add(1)
 }
+
+// EnsureSequenceCounter returns ctx unchanged when it already carries a
+// SequenceCounter; otherwise it returns a new ctx with a fresh counter
+// installed. Use at any invocation-entry point that may run downstream
+// of an upstream middleware which already installed a counter — e.g.,
+// the runner's per-A2A-request setup runs after the auth middleware
+// (which installs a counter so auth_verify lands seq=1) and must not
+// clobber it. See issue #174.
+func EnsureSequenceCounter(ctx context.Context) context.Context {
+	if SequenceCounterFromContext(ctx) != nil {
+		return ctx
+	}
+	return WithSequenceCounter(ctx, new(SequenceCounter))
+}


### PR DESCRIPTION
## Summary

Closes #174. The \`auth_verify\` / \`auth_fail\` audit events were emitted without a \`seq\` field because the per-invocation \`SequenceCounter\` was installed downstream of the auth middleware. Operators saw \`auth_verify\` sitting outside the per-correlation_id sequence, breaking the FWS-8 gap-detection contract.

## Symptom (user-visible, v0.15.0)

\`\`\`
auth_verify            (no seq)   ← BUG
session_start           seq=1
guardrail_check         seq=2
llm_call                seq=3
...
\`\`\`

## Fix

Install the \`SequenceCounter\` on \`r.Context()\` **before** the auth chain runs, via a thin middleware wrapper. The auth chain's \`OnAuth\` callback now uses \`EmitFromContext(req.Context(), ...)\` and stamps \`seq=1\` on \`auth_verify\`. The runner's per-A2A-request setup calls a new \`coreruntime.EnsureSequenceCounter\` helper that detects the existing counter and reuses it, so \`session_start\` lands \`seq=2\` and the per-correlation_id sequence is gap-free.

## After

\`\`\`
auth_verify             seq=1     ← FIXED
session_start           seq=2
guardrail_check         seq=3
llm_call                seq=4
...
\`\`\`

## Pieces

| File | Change |
|------|--------|
| \`forge-core/runtime/audit_schema.go\` | New \`EnsureSequenceCounter(ctx)\` helper — returns ctx unchanged when a counter is present, installs fresh when absent |
| \`forge-cli/runtime/sequence_counter_middleware.go\` (new) | Thin wrapper around \`auth.Middleware\` that installs the counter on \`r.Context()\` before delegating |
| \`forge-cli/runtime/runner.go\` | (1) \`AuthMiddleware: installSequenceCounterMiddleware(auth.Middleware(authCfg))\` (2) \`makeAuthAuditCallback\` switches \`Emit\` → \`EmitFromContext(req.Context(), ...)\` (3) Three in-request \`WithSequenceCounter(ctx, new(...))\` calls → \`EnsureSequenceCounter(ctx)\` |
| \`forge-cli/runtime/auth_audit_seq_test.go\` (new) | 5 tests pinning the invariant |

## What stays as plain \`Emit\` (intentional, documented in PR #173)

| Site | Why \`Emit\` is correct |
|------|---------------------|
| Egress proxy \`OnAttempt\` (\`source: proxy\`) | Subprocess HTTP CONNECT has no Go ctx |
| \`mcp_tool_conflict\` | Startup-time, no invocation scope |
| Schedule dispatcher (\`schedule_fire\` / \`schedule_complete\`) | Scheduler tick runs outside any A2A request scope |

After this PR, the only \"in-scope-but-plain-Emit\" pattern that motivated #175 (the lint) is gone. The three remaining sites are genuinely scope-less.

## Cost

The wrapper allocates a \`SequenceCounter\` (~24 bytes) on every HTTP request, including auth-skipped paths (\`/.well-known/agent-card.json\`, \`/healthz\`). The counter is unused on those paths but allocation is in the same ballpark as the request struct itself; threading skip-path knowledge into the wrapper would be more complexity than the savings warrant.

## End-to-end smoke

**\`--no-auth\` path** (wrapper still runs, but auth middleware is a passthrough):

\`\`\`
session_start          seq=1
session_end            seq=2
invocation_complete    seq=3
\`\`\`

**Auth on** (internal-token loopback, like channel-adapter callbacks and CronJob trigger pods):

\`\`\`
auth_verify            seq=1
session_start          seq=2
session_end            seq=3
invocation_complete    seq=4
\`\`\`

## Test plan

- [x] \`go test -count=1 ./...\` clean in forge-core and forge-cli
- [x] \`golangci-lint run ./...\` → 0 issues
- [x] \`gofmt -w\` applied
- [x] 5 new tests pass:
  - \`TestAuthAudit_SeqStampedWhenCounterInstalled\` — the #174 pin: counter on req.Context() → auth_verify gets seq=1
  - \`TestAuthAudit_NoSeqWhenCounterAbsent\` — back-compat: no counter on ctx → omitempty drops the field (legacy embedders that wire their own server.Server without the wrapper still work)
  - \`TestSequenceCounterMiddleware_InstallsCounterBeforeNext\` — the wrapper installs the counter before delegating to next
  - \`TestEnsureSequenceCounter_ReusesExisting\` — runner must NOT clobber an auth-installed counter (counter-pointer equality + sequence-continuity assertions)
  - \`TestEnsureSequenceCounter_InstallsFresh\` — --no-auth / direct-test path: install a fresh counter when ctx has none
- [x] End-to-end smoke against \`/tmp/forge-fix174\` binary verifying both paths produce the expected seq layout
- [x] Existing \`TestAuthAudit_*\` tests in \`auth_audit_test.go\` still pass (the back-compat assertion confirms emit shape is unchanged when no counter is installed)

## Schema impact

None. The events were already declared to carry \`seq\` — the field's \`omitempty\` JSON tag just dropped it when the value was zero. After the fix, consumers see the field they were already expecting on every per-invocation event; legacy consumers that ignored unknown keys see no behavioral change.

## Follow-on

When this merges, the third row of the four-row \"plain Emit is intentional\" table in #175's lint allow-list disappears (auth callback becomes \`EmitFromContext\`). The three remaining sites — egress proxy \`source: proxy\`, \`mcp_tool_conflict\`, scheduler dispatcher — are genuinely scope-less.