### PR TITLE
fix(init): make scaffolded agents runnable in-cluster (env secret provider + file scheduler)

### DIFF
--- a/forge-cli/templates/init/forge.yaml.tmpl
+++ b/forge-cli/templates/init/forge.yaml.tmpl
@@ -50,13 +50,14 @@ egress:
     - {{.}}
 {{- end}}
 {{- end}}
-{{- if .HasSecrets}}
 
 secrets:
   providers:
+{{- if .HasSecrets}}
     - encrypted-file
-    - env
 {{- end}}
+    - env
+
 {{- if .AuthBlock}}
 
 {{.AuthBlock}}


### PR DESCRIPTION
## Problem
Agents scaffolded by the platform (`forge init --non-interactive`) deploy but can't actually run. Two distinct startup failures, both rooted in the init template:

### 1. No secret provider → StubExecutor
`forge.yaml` had no `secrets:` block (only emitted when `HasSecrets`, i.e. inline secrets passed with values — the platform injects secrets later as k8s env). With no `env` provider, the runtime never reads the OS-injected `OPENAI_API_KEY`; `ResolveModelConfig` finds no key → **StubExecutor** → every task fails with `agent execution not configured for framework "forge"`.

### 2. auto scheduler → KubernetesBackend → crashloop
Once #1 is fixed and a real LLM executor initializes, the scheduler starts. `SchedulerConfig.Backend` defaults to `auto` → **Kubernetes backend in-cluster**, which requires `scheduler.kubernetes.service_url`. The platform deploys via its own manifests (not `forge package`), so service_url is unset → startup error `kubernetes scheduler backend: scheduler.kubernetes.service_url is required` → CrashLoopBackOff.

## Fix (init template)
- Always emit the `env` secret provider (harmless when empty); `encrypted-file` stays gated on `HasSecrets`.
- Default `scheduler.backend: file` (in-process ticker, no service_url). Opt into the K8s CronJob backend with `backend: kubernetes` + `kubernetes.service_url`.

## Verified
`forge init x --non-interactive -f forge -m openai` now scaffolds both `secrets.providers: [env]` and `scheduler.backend: file`. On a live deploy: secret loads from env (`"msg":"secret loaded","provider":"env"`) and the agent no longer crashloops on the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)