### PR TITLE
fix(init): default scheduler.backend to file in scaffolded forge.yaml

### DIFF
--- a/forge-cli/templates/init/forge.yaml.tmpl
+++ b/forge-cli/templates/init/forge.yaml.tmpl
@@ -58,6 +58,13 @@ secrets:
 {{- end}}
     - env
 
+scheduler:
+  # Use the in-process file scheduler by default. The "auto" default would
+  # pick the Kubernetes CronJob backend when running in-cluster, which
+  # requires scheduler.kubernetes.service_url. Switch to backend: kubernetes
+  # (and set kubernetes.service_url) when you want durable CronJob scheduling.
+  backend: file
+
 {{- if .AuthBlock}}
 
 {{.AuthBlock}}


### PR DESCRIPTION
## Problem
Follow-up to #177 (this change was authored alongside it but didn't land in the merge).

Once an agent has a working LLM executor, the runtime initializes the scheduler. `SchedulerConfig.Backend` defaults to `auto`, which selects the **Kubernetes CronJob backend** when running in-cluster — and that errors at startup unless `scheduler.kubernetes.service_url` is set:
```
Error: kubernetes scheduler backend: scheduler.kubernetes.service_url is required
```
Platform-scaffolded agents deploy via their own k8s manifests (not `forge package`, which would set service_url), so the auto→kubernetes path crashlooped (CrashLoopBackOff) as soon as a real executor came up.

## Fix
Default the init template to the in-process **file** scheduler:
```yaml
scheduler:
  backend: file
```
Opt into durable K8s CronJob scheduling by setting `backend: kubernetes` + `kubernetes.service_url`.

## Verified
Live deploy (`testing-sidecar5`): pod reaches `2/2 Ready` with no restarts; agent logs `using LLM executor` (no scheduler crash, no stub). Combined with #177, the full platform path — secret load → LLM executor → scheduler — now works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)