### PR TITLE
feat(ui): skill builder edit mode for attached skills (closes #193)

### DIFF
--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -30,6 +30,7 @@ After feature work, update the affected documentation to reflect code changes.
    | `forge-cli/internal/tui/` | `docs/reference/cli-reference.md` (wizard flow) |
    | `forge-plugins/` | `docs/core-concepts/channels.md`, `docs/reference/framework-plugins.md` |
    | `forge-ui/` | `docs/reference/web-dashboard.md` |
+   | `forge-ui/handlers_skill_builder.go`, `forge-ui/skill_builder_context.go`, `forge-ui/skill_validator.go`, `forge-ui/static/app.js` (SkillBuilderPage), `forge-cli/cmd/ui_skill_save.go` | `docs/reference/web-dashboard.md` (§ Skill Builder + § Editing an Attached Skill), `docs/skills/writing-custom-skills.md` (§ Iterating from the Skill Builder UI) — keep edit-mode endpoints, prompt-trailer behavior, and overwrite-clears-scripts rule in sync |
    | `forge-skills/` | `docs/skills/writing-custom-skills.md`, `docs/skills/contributing-a-skill.md` |
    | `forge-skills/registry/image-registry.yaml`, `forge-core/packaging/` | `docs/core-concepts/binary-dependencies.md` — refresh the registry contents, install methods, or Dockerfile shape sections; keep the source-file list at the bottom in sync with the actual files touched |
    | `forge-cli/templates/Dockerfile.tmpl`, `forge-cli/build/dockerfile_stage.go` | `docs/core-concepts/binary-dependencies.md` (image-shape section), `docs/deployment/docker.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@
 
 ### Added
 
+- **Skill Builder edit mode (issue #193).** The dashboard's Skill Builder
+  can now iterate on an already-attached custom skill instead of only
+  creating new ones. A new **Skills attached to this agent** panel lists
+  each `skills/<name>/SKILL.md` discovered on disk; clicking **Edit**
+  loads its current SKILL.md and helper scripts into the editor, primes
+  the chat with the existing content, and switches the LLM call to an
+  edit-mode prompt that instructs it to preserve `## Tool: <name>`
+  headings, default to minimal patches, and emit a `**Changed:**`
+  summary. A **Preview changes** Monaco diff modal shows editor-state
+  vs disk side-by-side before save. **Confirm save** overwrites the
+  existing skill directory in place; helper scripts dropped during the
+  edit are removed from disk so the runtime stops discovering them. A
+  **Restart agent** banner appears after a successful edit-mode save
+  because the running agent's tool registry is captured at startup and
+  not live-mutated.
+  - New endpoints: `GET /api/agents/{id}/skill-builder/skills`
+    (`[]CustomSkillSummary`) and `GET /api/agents/{id}/skill-builder/skills/{name}`
+    (`CustomSkillContent`). Both reject path-traversal, slashes,
+    backslashes, and non-kebab-case names with `400`.
+  - `POST /api/agents/{id}/skill-builder/chat` accepts `mode: "edit"`
+    and `editing_name`. The server loads the on-disk SKILL.md itself
+    (single source of truth — never trusts UI-provided baseline) and
+    appends an `## Edit Mode` trailer to the system prompt.
+  - `POST /api/agents/{id}/skill-builder/save` accepts `overwrite: true`
+    with `editing_name` matching `skill_name`. Mismatched editing_name
+    is rejected at the handler boundary as defense in depth; the writer
+    additionally guards against wiping scripts when names don't match.
+  - The script loader rejects symlinks whose resolved target escapes
+    the skill's own directory so a malicious link to `/etc/passwd`
+    never reaches the editor or LLM context.
+  - Pinned by `TestListCustomSkills_ReturnsAllForms`,
+    `TestGetCustomSkill_{Subdir,Flat,Errors}`,
+    `TestReadCustomSkill_SymlinkEscapeRejected`,
+    `TestChat_EditMode_PrimesPromptWithExistingSkill`,
+    `TestChat_CreateMode_OmitsEditTrailer`,
+    `TestSave_OverwriteMismatchedEditingName_Rejected`,
+    `TestValidateSkillMD_DuplicateNameSuppression`,
+    `TestSaveSkillToDisk_Overwrite_DropsStaleScripts`,
+    `TestSaveSkillToDisk_Overwrite_NameMismatch_DoesNotWipeScripts`.
+
 - **Subprocess W3C trace-context propagation + binary-runtime skills (issue
   #182).** Skill / tool subprocesses now receive `TRACEPARENT`,
   `TRACESTATE`, and `BAGGAGE` env vars derived from the parent agent's

--- a/docs/reference/web-dashboard.md
+++ b/docs/reference/web-dashboard.md
@@ -172,6 +172,42 @@ See [Skill Builder LLM](../ui/skill-builder-llm.md) for the full configuration r
 6. **Save** — writes `skills/{name}/SKILL.md` and `skills/{name}/scripts/` to the agent directory, merges egress domains into `forge.yaml`, and writes env vars to `.env`
 7. **Configure** — if the skill requires env vars that aren't set, the UI shows input fields to provide them and re-save
 
+### Editing an Attached Skill
+
+The Skill Builder also supports iterating on an already-attached custom
+skill — created either by the builder or by hand. Real-world bugs in a
+skill (wrong input schema, missing egress, brittle error handling) only
+surface once the LLM actually calls the tool inside the agent loop, so
+the create → test → fix loop needs a first-class edit path.
+
+| Step | What happens |
+|------|--------------|
+| 1. Open the Skill Builder for an agent that already has custom skills | A **Skills attached to this agent** panel lists each `skills/<name>/SKILL.md` (subdir form) and `skills/<name>.md` (flat form) discovered on disk. |
+| 2. Click **Edit** on one of them | The skill's current SKILL.md and helper scripts load into the editor; the chat is seeded with a system message naming the skill; the header shows an **Editing** banner with the skill name. |
+| 3. Describe the change in chat | The chat call passes `mode: "edit"` and `editing_name`. The server reloads the on-disk SKILL.md itself (single source of truth) and primes the LLM with an `## Edit Mode` trailer that instructs it to preserve existing `## Tool: <name>` headings, default to minimal patches, and end with a `**Changed:**` summary. |
+| 4. Click **Preview changes** | A Monaco side-by-side diff modal shows the editor state vs the on-disk baseline. Tabs cover SKILL.md plus every script that appears in either side — scripts present only in the new state are tagged `new`, scripts present only in the old state are tagged `removed`. |
+| 5. Click **Confirm save** | The save call sets `overwrite: true` and `editing_name` matching `skill_name`. The validator suppresses the duplicate-name warning (the skill IS the one being edited). The forge-cli writer wipes `skills/<name>/scripts/` before re-writing the script set so any dropped scripts disappear from disk — they would otherwise linger and the runtime would keep discovering them. |
+| 6. Restart prompt | After a successful edit-mode save, a banner offers a **Restart agent** action. The running agent's tool registry is frozen at startup, so a restart is the safe way to pick up the edited SKILL.md and scripts. (The watcher reloads the agent card on file changes, but not the live tool registry — see the [hot-reload note](#hot-reload-note) below.) |
+| 7. Click **New skill** to reset | Clears editor state and the chat, drops back into create mode so the next message starts a fresh skill. |
+
+#### Renaming a skill
+
+The frontmatter `name:` field IS the on-disk identifier and the tool
+name the LLM dispatches against — renaming it is a breaking change for
+any agent already wired to the existing tool. The validator surfaces a
+warning when the editor `name:` differs from the skill being edited.
+Save in that case writes a NEW skill directory under the new name and
+leaves the old directory in place; nothing is renamed in-place. Manual
+cleanup of the old directory is required.
+
+#### Hot-reload note
+
+The dashboard's file watcher reloads the agent card on SKILL.md
+changes, but the agent runtime's tool registry is captured once at
+startup and not live-mutated. Restart the agent (the banner that
+appears after save does this for you) to make edited skills callable
+in the running session.
+
 ### Validation Rules
 
 The validator enforces the [SKILL.md format](../core-concepts/skill-md-format.md):
@@ -194,9 +230,11 @@ The validator enforces the [SKILL.md format](../core-concepts/skill-md-format.md
 | `GET` | `/api/skill-builder/provider` | Returns the resolved workspace-level LLM (provider, model, `source`, `has_key`, deprecation `warning`). Use this for first-run detection before any agent is picked. |
 | `GET` | `/api/agents/{id}/skill-builder/provider` | Same shape as above, but consults the agent-fallback tier when no workspace/user config exists. |
 | `GET` | `/api/agents/{id}/skill-builder/context` | Returns the system prompt used for skill generation |
-| `POST` | `/api/agents/{id}/skill-builder/chat` | Streams an LLM conversation via SSE (accepts `messages` array). Returns `400` when the workspace LLM is `unset` or has no resolvable API key. |
-| `POST` | `/api/agents/{id}/skill-builder/validate` | Validates a SKILL.md and optional scripts |
-| `POST` | `/api/agents/{id}/skill-builder/save` | Saves a validated skill to `skills/{name}/`, merges egress domains, writes env vars; returns `SkillSaveResult` with `path`, `egress_added`, `env_configured`, `env_missing` |
+| `POST` | `/api/agents/{id}/skill-builder/chat` | Streams an LLM conversation via SSE. Accepts `messages` array; in edit mode also pass `mode: "edit"` and `editing_name` so the server loads the on-disk skill and primes an `## Edit Mode` system-prompt trailer. Returns `400` when the workspace LLM is `unset` or has no resolvable API key. |
+| `POST` | `/api/agents/{id}/skill-builder/validate` | Validates a SKILL.md and optional scripts. In edit mode pass `mode: "edit"` and `editing_name` to suppress the duplicate-name warning for the skill being edited. |
+| `POST` | `/api/agents/{id}/skill-builder/save` | Saves a validated skill to `skills/{name}/`, merges egress domains, writes env vars; returns `SkillSaveResult` with `path`, `egress_added`, `env_configured`, `env_missing`. In edit mode pass `overwrite: true` and `editing_name` matching `skill_name` to rewrite the existing directory and clear stale scripts. |
+| `GET` | `/api/agents/{id}/skill-builder/skills` | Lists custom skills attached to the agent (project-local SKILL.md files under `skills/`). Distinct from `/api/skills` which returns registry/embedded skills. Returns `[]CustomSkillSummary` with `name`, `description`, `category`, `tags`, `path`, `has_scripts`, `tools`. |
+| `GET` | `/api/agents/{id}/skill-builder/skills/{name}` | Loads one custom skill's SKILL.md plus any helper scripts so the builder can populate the editor. Returns `CustomSkillContent` with `skill_md`, `scripts` (basename → content), `format` (`subdir`\|`flat`). Rejects invalid names (path traversal, non-kebab-case) with `400`; returns `404` when the skill doesn't exist. |
 | `GET` | `/api/settings/skill-builder` | Returns the workspace-level config + metadata for the Settings modal (`source`, `has_key`, `providers` list). The API key value is never echoed back. |
 | `PUT` | `/api/settings/skill-builder` | Persists `provider`, `model`, optional `base_url`, optional `api_key_env` to `<workspace>/.forge/ui.yaml`. When an optional `api_key` field is present in the body, writes it to `<workspace>/.forge/.env` (mode `0600`) under `api_key_env` (or the provider default). The key value never leaks to `ui.yaml`. Submit an empty / omitted `api_key` to leave the saved value untouched. |
 

--- a/docs/skills/writing-custom-skills.md
+++ b/docs/skills/writing-custom-skills.md
@@ -112,6 +112,38 @@ Additionally, skill `Description()` methods and system prompt catalog entries us
 
 For full details on guardrail types, pattern syntax, and runtime behavior, see [Content Guardrails — Skill Guardrails](../security/guardrails.md#skill-guardrails).
 
+## Iterating from the Skill Builder UI
+
+Custom skills can be authored AND iterated on from the dashboard's
+[Skill Builder](../reference/web-dashboard.md#skill-builder). After a
+skill is saved and attached, real-world bugs surface only when the LLM
+actually calls the tool inside the agent loop — wrong input schema,
+brittle error handling, undeclared egress. The builder's **edit mode**
+closes the loop:
+
+1. Open the Skill Builder for the agent.
+2. The **Skills attached to this agent** panel lists your custom skills.
+3. Click **Edit** on a skill — its current SKILL.md and helper scripts
+   load into the Monaco editor and the chat is primed with the existing
+   content so the LLM can patch it intelligently.
+4. Describe the change in chat. The LLM is instructed to preserve
+   existing `## Tool: <name>` headings (renaming breaks any agent already
+   wired to that tool) and emit a `**Changed:**` summary.
+5. Click **Preview changes** for a side-by-side diff before saving.
+6. **Confirm save** overwrites the existing skill directory in place.
+   Helper scripts dropped from the new SKILL.md are removed from disk so
+   the runtime stops discovering them.
+7. **Restart agent** when prompted so the running agent picks up the
+   changes — the live tool registry is captured at startup and the
+   watcher refreshes the agent card, not the registry.
+
+Hand-editing `skills/<name>/SKILL.md` on disk still works for power
+users and remains supported. The builder's edit mode is a strict
+addition — no migration required for existing skills.
+
+See [Web Dashboard › Editing an Attached Skill](../reference/web-dashboard.md#editing-an-attached-skill)
+for the full UX walkthrough and API endpoints.
+
 ## Skill Instructions in System Prompt
 
 Forge injects the **full body** of each skill's SKILL.md into the LLM system prompt. This means all detailed operational instructions — triage steps, detection heuristics, output structure, safety constraints — are directly available in the LLM's context without requiring an extra `read_skill` tool call.

--- a/forge-cli/cmd/ui.go
+++ b/forge-cli/cmd/ui.go
@@ -207,57 +207,11 @@ func runUI(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Build the SkillSaveFunc for saving generated skills.
-	skillSaveFunc := func(opts forgeui.SkillSaveOptions) (*forgeui.SkillSaveResult, error) {
-		skillDir := filepath.Join(opts.AgentDir, "skills", opts.SkillName)
-		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			return nil, fmt.Errorf("creating skill directory: %w", err)
-		}
-
-		skillPath := filepath.Join(skillDir, "SKILL.md")
-		if err := os.WriteFile(skillPath, []byte(opts.SkillMD), 0o644); err != nil {
-			return nil, fmt.Errorf("writing SKILL.md: %w", err)
-		}
-
-		if len(opts.Scripts) > 0 {
-			scriptsDir := filepath.Join(skillDir, "scripts")
-			if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
-				return nil, fmt.Errorf("creating scripts directory: %w", err)
-			}
-			for filename, content := range opts.Scripts {
-				scriptPath := filepath.Join(scriptsDir, filename)
-				if err := os.WriteFile(scriptPath, []byte(content), 0o755); err != nil {
-					return nil, fmt.Errorf("writing script %s: %w", filename, err)
-				}
-			}
-		}
-
-		result := &forgeui.SkillSaveResult{
-			Path: "skills/" + opts.SkillName + "/SKILL.md",
-		}
-
-		// Parse skill requirements from SKILL.md
-		reqInfo := ParseSkillRequirements(opts.SkillMD)
-
-		// Write user-provided env vars to .env
-		if len(opts.EnvVars) > 0 {
-			written, _ := AppendEnvVars(opts.AgentDir, opts.EnvVars, opts.SkillName)
-			result.EnvConfigured = written
-		}
-
-		// Merge egress domains into forge.yaml
-		if len(reqInfo.EgressDomains) > 0 {
-			added, _ := MergeEgressDomains(opts.AgentDir, reqInfo.EgressDomains)
-			result.EgressAdded = added
-		}
-
-		// Check for missing env vars
-		if reqInfo.EnvReqs != nil {
-			result.EnvMissing = CheckMissingEnv(opts.AgentDir, reqInfo.EnvReqs)
-		}
-
-		return result, nil
-	}
+	// Build the SkillSaveFunc for saving generated skills. The
+	// actual disk-writing logic lives in SaveSkillToDisk so it's
+	// directly unit-testable — particularly the edit-mode
+	// scripts/-cleanup behavior (issue #193).
+	skillSaveFunc := SaveSkillToDisk
 
 	server := forgeui.NewUIServer(forgeui.UIServerConfig{
 		Port:          uiPort,

--- a/forge-cli/cmd/ui_skill_save.go
+++ b/forge-cli/cmd/ui_skill_save.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	forgeui "github.com/initializ/forge/forge-ui"
+)
+
+// SaveSkillToDisk writes a generated skill (SKILL.md plus any helper
+// scripts) into the agent's skills/ directory and returns the same
+// SkillSaveResult shape the dashboard's save endpoint emits.
+//
+// Edit-mode behavior (issue #193): when opts.Overwrite is true AND
+// opts.EditingName matches opts.SkillName, the function removes the
+// existing scripts/ directory before writing the new set. Without this
+// step, scripts the user dropped during the edit would linger on disk
+// — the rewritten SKILL.md would reference some-other-script.sh while
+// the old, no-longer-listed scripts continued to be discovered. The
+// EditingName==SkillName guard is defense in depth — the calling
+// handler already rejects overwrite requests where the names don't
+// match, but mirroring it here keeps this function safe to call from
+// any future caller too.
+//
+// This function is lifted out of ui.go's anonymous SkillSaveFunc so
+// it's directly unit-testable.
+func SaveSkillToDisk(opts forgeui.SkillSaveOptions) (*forgeui.SkillSaveResult, error) {
+	skillDir := filepath.Join(opts.AgentDir, "skills", opts.SkillName)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating skill directory: %w", err)
+	}
+
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte(opts.SkillMD), 0o644); err != nil {
+		return nil, fmt.Errorf("writing SKILL.md: %w", err)
+	}
+
+	scriptsDir := filepath.Join(skillDir, "scripts")
+	if opts.Overwrite && opts.EditingName == opts.SkillName {
+		if err := os.RemoveAll(scriptsDir); err != nil {
+			return nil, fmt.Errorf("clearing stale scripts: %w", err)
+		}
+	}
+	if len(opts.Scripts) > 0 {
+		if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+			return nil, fmt.Errorf("creating scripts directory: %w", err)
+		}
+		for filename, content := range opts.Scripts {
+			scriptPath := filepath.Join(scriptsDir, filename)
+			if err := os.WriteFile(scriptPath, []byte(content), 0o755); err != nil {
+				return nil, fmt.Errorf("writing script %s: %w", filename, err)
+			}
+		}
+	}
+
+	result := &forgeui.SkillSaveResult{
+		Path: "skills/" + opts.SkillName + "/SKILL.md",
+	}
+
+	reqInfo := ParseSkillRequirements(opts.SkillMD)
+
+	if len(opts.EnvVars) > 0 {
+		written, _ := AppendEnvVars(opts.AgentDir, opts.EnvVars, opts.SkillName)
+		result.EnvConfigured = written
+	}
+
+	if len(reqInfo.EgressDomains) > 0 {
+		added, _ := MergeEgressDomains(opts.AgentDir, reqInfo.EgressDomains)
+		result.EgressAdded = added
+	}
+
+	if reqInfo.EnvReqs != nil {
+		result.EnvMissing = CheckMissingEnv(opts.AgentDir, reqInfo.EnvReqs)
+	}
+
+	return result, nil
+}

--- a/forge-cli/cmd/ui_skill_save_test.go
+++ b/forge-cli/cmd/ui_skill_save_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	forgeui "github.com/initializ/forge/forge-ui"
+)
+
+// TestSaveSkillToDisk_CreateNew_WritesSkillAndScripts pins the
+// create-path behavior unchanged by issue #193 — a fresh skill lands
+// at skills/<name>/SKILL.md with executable scripts beside it.
+func TestSaveSkillToDisk_CreateNew_WritesSkillAndScripts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "forge.yaml"),
+		[]byte("agent_id: t\nversion: 0.1\nframework: forge\nmodel:\n  provider: openai\n  name: x\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := SaveSkillToDisk(forgeui.SkillSaveOptions{
+		AgentDir:  root,
+		SkillName: "fresh",
+		SkillMD:   "---\nname: fresh\ndescription: x\n---\n# F\n## Tool: t\nA tool.\n",
+		Scripts: map[string]string{
+			"a.sh": "#!/bin/sh\necho a\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveSkillToDisk: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "skills", "fresh", "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "skills", "fresh", "scripts", "a.sh")); err != nil {
+		t.Errorf("script a.sh not written: %v", err)
+	}
+}
+
+// TestSaveSkillToDisk_Overwrite_DropsStaleScripts is the issue #193
+// invariant: when the user edits a skill and removes one of its
+// helper scripts, the stale .sh on disk MUST be gone after save.
+// Otherwise the runtime (which globs the scripts/ directory) keeps
+// finding and executing scripts the SKILL.md no longer references.
+func TestSaveSkillToDisk_Overwrite_DropsStaleScripts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "forge.yaml"),
+		[]byte("agent_id: t\nversion: 0.1\nframework: forge\nmodel:\n  provider: openai\n  name: x\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a skill with two scripts.
+	_, err := SaveSkillToDisk(forgeui.SkillSaveOptions{
+		AgentDir:  root,
+		SkillName: "iter",
+		SkillMD:   "---\nname: iter\ndescription: x\n---\n# I\n## Tool: t\nA tool.\n",
+		Scripts: map[string]string{
+			"old.sh":  "#!/bin/sh\necho old\n",
+			"keep.sh": "#!/bin/sh\necho keep\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+
+	// Edit: drop old.sh, modify keep.sh.
+	_, err = SaveSkillToDisk(forgeui.SkillSaveOptions{
+		AgentDir:    root,
+		SkillName:   "iter",
+		EditingName: "iter",
+		Overwrite:   true,
+		SkillMD:     "---\nname: iter\ndescription: x updated\n---\n# I\n## Tool: t\nA tool.\n",
+		Scripts: map[string]string{
+			"keep.sh": "#!/bin/sh\necho keep modified\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("overwrite save: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "skills", "iter", "scripts", "old.sh")); !os.IsNotExist(err) {
+		t.Errorf("stale script old.sh still present after edit (err: %v)", err)
+	}
+	keep, err := os.ReadFile(filepath.Join(root, "skills", "iter", "scripts", "keep.sh"))
+	if err != nil {
+		t.Fatalf("keep.sh missing: %v", err)
+	}
+	if string(keep) != "#!/bin/sh\necho keep modified\n" {
+		t.Errorf("keep.sh not updated; got %q", string(keep))
+	}
+}
+
+// TestSaveSkillToDisk_Overwrite_NameMismatch_DoesNotWipeScripts is
+// the defense-in-depth pin: even if a caller bypasses the handler
+// and passes Overwrite=true with EditingName != SkillName, the
+// scripts/-cleanup path must NOT fire. The handler is the primary
+// guard; this is the belt to its suspenders.
+func TestSaveSkillToDisk_Overwrite_NameMismatch_DoesNotWipeScripts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "forge.yaml"),
+		[]byte("agent_id: t\nversion: 0.1\nframework: forge\nmodel:\n  provider: openai\n  name: x\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := SaveSkillToDisk(forgeui.SkillSaveOptions{
+		AgentDir:  root,
+		SkillName: "victim",
+		SkillMD:   "---\nname: victim\ndescription: x\n---\n# V\n## Tool: t\nA tool.\n",
+		Scripts: map[string]string{
+			"important.sh": "#!/bin/sh\necho important\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+
+	// Caller bypasses the handler: overwrite=true with mismatched
+	// editing_name. The RemoveAll branch must not fire because the
+	// guard would have rejected this at the handler boundary.
+	_, err = SaveSkillToDisk(forgeui.SkillSaveOptions{
+		AgentDir:    root,
+		SkillName:   "victim",
+		EditingName: "attacker", // <-- mismatch
+		Overwrite:   true,
+		SkillMD:     "---\nname: victim\ndescription: y\n---\n# V\n## Tool: t\nA tool.\n",
+		Scripts:     nil,
+	})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "skills", "victim", "scripts", "important.sh")); err != nil {
+		t.Errorf("important.sh wiped under mismatched-name overwrite: %v", err)
+	}
+}

--- a/forge-ui/handlers_skill_builder.go
+++ b/forge-ui/handlers_skill_builder.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/initializ/forge/forge-skills/parser"
 	"github.com/initializ/forge/forge-ui/uiconfig"
 )
 
@@ -77,9 +81,15 @@ func (s *UIServer) handleSkillBuilderProvider(w http.ResponseWriter, r *http.Req
 }
 
 // handleSkillBuilderContext returns the system prompt for the skill builder.
+//
+// Returns the create-mode prompt by default. Edit-mode prompts are
+// constructed on-demand by handleSkillBuilderChat itself (which loads
+// the live on-disk state) so this endpoint stays cheap and stateless —
+// it's only used by the UI to surface the prompt for the operator to
+// read, never to drive an actual LLM call.
 func (s *UIServer) handleSkillBuilderContext(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
-		"system_prompt": skillBuilderSystemPrompt,
+		"system_prompt": skillBuilderSystemPrompt(modeCreate, nil),
 	})
 }
 
@@ -140,12 +150,38 @@ func (s *UIServer) handleSkillBuilderChat(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Connection", "keep-alive")
 	flusher.Flush()
 
+	// Build the system prompt. In edit mode the handler loads the on-
+	// disk SKILL.md + scripts itself (single source of truth — never
+	// trust UI-provided content here, since a stale or tampered editor
+	// state would feed the LLM the wrong baseline) and primes the
+	// prompt with an "## Edit Mode" trailer. See issue #193.
+	mode := modeCreate
+	var existing *existingSkillContext
+	if req.Mode == "edit" {
+		if err := validateSkillNameForPath(req.EditingName); err != nil {
+			writeError(w, http.StatusBadRequest, "editing_name: "+err.Error())
+			return
+		}
+		ex, err := readCustomSkill(agentDir, req.EditingName)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "loading skill to edit: "+err.Error())
+			return
+		}
+		mode = modeEdit
+		existing = &existingSkillContext{
+			Name:    ex.Name,
+			SkillMD: ex.SkillMD,
+			Scripts: ex.Scripts,
+		}
+	}
+	systemPrompt := skillBuilderSystemPrompt(mode, existing)
+
 	var fullResponse strings.Builder
 
 	err = s.cfg.LLMStreamFunc(r.Context(), LLMStreamOptions{
 		LLM:          llm,
 		AgentDir:     agentDir,
-		SystemPrompt: skillBuilderSystemPrompt,
+		SystemPrompt: systemPrompt,
 		Messages:     req.Messages,
 		OnChunk: func(chunk string) {
 			fullResponse.WriteString(chunk)
@@ -178,6 +214,49 @@ func (s *UIServer) handleSkillBuilderChat(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// handleSkillBuilderListCustomSkills lists project-local skills attached
+// to the agent (issue #193). Builtin / embedded registry skills are NOT
+// included — those live in the binary, can't be edited from the
+// dashboard, and have their own /api/skills endpoint.
+func (s *UIServer) handleSkillBuilderListCustomSkills(w http.ResponseWriter, r *http.Request) {
+	agentDir := s.resolveAgentDir(w, r)
+	if agentDir == "" {
+		return
+	}
+	skills, err := listCustomSkills(agentDir)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "listing custom skills: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, skills)
+}
+
+// handleSkillBuilderGetCustomSkill returns the SKILL.md and scripts for
+// a single custom skill so the Skill Builder can populate the editor in
+// edit mode (issue #193). 404 if the skill doesn't exist on disk; 400
+// for an invalid name.
+func (s *UIServer) handleSkillBuilderGetCustomSkill(w http.ResponseWriter, r *http.Request) {
+	agentDir := s.resolveAgentDir(w, r)
+	if agentDir == "" {
+		return
+	}
+	name := r.PathValue("name")
+	if err := validateSkillNameForPath(name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	content, err := readCustomSkill(agentDir, name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "skill not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "loading skill: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, content)
+}
+
 // handleSkillBuilderValidate validates a SKILL.md and optional scripts.
 func (s *UIServer) handleSkillBuilderValidate(w http.ResponseWriter, r *http.Request) {
 	agentDir := s.resolveAgentDir(w, r)
@@ -191,7 +270,13 @@ func (s *UIServer) handleSkillBuilderValidate(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result := validateSkillMD(req.SkillMD, req.Scripts, agentDir)
+	// In edit mode, suppress the duplicate-name warning for the skill
+	// being edited; a rename still warns. See validateSkillMD (issue #193).
+	editing := ""
+	if req.Mode == "edit" {
+		editing = req.EditingName
+	}
+	result := validateSkillMD(req.SkillMD, req.Scripts, agentDir, editing)
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -213,22 +298,35 @@ func (s *UIServer) handleSkillBuilderSave(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Validate skill name format (security: prevent path traversal)
-	if req.SkillName == "" {
-		writeError(w, http.StatusBadRequest, "skill_name is required")
-		return
-	}
-	if !skillNamePattern.MatchString(req.SkillName) {
-		writeError(w, http.StatusBadRequest, "skill_name must be lowercase kebab-case")
-		return
-	}
-	if strings.Contains(req.SkillName, "/") || strings.Contains(req.SkillName, "\\") || strings.Contains(req.SkillName, "..") {
-		writeError(w, http.StatusBadRequest, "skill_name contains invalid characters")
+	if err := validateSkillNameForPath(req.SkillName); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	// Validate content first
-	result := validateSkillMD(req.SkillMD, req.Scripts, agentDir)
+	// Edit-mode safety: overwrite is only valid when the request's
+	// editing_name matches the skill_name being saved. Trying to
+	// overwrite a DIFFERENT skill's directory is rejected here so the
+	// SkillSaveFunc never sees a request that would clobber an
+	// unrelated skill (issue #193).
+	if req.Overwrite && req.EditingName != req.SkillName {
+		writeError(w, http.StatusBadRequest,
+			"overwrite is only allowed when editing_name matches skill_name")
+		return
+	}
+	if req.EditingName != "" {
+		if err := validateSkillNameForPath(req.EditingName); err != nil {
+			writeError(w, http.StatusBadRequest, "editing_name: "+err.Error())
+			return
+		}
+	}
+
+	// Validate content first. In edit mode the duplicate-name warning
+	// is suppressed for the skill being edited — see validateSkillMD.
+	editingForValidate := ""
+	if req.Overwrite {
+		editingForValidate = req.EditingName
+	}
+	result := validateSkillMD(req.SkillMD, req.Scripts, agentDir, editingForValidate)
 	if !result.Valid {
 		writeJSON(w, http.StatusBadRequest, map[string]any{
 			"error":      "validation failed",
@@ -238,11 +336,13 @@ func (s *UIServer) handleSkillBuilderSave(w http.ResponseWriter, r *http.Request
 	}
 
 	saveResult, err := s.cfg.SkillSaveFunc(SkillSaveOptions{
-		AgentDir:  agentDir,
-		SkillName: req.SkillName,
-		SkillMD:   req.SkillMD,
-		Scripts:   req.Scripts,
-		EnvVars:   req.EnvVars,
+		AgentDir:    agentDir,
+		SkillName:   req.SkillName,
+		SkillMD:     req.SkillMD,
+		Scripts:     req.Scripts,
+		EnvVars:     req.EnvVars,
+		Overwrite:   req.Overwrite,
+		EditingName: req.EditingName,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "saving skill: "+err.Error())
@@ -250,4 +350,240 @@ func (s *UIServer) handleSkillBuilderSave(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, http.StatusOK, saveResult)
+}
+
+// validateSkillNameForPath checks that a skill name is safe to use as
+// a path component. Shared between the save, load, and edit-mode chat
+// handlers — skill names always cross the filesystem boundary so the
+// guard MUST be identical across every entry point.
+func validateSkillNameForPath(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill_name is required")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("skill_name must be lowercase kebab-case")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("skill_name contains invalid characters")
+	}
+	return nil
+}
+
+// listCustomSkillFiles globs the agent's skills directory for SKILL.md
+// files — both the subdir form (skills/<name>/SKILL.md) and the flat
+// form (skills/<name>.md). The agent's root SKILL.md is deliberately
+// excluded: it describes the agent itself, not an attached skill.
+//
+// Returned paths are absolute. Used by the list-custom-skills endpoint
+// (issue #193) and only here — the runtime has its own equivalent walk
+// at forge-cli/runtime/runner.go:discoverSkillFiles which we don't
+// import to avoid a forge-cli → forge-ui dependency cycle.
+func listCustomSkillFiles(agentDir string) ([]string, error) {
+	skillsDir := filepath.Join(agentDir, "skills")
+	info, err := os.Stat(skillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() {
+			subdirSkill := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+			if _, err := os.Stat(subdirSkill); err == nil {
+				paths = append(paths, subdirSkill)
+			}
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".md") && e.Name() != "SKILL.md" {
+			paths = append(paths, filepath.Join(skillsDir, e.Name()))
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// listCustomSkills walks the agent's skills/ directory and returns one
+// CustomSkillSummary per discovered SKILL.md (issue #193). A skill with
+// a parse error is logged-and-skipped rather than failing the whole
+// list — the operator may have a half-edited skill on disk and we
+// want the rest of the picker to keep working.
+func listCustomSkills(agentDir string) ([]CustomSkillSummary, error) {
+	paths, err := listCustomSkillFiles(agentDir)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]CustomSkillSummary, 0, len(paths))
+	for _, p := range paths {
+		f, err := os.Open(p)
+		if err != nil {
+			continue
+		}
+		entries, meta, err := parser.ParseWithMetadata(f)
+		_ = f.Close()
+		if err != nil || meta == nil {
+			continue
+		}
+		// Derive the directory-name for path-style identification.
+		// For the subdir form, the skill's directory IS the canonical
+		// identifier; for flat form, it's the file's basename minus
+		// .md. The frontmatter Name takes precedence either way (it's
+		// what `forge skills validate` and the runtime register on),
+		// but we fall back to the directory name when frontmatter
+		// Name is empty so a half-authored skill still appears in
+		// the list.
+		display := meta.Name
+		if display == "" {
+			dir := filepath.Dir(p)
+			if filepath.Base(p) == "SKILL.md" {
+				display = filepath.Base(dir)
+			} else {
+				display = strings.TrimSuffix(filepath.Base(p), ".md")
+			}
+		}
+		rel, _ := filepath.Rel(agentDir, p)
+		if rel == "" {
+			rel = p
+		}
+		hasScripts := false
+		if filepath.Base(p) == "SKILL.md" {
+			scriptsDir := filepath.Join(filepath.Dir(p), "scripts")
+			if info, statErr := os.Stat(scriptsDir); statErr == nil && info.IsDir() {
+				hasScripts = true
+			}
+		}
+		var toolNames []string
+		for _, e := range entries {
+			if e.Name != "" {
+				toolNames = append(toolNames, e.Name)
+			}
+		}
+		summaries = append(summaries, CustomSkillSummary{
+			Name:        display,
+			Description: meta.Description,
+			Category:    meta.Category,
+			Tags:        meta.Tags,
+			Path:        rel,
+			HasScripts:  hasScripts,
+			Tools:       toolNames,
+		})
+	}
+	return summaries, nil
+}
+
+// readCustomSkill loads a skill's SKILL.md and any helper scripts into
+// memory so the Skill Builder can populate the editor (issue #193).
+// Tries subdir form (skills/<name>/SKILL.md) first, then flat form
+// (skills/<name>.md). Returns an os.IsNotExist-compatible error when
+// neither path exists so the handler can return 404.
+//
+// Symlink hardening: scripts are walked with strict symlink-escape
+// rejection. Any script whose resolved target falls outside the
+// skill's own directory is dropped from the result — a malicious or
+// accidental link to /etc/passwd never reaches the editor.
+func readCustomSkill(agentDir, name string) (*CustomSkillContent, error) {
+	subdirPath := filepath.Join(agentDir, "skills", name, "SKILL.md")
+	flatPath := filepath.Join(agentDir, "skills", name+".md")
+
+	var path, format string
+	if _, err := os.Stat(subdirPath); err == nil {
+		path = subdirPath
+		format = "subdir"
+	} else if _, err := os.Stat(flatPath); err == nil {
+		path = flatPath
+		format = "flat"
+	} else {
+		return nil, os.ErrNotExist
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	rel, _ := filepath.Rel(agentDir, path)
+	if rel == "" {
+		rel = path
+	}
+
+	content := &CustomSkillContent{
+		Name:    name,
+		SkillMD: string(data),
+		Path:    rel,
+		Format:  format,
+	}
+
+	if format == "subdir" {
+		scriptsDir := filepath.Join(agentDir, "skills", name, "scripts")
+		scripts, err := readSkillScripts(scriptsDir)
+		if err != nil {
+			return nil, err
+		}
+		content.Scripts = scripts
+	}
+	return content, nil
+}
+
+// readSkillScripts loads every regular file under scriptsDir into a
+// basename → content map. Symlinks whose resolved target escapes
+// scriptsDir are skipped (defense in depth — the skill directory is
+// trusted, but a symlink inside it isn't).
+func readSkillScripts(scriptsDir string) (map[string]string, error) {
+	info, err := os.Stat(scriptsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+	scriptsAbs, err := filepath.Abs(scriptsDir)
+	if err != nil {
+		return nil, err
+	}
+	if real, err := filepath.EvalSymlinks(scriptsAbs); err == nil {
+		scriptsAbs = real
+	}
+
+	scripts := make(map[string]string)
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		entryPath := filepath.Join(scriptsDir, e.Name())
+		realPath, err := filepath.EvalSymlinks(entryPath)
+		if err != nil {
+			continue
+		}
+		// Reject if the resolved target falls outside scriptsAbs —
+		// stops a symlink-to-/etc/passwd from leaking the file into
+		// the editor and from there into the LLM context.
+		realAbs, err := filepath.Abs(realPath)
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(realAbs+string(os.PathSeparator), scriptsAbs+string(os.PathSeparator)) &&
+			realAbs != scriptsAbs {
+			continue
+		}
+		data, err := os.ReadFile(entryPath)
+		if err != nil {
+			continue
+		}
+		scripts[e.Name()] = string(data)
+	}
+	return scripts, nil
 }

--- a/forge-ui/handlers_skill_builder_edit_test.go
+++ b/forge-ui/handlers_skill_builder_edit_test.go
@@ -1,0 +1,472 @@
+package forgeui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedAgentSkills writes a forge.yaml plus a fixed set of skills under
+// skills/ so the list + load handlers have something to discover. The
+// shape mirrors what `forge init` + `forge skills add` produce in the
+// wild — subdir form with helper scripts and a flat single-file form.
+func seedAgentSkills(t *testing.T) (root string, agentID string) {
+	t.Helper()
+	isolateHome(t)
+	root = t.TempDir()
+	agentID = "edit-test-agent"
+	agentDir := filepath.Join(root, agentID)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(agentDir, "forge.yaml"), `agent_id: edit-test-agent
+version: 0.1.0
+framework: forge
+model:
+  provider: openai
+  name: gpt-4o
+`)
+
+	// Subdir skill with a helper script.
+	subdir := filepath.Join(agentDir, "skills", "foo")
+	if err := os.MkdirAll(filepath.Join(subdir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(subdir, "SKILL.md"), `---
+name: foo
+description: A foo skill
+category: ops
+tags: [foo, search]
+---
+
+# Foo
+
+## Tool: foo_search
+
+Search for foo.
+
+**Input:** query (string)
+**Output:** JSON results
+`)
+	writeFile(t, filepath.Join(subdir, "scripts", "foo_search.sh"), "#!/usr/bin/env bash\necho foo\n")
+
+	// Flat single-file skill (no scripts dir).
+	writeFile(t, filepath.Join(agentDir, "skills", "bar.md"), `---
+name: bar
+description: A flat-form skill
+---
+
+# Bar
+
+## Tool: bar_do
+
+Do bar.
+`)
+
+	// Subdir skill without scripts/ — exercises HasScripts=false.
+	baz := filepath.Join(agentDir, "skills", "baz")
+	if err := os.MkdirAll(baz, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(baz, "SKILL.md"), `---
+name: baz
+description: Subdir but no scripts
+---
+
+# Baz
+
+## Tool: baz_run
+
+Run baz.
+`)
+
+	return root, agentID
+}
+
+func newSkillEditServer(t *testing.T, root string) *UIServer {
+	t.Helper()
+	return NewUIServer(UIServerConfig{
+		Port:      4200,
+		WorkDir:   root,
+		ExePath:   "/usr/bin/false",
+		AgentPort: 9100,
+	})
+}
+
+func TestListCustomSkills_ReturnsAllForms(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+	srv := newSkillEditServer(t, root)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/agents/"+agentID+"/skill-builder/skills", nil)
+	req.SetPathValue("id", agentID)
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderListCustomSkills(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got []CustomSkillSummary
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 skills, got %d: %+v", len(got), got)
+	}
+	byName := map[string]CustomSkillSummary{}
+	for _, s := range got {
+		byName[s.Name] = s
+	}
+
+	foo, ok := byName["foo"]
+	if !ok {
+		t.Fatalf("foo missing; got %+v", got)
+	}
+	if !foo.HasScripts {
+		t.Errorf("foo.HasScripts = false, want true (skills/foo/scripts/ exists)")
+	}
+	if foo.Description != "A foo skill" {
+		t.Errorf("foo.Description = %q", foo.Description)
+	}
+	if len(foo.Tools) != 1 || foo.Tools[0] != "foo_search" {
+		t.Errorf("foo.Tools = %+v, want [foo_search]", foo.Tools)
+	}
+	if foo.Path != filepath.Join("skills", "foo", "SKILL.md") {
+		t.Errorf("foo.Path = %q", foo.Path)
+	}
+
+	bar, ok := byName["bar"]
+	if !ok {
+		t.Fatalf("bar missing")
+	}
+	if bar.HasScripts {
+		t.Errorf("bar.HasScripts = true, want false (flat form has no scripts dir)")
+	}
+	if bar.Path != filepath.Join("skills", "bar.md") {
+		t.Errorf("bar.Path = %q", bar.Path)
+	}
+
+	baz, ok := byName["baz"]
+	if !ok {
+		t.Fatalf("baz missing")
+	}
+	if baz.HasScripts {
+		t.Errorf("baz.HasScripts = true, want false (no scripts/ subdir)")
+	}
+}
+
+func TestListCustomSkills_EmptyAgent(t *testing.T) {
+	isolateHome(t)
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "empty-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(agentDir, "forge.yaml"), `agent_id: empty-agent
+version: 0.1.0
+framework: forge
+model:
+  provider: openai
+  name: gpt-4o
+`)
+
+	srv := newSkillEditServer(t, root)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/agents/empty-agent/skill-builder/skills", nil)
+	req.SetPathValue("id", "empty-agent")
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderListCustomSkills(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got []CustomSkillSummary
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty list, got %+v", got)
+	}
+}
+
+func TestGetCustomSkill_Subdir(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+	srv := newSkillEditServer(t, root)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/agents/"+agentID+"/skill-builder/skills/foo", nil)
+	req.SetPathValue("id", agentID)
+	req.SetPathValue("name", "foo")
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderGetCustomSkill(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got CustomSkillContent
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Format != "subdir" {
+		t.Errorf("Format = %q, want subdir", got.Format)
+	}
+	if !strings.Contains(got.SkillMD, "name: foo") {
+		t.Errorf("SkillMD missing frontmatter; got: %q", got.SkillMD)
+	}
+	if _, ok := got.Scripts["foo_search.sh"]; !ok {
+		t.Errorf("expected foo_search.sh in scripts; got %+v", got.Scripts)
+	}
+}
+
+func TestGetCustomSkill_Flat(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+	srv := newSkillEditServer(t, root)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/agents/"+agentID+"/skill-builder/skills/bar", nil)
+	req.SetPathValue("id", agentID)
+	req.SetPathValue("name", "bar")
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderGetCustomSkill(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got CustomSkillContent
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Format != "flat" {
+		t.Errorf("Format = %q, want flat", got.Format)
+	}
+	if len(got.Scripts) != 0 {
+		t.Errorf("flat form must not return scripts; got %+v", got.Scripts)
+	}
+}
+
+// TestGetCustomSkill_Errors pins the security-sensitive error paths
+// for the load endpoint. The skill name is a path component, so each
+// of these inputs MUST fail before the handler touches the filesystem.
+func TestGetCustomSkill_Errors(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+	srv := newSkillEditServer(t, root)
+
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"missing", "no-such-skill", http.StatusNotFound},
+		{"path-traversal", "..", http.StatusBadRequest},
+		{"slash", "foo/bar", http.StatusBadRequest},
+		{"backslash", `foo\bar`, http.StatusBadRequest},
+		{"non-kebab", "Foo_Bar", http.StatusBadRequest},
+		{"empty", "", http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/agents/"+agentID+"/skill-builder/skills/"+c.raw, nil)
+			req.SetPathValue("id", agentID)
+			req.SetPathValue("name", c.raw)
+			w := httptest.NewRecorder()
+			srv.handleSkillBuilderGetCustomSkill(w, req)
+			if w.Code != c.want {
+				t.Errorf("name=%q: status = %d, want %d; body: %s",
+					c.raw, w.Code, c.want, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestReadCustomSkill_SymlinkEscapeRejected pins the script-loader's
+// symlink guard. A skill directory is trusted, but a symlink INSIDE
+// it that resolves to a file outside the directory (e.g. /etc/passwd
+// or a sibling skill's secret) must not surface in the editor — and
+// from there into the LLM context. The link is silently dropped from
+// the scripts map; the rest of the skill still loads.
+func TestReadCustomSkill_SymlinkEscapeRejected(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+
+	scriptsDir := filepath.Join(root, agentID, "skills", "foo", "scripts")
+	// Create a file OUTSIDE the skill directory.
+	outside := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(outside, []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink inside scripts/ pointing at it.
+	link := filepath.Join(scriptsDir, "leak.sh")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	srv := newSkillEditServer(t, root)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/agents/"+agentID+"/skill-builder/skills/foo", nil)
+	req.SetPathValue("id", agentID)
+	req.SetPathValue("name", "foo")
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderGetCustomSkill(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var got CustomSkillContent
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if _, leaked := got.Scripts["leak.sh"]; leaked {
+		t.Errorf("symlink leak: outside-of-skill file surfaced as a script (content: %q)", got.Scripts["leak.sh"])
+	}
+	// The legitimate sibling script must still be present.
+	if _, ok := got.Scripts["foo_search.sh"]; !ok {
+		t.Errorf("legitimate script foo_search.sh dropped alongside the symlink reject")
+	}
+}
+
+// TestChat_EditMode_PrimesPromptWithExistingSkill captures the
+// system prompt the chat handler sends to the LLM. In edit mode the
+// prompt MUST include the "## Edit Mode" trailer and the on-disk
+// SKILL.md content — the single-source-of-truth invariant means the
+// handler loads from disk itself rather than trusting the request
+// body. Issue #193.
+func TestChat_EditMode_PrimesPromptWithExistingSkill(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+
+	// Tier-1 workspace LLM config so LoadSkillBuilderLLM resolves to
+	// a fully-credentialed config without depending on the dev
+	// machine's HOME or env.
+	wsConfig := filepath.Join(root, ".forge", "ui.yaml")
+	if err := os.MkdirAll(filepath.Dir(wsConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, wsConfig, `skill_builder:
+  provider: openai
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY
+`)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	var captured string
+	srv := NewUIServer(UIServerConfig{
+		Port:      4200,
+		WorkDir:   root,
+		ExePath:   "/usr/bin/false",
+		AgentPort: 9100,
+		LLMStreamFunc: func(_ context.Context, opts LLMStreamOptions) error {
+			captured = opts.SystemPrompt
+			opts.OnDone("ack")
+			return nil
+		},
+	})
+
+	body, _ := json.Marshal(SkillBuilderChatRequest{
+		Mode:        "edit",
+		EditingName: "foo",
+		Messages: []SkillBuilderMessage{
+			{Role: "user", Content: "add a flag to skip the cache"},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/agents/"+agentID+"/skill-builder/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", agentID)
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !strings.Contains(captured, "## Edit Mode") {
+		t.Errorf("system prompt missing '## Edit Mode' trailer; got:\n%s", captured)
+	}
+	if !strings.Contains(captured, "name: foo") {
+		t.Errorf("system prompt missing the on-disk SKILL.md frontmatter; got:\n%s", captured)
+	}
+	if !strings.Contains(captured, "current-script:foo_search.sh") {
+		t.Errorf("system prompt missing the on-disk helper script reference; got:\n%s", captured)
+	}
+}
+
+// TestChat_CreateMode_OmitsEditTrailer pins the inverse: create mode
+// must NEVER ship the edit-mode trailer or any reference to an
+// existing skill. Otherwise an attacker could trick the LLM into
+// scraping a skill's source by sending mode=create with garbage in
+// the request — the handler ignores mode≠"edit" entirely.
+func TestChat_CreateMode_OmitsEditTrailer(t *testing.T) {
+	root, agentID := seedAgentSkills(t)
+
+	wsConfig := filepath.Join(root, ".forge", "ui.yaml")
+	if err := os.MkdirAll(filepath.Dir(wsConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, wsConfig, `skill_builder:
+  provider: openai
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY
+`)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	var captured string
+	srv := NewUIServer(UIServerConfig{
+		Port:      4200,
+		WorkDir:   root,
+		ExePath:   "/usr/bin/false",
+		AgentPort: 9100,
+		LLMStreamFunc: func(_ context.Context, opts LLMStreamOptions) error {
+			captured = opts.SystemPrompt
+			opts.OnDone("ack")
+			return nil
+		},
+	})
+
+	body, _ := json.Marshal(SkillBuilderChatRequest{
+		Messages: []SkillBuilderMessage{
+			{Role: "user", Content: "make me a fresh skill"},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/agents/"+agentID+"/skill-builder/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", agentID)
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderChat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if strings.Contains(captured, "## Edit Mode") {
+		t.Errorf("create-mode prompt leaked the edit trailer:\n%s", captured)
+	}
+	if strings.Contains(captured, "current-skill.md") {
+		t.Errorf("create-mode prompt leaked existing skill content marker")
+	}
+}
+
+// TestSave_OverwriteMismatchedEditingName_Rejected pins the defense
+// in depth: overwrite=true with an editing_name that doesn't match
+// skill_name is rejected at the handler before SkillSaveFunc runs,
+// so a malicious request can never use the edit path to clobber a
+// DIFFERENT skill's directory.
+func TestSave_OverwriteMismatchedEditingName_Rejected(t *testing.T) {
+	srv, _ := setupTestServerWithSkillBuilder(t)
+	body, _ := json.Marshal(SkillBuilderSaveRequest{
+		SkillName:   "victim",
+		EditingName: "attacker",
+		Overwrite:   true,
+		SkillMD:     "---\nname: victim\ndescription: x\n---\n# v\n## Tool: t\nA tool.\n",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/agents/test-agent/skill-builder/save", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", "test-agent")
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderSave(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/forge-ui/server.go
+++ b/forge-ui/server.go
@@ -108,6 +108,12 @@ func (s *UIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /api/agents/{id}/skill-builder/save", s.handleSkillBuilderSave)
 	mux.HandleFunc("GET /api/agents/{id}/skill-builder/context", s.handleSkillBuilderContext)
 	mux.HandleFunc("GET /api/agents/{id}/skill-builder/provider", s.handleSkillBuilderProvider)
+	// Custom-skill listing + loading for the Skill Builder edit flow
+	// (issue #193). Distinct from /api/skills which returns registry /
+	// embedded skills — these endpoints surface only project-local
+	// skills already attached to the agent on disk.
+	mux.HandleFunc("GET /api/agents/{id}/skill-builder/skills", s.handleSkillBuilderListCustomSkills)
+	mux.HandleFunc("GET /api/agents/{id}/skill-builder/skills/{name}", s.handleSkillBuilderGetCustomSkill)
 	// Workspace-level skill-builder settings (issue #92). The
 	// path-less /api/skill-builder/provider lets the UI query the
 	// resolved config before any agent is picked — needed for first-run

--- a/forge-ui/skill_builder_context.go
+++ b/forge-ui/skill_builder_context.go
@@ -1,7 +1,78 @@
 package forgeui
 
-// skillBuilderSystemPrompt is the system prompt for the Forge Skill Designer AI assistant.
-const skillBuilderSystemPrompt = `You are the Forge Skill Designer, an expert assistant that helps users create valid SKILL.md files for Forge agents.
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// skillBuilderMode selects the prompt variant. Create mode is the
+// pre-issue-#193 behavior — author a brand new SKILL.md from scratch.
+// Edit mode primes the LLM with the existing skill's content and
+// guides it to emit minimal patches without renaming tools (issue #193).
+type skillBuilderMode int
+
+const (
+	modeCreate skillBuilderMode = iota
+	modeEdit
+)
+
+// existingSkillContext is the on-disk state of the skill currently
+// being edited. The chat handler loads this itself rather than
+// trusting UI-provided content so a stale or tampered editor state
+// can't feed the LLM the wrong baseline.
+type existingSkillContext struct {
+	Name    string
+	SkillMD string
+	Scripts map[string]string
+}
+
+// skillBuilderSystemPrompt builds the system prompt for the Forge
+// Skill Designer LLM. The base prose (skillBuilderPromptBase) is the
+// pre-issue-#193 contract — both create and edit mode reuse it
+// verbatim so the frontmatter rules, body sections, and example
+// shapes stay in lockstep. Edit mode appends an "## Edit Mode"
+// trailer carrying the existing skill's current SKILL.md + scripts
+// and the iteration rules (preserve tool names, minimal patches,
+// emit a **Changed:** summary).
+func skillBuilderSystemPrompt(mode skillBuilderMode, existing *existingSkillContext) string {
+	if mode != modeEdit || existing == nil {
+		return skillBuilderPromptBase
+	}
+	var b strings.Builder
+	b.WriteString(skillBuilderPromptBase)
+	b.WriteString("\n\n## Edit Mode\n\n")
+	fmt.Fprintf(&b,
+		"You are EDITING the existing skill `%s`. Its current `SKILL.md` and helper scripts are shown below — treat them as the baseline.\n\n",
+		existing.Name)
+	b.WriteString("Rules for edit mode:\n\n")
+	b.WriteString("1. Preserve every `## Tool: <name>` heading exactly as it is now. Renaming a tool is a breaking change for any agent already wired to that tool name — only rename if the user explicitly asks for it.\n")
+	b.WriteString("2. Default to minimal patches. Re-emit the FULL `skill.md` fence so the editor can swap atomically, but call out what changed.\n")
+	b.WriteString("3. After the closing fence, add a `**Changed:**` bullet list summarizing the diff (one line per change).\n")
+	b.WriteString("4. If a helper script needs to be dropped entirely, say so in the **Changed:** list — do NOT re-emit it.\n\n")
+	b.WriteString("Current state of the skill being edited:\n\n")
+	b.WriteString("````current-skill.md\n")
+	b.WriteString(strings.TrimRight(existing.SkillMD, "\n"))
+	b.WriteString("\n````\n")
+	if len(existing.Scripts) > 0 {
+		names := make([]string, 0, len(existing.Scripts))
+		for n := range existing.Scripts {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(&b, "\n````current-script:%s\n", n)
+			b.WriteString(strings.TrimRight(existing.Scripts[n], "\n"))
+			b.WriteString("\n````\n")
+		}
+	}
+	return b.String()
+}
+
+// skillBuilderPromptBase is the pre-issue-#193 system prompt for the
+// Forge Skill Designer AI assistant. Shared between create and edit
+// mode — the edit-mode delta is appended by skillBuilderSystemPrompt.
+const skillBuilderPromptBase = `You are the Forge Skill Designer, an expert assistant that helps users create valid SKILL.md files for Forge agents.
 
 ## Your Role
 

--- a/forge-ui/skill_validator.go
+++ b/forge-ui/skill_validator.go
@@ -18,7 +18,15 @@ var (
 )
 
 // validateSkillMD validates SKILL.md content and optional scripts.
-func validateSkillMD(content string, scripts map[string]string, agentDir string) SkillValidationResult {
+//
+// editingName, when non-empty, suppresses the "already exists" warning
+// for the skill being edited so the operator doesn't see a spurious
+// duplicate-name nag every time they Save in the Skill Builder edit
+// flow (issue #193). A rename (editor name ≠ editingName) still emits
+// the warning because the user IS introducing a new skill with the
+// existing one's name and that's the breaking-change case we want to
+// flag. Pass "" for the create flow.
+func validateSkillMD(content string, scripts map[string]string, agentDir, editingName string) SkillValidationResult {
 	var result SkillValidationResult
 	result.Valid = true
 
@@ -115,8 +123,10 @@ func validateSkillMD(content string, scripts map[string]string, agentDir string)
 		}
 	}
 
-	// Name uniqueness
-	if meta != nil && meta.Name != "" && agentDir != "" {
+	// Name uniqueness. Skipped when editingName matches the
+	// frontmatter name — that's the "saving over the skill currently
+	// being edited" case and the warning would be noise (issue #193).
+	if meta != nil && meta.Name != "" && agentDir != "" && meta.Name != editingName {
 		skillDir := filepath.Join(agentDir, "skills", meta.Name)
 		if _, err := os.Stat(skillDir); err == nil {
 			result.Warnings = append(result.Warnings, ValidationError{

--- a/forge-ui/skill_validator_test.go
+++ b/forge-ui/skill_validator_test.go
@@ -1,6 +1,8 @@
 package forgeui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -33,7 +35,7 @@ A test tool.
 **Output:** JSON results
 `
 
-	result := validateSkillMD(content, nil, "")
+	result := validateSkillMD(content, nil, "", "")
 	if !result.Valid {
 		t.Errorf("expected valid, got errors: %v", result.Errors)
 	}
@@ -47,7 +49,7 @@ func TestValidateSkillMDMissingFrontmatter(t *testing.T) {
 A test tool.
 `
 
-	result := validateSkillMD(content, nil, "")
+	result := validateSkillMD(content, nil, "", "")
 	if result.Valid {
 		t.Error("expected invalid for missing frontmatter")
 	}
@@ -71,7 +73,7 @@ description: A test skill
 # My Skill
 `
 
-	result := validateSkillMD(content, nil, "")
+	result := validateSkillMD(content, nil, "", "")
 	if result.Valid {
 		t.Error("expected invalid for missing name")
 	}
@@ -104,7 +106,7 @@ func TestValidateSkillMDInvalidNameFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			content := "---\nname: " + tt.input + "\ndescription: test\n---\n# Test\n"
-			result := validateSkillMD(content, nil, "")
+			result := validateSkillMD(content, nil, "", "")
 			if tt.wantErr && result.Valid {
 				t.Errorf("expected invalid for name %q", tt.input)
 			}
@@ -123,7 +125,7 @@ name: my-skill
 # My Skill
 `
 
-	result := validateSkillMD(content, nil, "")
+	result := validateSkillMD(content, nil, "", "")
 	if result.Valid {
 		t.Error("expected invalid for missing description")
 	}
@@ -150,7 +152,7 @@ description: A test skill
 Just some text, no tools.
 `
 
-	result := validateSkillMD(content, nil, "")
+	result := validateSkillMD(content, nil, "", "")
 	if !result.Valid {
 		t.Errorf("should be valid (missing tools is warning, not error)")
 	}
@@ -269,7 +271,7 @@ A test tool.
 		"fetch.sh": `curl https://api.example.com/data`,
 	}
 
-	result := validateSkillMD(content, scripts, "")
+	result := validateSkillMD(content, scripts, "", "")
 	if !result.Valid {
 		t.Error("should be valid")
 	}
@@ -282,6 +284,66 @@ A test tool.
 	}
 	if !found {
 		t.Error("expected egress_domains warning for undeclared domain in scripts")
+	}
+}
+
+// TestValidateSkillMD_DuplicateNameSuppression pins the issue #193
+// behavior: in edit mode the duplicate-name warning is suppressed for
+// the skill being edited (every save would otherwise nag), but a
+// rename — frontmatter name ≠ editingName — still emits the warning
+// because the user IS introducing a new skill colliding with an
+// existing directory.
+func TestValidateSkillMD_DuplicateNameSuppression(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "skills", "existing-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `---
+name: existing-skill
+description: An existing skill being edited
+---
+
+# Existing
+
+## Tool: do_thing
+
+A tool.
+`
+
+	// editingName == frontmatter name → warning suppressed.
+	res := validateSkillMD(content, nil, root, "existing-skill")
+	if !res.Valid {
+		t.Fatalf("expected valid, got errors: %v", res.Errors)
+	}
+	for _, w := range res.Warnings {
+		if w.Field == "name" {
+			t.Errorf("expected no name warning in edit-self mode; got: %+v", w)
+		}
+	}
+
+	// editingName == "" (create mode) → warning fires.
+	res = validateSkillMD(content, nil, root, "")
+	foundCreate := false
+	for _, w := range res.Warnings {
+		if w.Field == "name" {
+			foundCreate = true
+		}
+	}
+	if !foundCreate {
+		t.Errorf("expected name warning in create mode for colliding skill name")
+	}
+
+	// editingName != frontmatter name (rename case) → warning fires.
+	res = validateSkillMD(content, nil, root, "different-skill")
+	foundRename := false
+	for _, w := range res.Warnings {
+		if w.Field == "name" {
+			foundRename = true
+		}
+	}
+	if !foundRename {
+		t.Errorf("expected name warning on rename — editing 'different-skill' but content says 'existing-skill'")
 	}
 }
 

--- a/forge-ui/static/app.js
+++ b/forge-ui/static/app.js
@@ -140,11 +140,16 @@ async function fetchSkillBuilderProvider(agentId) {
   return res.json();
 }
 
-async function streamSkillBuilderChat(agentId, messages, { onChunk, onSkillDraft, onError, onDone, signal }) {
+async function streamSkillBuilderChat(agentId, messages, { onChunk, onSkillDraft, onError, onDone, signal, mode, editingName }) {
+  const body = { messages };
+  if (mode === 'edit' && editingName) {
+    body.mode = 'edit';
+    body.editing_name = editingName;
+  }
   const res = await fetch(`/api/agents/${agentId}/skill-builder/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages }),
+    body: JSON.stringify(body),
     signal,
   });
 
@@ -185,19 +190,28 @@ async function streamSkillBuilderChat(agentId, messages, { onChunk, onSkillDraft
   }
 }
 
-async function validateSkillBuilderMD(agentId, skillMD, scripts) {
+async function validateSkillBuilderMD(agentId, skillMD, scripts, { mode, editingName } = {}) {
+  const body = { skill_md: skillMD, scripts };
+  if (mode === 'edit' && editingName) {
+    body.mode = 'edit';
+    body.editing_name = editingName;
+  }
   const res = await fetch(`/api/agents/${agentId}/skill-builder/validate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ skill_md: skillMD, scripts }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`Validation failed: ${res.status}`);
   return res.json();
 }
 
-async function saveSkillBuilder(agentId, skillName, skillMD, scripts, envVars) {
+async function saveSkillBuilder(agentId, skillName, skillMD, scripts, envVars, { overwrite, editingName } = {}) {
   const body = { skill_name: skillName, skill_md: skillMD, scripts };
   if (envVars && Object.keys(envVars).length > 0) body.env_vars = envVars;
+  if (overwrite) {
+    body.overwrite = true;
+    body.editing_name = editingName;
+  }
   const res = await fetch(`/api/agents/${agentId}/skill-builder/save`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -206,6 +220,26 @@ async function saveSkillBuilder(agentId, skillName, skillMD, scripts, envVars) {
   const data = await res.json();
   if (!res.ok) throw new Error(data.error || `Save failed: ${res.status}`);
   return data;
+}
+
+// Lists custom skills attached to the agent on disk (skills/<name>/SKILL.md
+// or skills/<name>.md). Distinct from /api/skills which returns registry/
+// embedded skills available to ADD. Issue #193.
+async function fetchCustomSkills(agentId) {
+  const res = await fetch(`/api/agents/${agentId}/skill-builder/skills`);
+  if (!res.ok) throw new Error(`Failed to list custom skills: ${res.status}`);
+  return res.json();
+}
+
+// Loads a single custom skill's SKILL.md + helper scripts so the Skill
+// Builder can populate the editor for the edit flow. Issue #193.
+async function loadCustomSkill(agentId, name) {
+  const res = await fetch(`/api/agents/${agentId}/skill-builder/skills/${encodeURIComponent(name)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to load skill: ${res.status}`);
+  }
+  return res.json();
 }
 
 // ── SSE Hook ─────────────────────────────────────────────────
@@ -2494,6 +2528,29 @@ function SkillBuilderPage({ agentId }) {
   const [envInputs, setEnvInputs] = useState({});
   const [error, setError] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
+  // Edit-mode state (issue #193).
+  //
+  //   mode             — 'create' or 'edit'. Switches the system prompt
+  //                      sent to the LLM and toggles the diff/save UX.
+  //   editingSkillName — the on-disk name of the skill being edited;
+  //                      preserved across save so the user can keep
+  //                      iterating on the same skill.
+  //   customSkills     — list shown in the skills panel for "Edit"
+  //                      buttons; refetched after every save.
+  //   originalSkillMD/originalScripts — baseline for the diff modal so
+  //                      the diff is always editor-state-vs-disk, not
+  //                      against the previous unsaved edit.
+  //   showDiff         — controls the Monaco diff preview modal.
+  //   restartPending   — controls the "restart to load changes" banner
+  //                      shown after a successful edit-mode save.
+  const [mode, setMode] = useState('create');
+  const [editingSkillName, setEditingSkillName] = useState(null);
+  const [customSkills, setCustomSkills] = useState([]);
+  const [originalSkillMD, setOriginalSkillMD] = useState('');
+  const [originalScripts, setOriginalScripts] = useState({});
+  const [showDiff, setShowDiff] = useState(false);
+  const [restartPending, setRestartPending] = useState(false);
+  const [restarting, setRestarting] = useState(false);
   const abortRef = useRef(null);
   const chatEndRef = useRef(null);
   const editorRef = useRef(null);
@@ -2504,6 +2561,16 @@ function SkillBuilderPage({ agentId }) {
       .then(setProvider)
       .catch(err => setError('Failed to load provider: ' + err.message));
   }, [agentId]);
+
+  // Fetch custom skills attached to the agent for the edit picker
+  // (issue #193). Refetched after every successful save so a newly
+  // created skill appears immediately in the list.
+  const refreshCustomSkills = useCallback(() => {
+    fetchCustomSkills(agentId)
+      .then(setCustomSkills)
+      .catch(() => { /* non-fatal — the picker just stays empty */ });
+  }, [agentId]);
+  useEffect(() => { refreshCustomSkills(); }, [refreshCustomSkills]);
 
   // Auto-scroll chat
   useEffect(() => {
@@ -2583,6 +2650,8 @@ function SkillBuilderPage({ agentId }) {
     try {
       await streamSkillBuilderChat(agentId, newMessages, {
         signal: abort.signal,
+        mode,
+        editingName: editingSkillName,
         onChunk(content) {
           assistantMsg.content += content;
           setMessages([...newMessages, { ...assistantMsg }]);
@@ -2608,16 +2677,19 @@ function SkillBuilderPage({ agentId }) {
       setStreaming(false);
       abortRef.current = null;
     }
-  }, [agentId, messages, input, streaming]);
+  }, [agentId, messages, input, streaming, mode, editingSkillName]);
 
   const handleValidate = useCallback(async () => {
     try {
-      const result = await validateSkillBuilderMD(agentId, skillMD, scripts);
+      const result = await validateSkillBuilderMD(agentId, skillMD, scripts, {
+        mode,
+        editingName: editingSkillName,
+      });
       setValidation(result);
     } catch (err) {
       setError('Validation failed: ' + err.message);
     }
-  }, [agentId, skillMD, scripts]);
+  }, [agentId, skillMD, scripts, mode, editingSkillName]);
 
   const handleSave = useCallback(async () => {
     // Extract name from SKILL.md frontmatter
@@ -2627,18 +2699,109 @@ function SkillBuilderPage({ agentId }) {
       setError('Cannot save: no "name" field found in SKILL.md frontmatter');
       return;
     }
+    // In edit mode the user can rename the skill (frontmatter
+    // name ≠ editing name) — that's a breaking change for any
+    // wired-up agent. We don't block it (the validator surfaces a
+    // warning), but we DON'T overwrite the existing directory under
+    // that case: overwrite is only valid when the names match.
+    const overwrite = mode === 'edit' && editingSkillName && skillName === editingSkillName;
 
     try {
-      // Pass any user-provided env vars
       const envVars = Object.keys(envInputs).length > 0 ? envInputs : undefined;
-      const result = await saveSkillBuilder(agentId, skillName, skillMD, scripts, envVars);
+      const result = await saveSkillBuilder(agentId, skillName, skillMD, scripts, envVars, {
+        overwrite,
+        editingName: editingSkillName,
+      });
       setSaveStatus(result);
       setEnvInputs({});
       setError(null);
+      // After a successful save, baseline = saved state so the
+      // diff resets, and surface the restart prompt for edit-mode
+      // changes (the running agent's tool registry is still
+      // pinned to its startup snapshot until restart).
+      setOriginalSkillMD(skillMD);
+      setOriginalScripts({ ...scripts });
+      if (mode === 'edit') {
+        setRestartPending(true);
+      } else {
+        // After a create, switch into edit mode for this skill so
+        // the next iteration uses the edit-mode prompt.
+        setMode('edit');
+        setEditingSkillName(skillName);
+      }
+      refreshCustomSkills();
     } catch (err) {
       setError('Save failed: ' + err.message);
     }
-  }, [agentId, skillMD, scripts, envInputs]);
+  }, [agentId, skillMD, scripts, envInputs, mode, editingSkillName, refreshCustomSkills]);
+
+  // handleEdit loads a custom skill from disk and primes the builder
+  // for iteration. Edit mode is what makes the LLM use the
+  // "## Edit Mode" prompt trailer and what flips the save path to
+  // overwrite-in-place. Issue #193.
+  const handleEdit = useCallback(async (name) => {
+    try {
+      const content = await loadCustomSkill(agentId, name);
+      setSkillMD(content.skill_md || '');
+      setScripts(content.scripts || {});
+      setOriginalSkillMD(content.skill_md || '');
+      setOriginalScripts(content.scripts || {});
+      setMode('edit');
+      setEditingSkillName(name);
+      setActiveTab('skill.md');
+      setValidation(null);
+      setSaveStatus(null);
+      setError(null);
+      setRestartPending(false);
+      setMessages([{
+        role: 'assistant',
+        content: `Loaded skill **${name}** for editing. The current SKILL.md and scripts are in the editor. Describe what you want to change.`,
+      }]);
+    } catch (err) {
+      setError('Failed to load skill: ' + err.message);
+    }
+  }, [agentId]);
+
+  // handleNewSkill resets state for a fresh create-mode session.
+  // Used by the "New skill" button alongside the custom-skills list.
+  const handleNewSkill = useCallback(() => {
+    setMode('create');
+    setEditingSkillName(null);
+    setSkillMD('');
+    setScripts({});
+    setOriginalSkillMD('');
+    setOriginalScripts({});
+    setMessages([]);
+    setValidation(null);
+    setSaveStatus(null);
+    setError(null);
+    setRestartPending(false);
+    setActiveTab('skill.md');
+  }, []);
+
+  // handleRestart triggers a stop + start on the agent process so
+  // the runtime re-runs registerSkillTools and picks up the edited
+  // SKILL.md / scripts. The dashboard already exposes these as
+  // separate endpoints — see server.go:78-79. We do NOT silently
+  // restart on save: the operator may be mid-task in a live chat
+  // and an unsolicited restart would lose context.
+  const handleRestart = useCallback(async () => {
+    setRestarting(true);
+    try {
+      await fetch(`/api/agents/${agentId}/stop`, { method: 'POST' });
+      // Small delay so the SSE state machine drains the stop event
+      // before we issue start — otherwise the dashboard's status
+      // chip flickers from running → stopped → starting → running
+      // in a way that looks broken.
+      await new Promise(r => setTimeout(r, 500));
+      await fetch(`/api/agents/${agentId}/start`, { method: 'POST' });
+      setRestartPending(false);
+    } catch (err) {
+      setError('Restart failed: ' + err.message);
+    } finally {
+      setRestarting(false);
+    }
+  }, [agentId]);
 
   const handleKeyDown = useCallback((e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -2668,10 +2831,48 @@ function SkillBuilderPage({ agentId }) {
             </div>
           `}
           ${showSettings && html`<${SkillBuilderSettingsModal} initial=${provider} onClose=${() => setShowSettings(false)} onSaved=${(updated) => { setProvider(updated); setShowSettings(false); }} />`}
+
+          ${mode === 'edit' && editingSkillName && html`
+            <div class="sb-mode-banner">
+              <span class="sb-mode-label">Editing</span>
+              <code>${editingSkillName}</code>
+              <button class="btn btn-link btn-sm" onClick=${handleNewSkill}>New skill</button>
+            </div>
+          `}
+
+          ${(customSkills.length > 0 || mode === 'edit') && html`
+            <details class="sb-custom-skills" open=${mode === 'create'}>
+              <summary>Skills attached to this agent (${customSkills.length})</summary>
+              ${customSkills.length === 0 && html`
+                <div class="sb-custom-skills-empty">No custom skills yet — create one below, or attach skills from the registry via the Skills tab.</div>
+              `}
+              ${customSkills.map(s => html`
+                <div key=${s.path} class="sb-custom-skill-row">
+                  <div class="sb-custom-skill-info">
+                    <div class="sb-custom-skill-name">
+                      <code>${s.name}</code>
+                      ${editingSkillName === s.name && html`<span class="sb-pill sb-pill-active">editing</span>`}
+                    </div>
+                    <div class="sb-custom-skill-desc">${s.description || 'No description'}</div>
+                  </div>
+                  <button class="btn btn-ghost btn-sm"
+                    onClick=${() => handleEdit(s.name)}
+                    disabled=${streaming || editingSkillName === s.name}>
+                    Edit
+                  </button>
+                </div>
+              `)}
+              ${mode === 'edit' && html`
+                <div class="sb-custom-skills-footer">
+                  <button class="btn btn-link btn-sm" onClick=${handleNewSkill}>+ New skill</button>
+                </div>
+              `}
+            </details>
+          `}
         </div>
 
         <div class="sb-messages">
-          ${messages.length === 0 && html`
+          ${messages.length === 0 && mode === 'create' && html`
             <div class="sb-empty">
               <div class="sb-empty-title">Design a new skill</div>
               <div class="sb-empty-text">Describe the skill you want to create. The AI will generate a valid SKILL.md file.</div>
@@ -2804,6 +3005,18 @@ function SkillBuilderPage({ agentId }) {
             </div>
           `}
 
+          ${restartPending && html`
+            <div class="sb-restart-banner">
+              <div>Skill saved. Restart the agent to load changes.</div>
+              <div class="sb-restart-actions">
+                <button class="btn btn-ghost btn-sm" onClick=${() => setRestartPending(false)} disabled=${restarting}>Later</button>
+                <button class="btn btn-primary btn-sm" onClick=${handleRestart} disabled=${restarting}>
+                  ${restarting ? 'Restarting…' : 'Restart agent'}
+                </button>
+              </div>
+            </div>
+          `}
+
           <div class="sb-action-buttons">
             <button class="btn btn-ghost btn-sm" onClick=${handleValidate} disabled=${!skillMD}>
               Revalidate
@@ -2811,13 +3024,128 @@ function SkillBuilderPage({ agentId }) {
             <button class="btn btn-ghost btn-sm" onClick=${() => { if (skillMD) { navigator.clipboard.writeText(skillMD); } }}>
               Copy
             </button>
+            ${mode === 'edit' && html`
+              <button class="btn btn-ghost btn-sm" onClick=${() => setShowDiff(true)} disabled=${!skillMD}>
+                Preview changes
+              </button>
+            `}
             <button class="btn btn-primary btn-sm" onClick=${handleSave} disabled=${!skillMD}>
-              Save & Attach
+              ${mode === 'edit' ? 'Save changes' : 'Save & Attach'}
             </button>
           </div>
         </div>
       </div>
+      ${showDiff && html`
+        <${SkillDiffModal}
+          originalSkillMD=${originalSkillMD}
+          newSkillMD=${skillMD}
+          originalScripts=${originalScripts}
+          newScripts=${scripts}
+          onClose=${() => setShowDiff(false)}
+          onConfirm=${() => { setShowDiff(false); handleSave(); }}
+        />
+      `}
     </main>
+  `;
+}
+
+// SkillDiffModal renders a Monaco side-by-side diff per artifact —
+// SKILL.md plus every script that appears in either the on-disk or
+// editor state. The diff is editor-state-vs-disk (issue #193): the
+// originalSkillMD baseline is what was loaded at handleEdit time and
+// is updated by each successful save so iteration always diffs from
+// the most recent persisted state, not from initial load.
+function SkillDiffModal({ originalSkillMD, newSkillMD, originalScripts, newScripts, onClose, onConfirm }) {
+  const orig = originalScripts || {};
+  const next = newScripts || {};
+  const scriptNames = Array.from(new Set([...Object.keys(orig), ...Object.keys(next)])).sort();
+  const tabs = ['skill.md', ...scriptNames];
+  const [activeTab, setActiveTab] = useState('skill.md');
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+
+  // Mount + reuse a single Monaco diff editor across tabs; just swap
+  // the model on tab-change. Avoids the cost of recreating the diff
+  // engine per tab, which matters for skills with many scripts.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const container = containerRef.current;
+    let cancelled = false;
+    const setup = async () => {
+      try {
+        const monaco = await import('/monaco/editor.js');
+        if (cancelled) return;
+        if (!editorRef.current) {
+          editorRef.current = monaco.editor.createDiffEditor(container, {
+            theme: 'vs-dark',
+            automaticLayout: true,
+            readOnly: true,
+            renderSideBySide: true,
+            minimap: { enabled: false },
+            fontSize: 13,
+          });
+        }
+        const language = activeTab === 'skill.md' ? 'markdown' : 'shell';
+        const baseline = activeTab === 'skill.md' ? (originalSkillMD || '') : (orig[activeTab] || '');
+        const draft = activeTab === 'skill.md' ? (newSkillMD || '') : (next[activeTab] || '');
+        editorRef.current.setModel({
+          original: monaco.editor.createModel(baseline, language),
+          modified: monaco.editor.createModel(draft, language),
+        });
+      } catch (err) {
+        console.error('Failed to mount Monaco diff editor:', err);
+      }
+    };
+    setup();
+    return () => {
+      cancelled = true;
+      if (editorRef.current) {
+        const model = editorRef.current.getModel();
+        if (model) {
+          model.original.dispose();
+          model.modified.dispose();
+        }
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, originalSkillMD, newSkillMD]);
+
+  // Tear down the diff editor on unmount so the next open is a
+  // fresh mount — the model swap above handles tab changes but
+  // leaving the editor instance behind across modal opens leaks
+  // Monaco textures.
+  useEffect(() => () => {
+    if (editorRef.current) {
+      editorRef.current.dispose();
+      editorRef.current = null;
+    }
+  }, []);
+
+  return html`
+    <div class="modal-backdrop sb-diff-backdrop" onClick=${onClose}>
+      <div class="modal sb-diff-modal" onClick=${(e) => e.stopPropagation()}>
+        <div class="modal-header">
+          <h3>Preview changes</h3>
+          <button class="modal-close" onClick=${onClose}>×</button>
+        </div>
+        <div class="sb-diff-tabs">
+          ${tabs.map(name => html`
+            <button key=${name}
+              class="sb-tab ${activeTab === name ? 'sb-tab-active' : ''}"
+              onClick=${() => setActiveTab(name)}>
+              ${name}
+              ${name !== 'skill.md' && !(name in orig) && html`<span class="sb-pill sb-pill-new">new</span>`}
+              ${name !== 'skill.md' && !(name in next) && html`<span class="sb-pill sb-pill-gone">removed</span>`}
+            </button>
+          `)}
+        </div>
+        <div class="sb-diff-body" ref=${containerRef} />
+        <div class="modal-footer">
+          <button class="btn btn-ghost" onClick=${onClose}>Cancel</button>
+          <button class="btn btn-primary" onClick=${onConfirm}>Confirm save</button>
+        </div>
+      </div>
+    </div>
   `;
 }
 

--- a/forge-ui/static/style.css
+++ b/forge-ui/static/style.css
@@ -1799,6 +1799,7 @@ body {
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-color);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 16px;
 }
@@ -2136,4 +2137,142 @@ body {
     border-right: none;
     border-bottom: 1px solid var(--border-color);
   }
+}
+
+/* Skill Builder edit-mode UI (issue #193) */
+
+.sb-mode-banner {
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  padding: 6px 10px;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: var(--radius);
+}
+
+.sb-mode-label {
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 10px;
+}
+
+.sb-custom-skills {
+  flex-basis: 100%;
+  font-size: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+}
+
+.sb-custom-skills summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 4px 0;
+}
+
+.sb-custom-skills-empty {
+  color: var(--text-muted);
+  padding: 6px 0;
+}
+
+.sb-custom-skill-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-top: 1px solid var(--border-color);
+}
+
+.sb-custom-skill-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.sb-custom-skill-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.sb-custom-skill-desc {
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sb-custom-skills-footer {
+  padding-top: 6px;
+  border-top: 1px solid var(--border-color);
+}
+
+.sb-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sb-pill-active {
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--blue, #3b82f6);
+}
+
+.sb-pill-new {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--green);
+}
+
+.sb-pill-gone {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+}
+
+.sb-restart-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  padding: 8px 10px;
+  background: rgba(245, 158, 11, 0.10);
+  border: 1px solid rgba(245, 158, 11, 0.30);
+  border-radius: var(--radius);
+}
+
+.sb-restart-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.sb-diff-backdrop {
+  z-index: 100;
+}
+
+.sb-diff-modal {
+  width: min(90vw, 1400px);
+  height: min(85vh, 900px);
+  display: flex;
+  flex-direction: column;
+}
+
+.sb-diff-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sb-diff-body {
+  flex: 1;
+  min-height: 0;
 }

--- a/forge-ui/types.go
+++ b/forge-ui/types.go
@@ -114,12 +114,22 @@ type LLMStreamOptions struct {
 type LLMStreamFunc func(ctx context.Context, opts LLMStreamOptions) error
 
 // SkillSaveOptions configures saving a skill to an agent's skills directory.
+//
+// Overwrite=true with EditingName matching SkillName is the edit-mode
+// path (issue #193). The forge-cli implementation MUST honor this: on
+// overwrite it should remove the existing scripts/ directory before
+// writing the new script set, so scripts dropped during the edit don't
+// linger. Overwrite without an EditingName match — i.e. trying to
+// overwrite a different skill — is rejected by the handler before the
+// SkillSaveFunc is called.
 type SkillSaveOptions struct {
-	AgentDir  string
-	SkillName string
-	SkillMD   string
-	Scripts   map[string]string
-	EnvVars   map[string]string // env vars to write to .env
+	AgentDir    string
+	SkillName   string
+	SkillMD     string
+	Scripts     map[string]string
+	EnvVars     map[string]string // env vars to write to .env
+	Overwrite   bool
+	EditingName string
 }
 
 // SkillSaveResult holds the result of saving a skill, including env/egress changes.
@@ -141,22 +151,75 @@ type SkillEnvEntry struct {
 type SkillSaveFunc func(opts SkillSaveOptions) (*SkillSaveResult, error)
 
 // SkillBuilderChatRequest is the POST body for the skill builder chat endpoint.
+//
+// Mode selects between "create" (default) and "edit". In edit mode the
+// handler loads the skill named by EditingName from disk and primes the
+// system prompt with its current SKILL.md + scripts so the LLM is grounded
+// on the existing state. See issue #193.
 type SkillBuilderChatRequest struct {
-	Messages []SkillBuilderMessage `json:"messages"`
+	Messages    []SkillBuilderMessage `json:"messages"`
+	Mode        string                `json:"mode,omitempty"`
+	EditingName string                `json:"editing_name,omitempty"`
 }
 
 // SkillBuilderValidateRequest is the POST body for skill validation.
+//
+// When Mode == "edit" and EditingName matches the skill name in the
+// frontmatter, the "already exists" warning is suppressed — the
+// skill IS the one being edited. A rename (EditingName != frontmatter
+// name) still surfaces the warning so the user sees the breaking-change
+// risk.
 type SkillBuilderValidateRequest struct {
-	SkillMD string            `json:"skill_md"`
-	Scripts map[string]string `json:"scripts,omitempty"`
+	SkillMD     string            `json:"skill_md"`
+	Scripts     map[string]string `json:"scripts,omitempty"`
+	Mode        string            `json:"mode,omitempty"`
+	EditingName string            `json:"editing_name,omitempty"`
 }
 
 // SkillBuilderSaveRequest is the POST body for saving a skill.
+//
+// Overwrite=true with EditingName matching SkillName allows rewriting the
+// existing skill directory in place (issue #193 — edit-mode iteration).
+// Stale scripts in the existing scripts/ dir are removed before the new
+// set is written so dropped scripts don't linger. Overwriting any OTHER
+// skill's directory is denied as defense in depth.
 type SkillBuilderSaveRequest struct {
-	SkillName string            `json:"skill_name"`
-	SkillMD   string            `json:"skill_md"`
-	Scripts   map[string]string `json:"scripts,omitempty"`
-	EnvVars   map[string]string `json:"env_vars,omitempty"`
+	SkillName   string            `json:"skill_name"`
+	SkillMD     string            `json:"skill_md"`
+	Scripts     map[string]string `json:"scripts,omitempty"`
+	EnvVars     map[string]string `json:"env_vars,omitempty"`
+	Overwrite   bool              `json:"overwrite,omitempty"`
+	EditingName string            `json:"editing_name,omitempty"`
+}
+
+// CustomSkillSummary describes one project-local skill discovered under
+// the agent's skills/ directory (issue #193). Distinct from
+// SkillBrowserEntry, which describes registry/embedded skills the user
+// can add to a new agent — this type only covers skills already attached
+// to the agent on disk.
+type CustomSkillSummary struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Category    string   `json:"category,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Path        string   `json:"path"`
+	HasScripts  bool     `json:"has_scripts"`
+	Tools       []string `json:"tools,omitempty"`
+}
+
+// CustomSkillContent is the full payload for one custom skill — its
+// SKILL.md body plus any helper scripts under skills/<name>/scripts/.
+// Used by the Skill Builder edit flow to populate the editor (issue #193).
+//
+// Format is "subdir" when the skill lives at skills/<name>/SKILL.md (the
+// common case, where helper scripts live next to it), or "flat" when it's
+// a single-file skills/<name>.md (no scripts directory).
+type CustomSkillContent struct {
+	Name    string            `json:"name"`
+	SkillMD string            `json:"skill_md"`
+	Scripts map[string]string `json:"scripts,omitempty"`
+	Path    string            `json:"path"`
+	Format  string            `json:"format"`
 }
 
 // SkillValidationResult holds the result of validating a SKILL.md.


### PR DESCRIPTION
## Summary

- Adds an **Edit existing skill** flow to the dashboard's Skill Builder so the developer can iterate on an already-attached skill without delete-and-recreate or hand-editing on disk.
- New backend endpoints list and load project-local custom skills; chat / validate / save accept edit-mode flags so the LLM is primed with the on-disk SKILL.md, the duplicate-name warning is suppressed, and the existing skill directory is overwritten in place (with stale scripts cleared).
- A Monaco side-by-side diff modal previews editor-state vs disk before save; a **Restart agent** banner picks up the changes in the running runtime, whose tool registry is captured at startup.

## Why

Real-world skill bugs (wrong input schema, undeclared egress, brittle error handling) only surface once the LLM actually calls the tool inside the agent loop. The previous create-only flow forced the developer to either lose their builder chat context every iteration or bypass the guided authoring surface entirely. Closes #193.

## Endpoints

| Method | Path | Notes |
|---|---|---|
| `GET` | `/api/agents/{id}/skill-builder/skills` | `[]CustomSkillSummary` — name, description, category, tags, path, has_scripts, tools |
| `GET` | `/api/agents/{id}/skill-builder/skills/{name}` | `CustomSkillContent` — skill_md + scripts map. Rejects path-traversal / non-kebab-case names with 400; symlinks escaping the skill directory are silently dropped. |
| `POST` | `/api/agents/{id}/skill-builder/chat` | Existing endpoint, now accepts `mode: \"edit\"` + `editing_name`. Server reloads on-disk content itself (single source of truth) and appends an `## Edit Mode` trailer to the system prompt. |
| `POST` | `/api/agents/{id}/skill-builder/validate` | Existing endpoint, now accepts `mode` + `editing_name` to suppress the duplicate-name warning for the skill being edited. |
| `POST` | `/api/agents/{id}/skill-builder/save` | Existing endpoint, now accepts `overwrite: true` + `editing_name`. Mismatched names are rejected at the handler boundary; the writer mirrors the guard and additionally wipes `scripts/` before re-writing so dropped scripts disappear from disk. |

## Safety

- `validateSkillNameForPath` is shared across save / load / edit-chat — one regex + traversal guard, three entry points.
- `Overwrite=true` with `EditingName != SkillName` is rejected by both the handler and the writer.
- The script loader rejects symlinks whose resolved target escapes the skill's directory so a malicious link to `/etc/passwd` never reaches the editor or the LLM context.
- Edit mode always loads the SKILL.md baseline from disk on the server, never from the request body — a stale or tampered editor state can't feed the LLM the wrong context.

## Out of scope (deferred follow-ups)

- Live in-process tool-registry hot-swap. Would extend `forge-cli/runtime/watcher.go` to include `.md` and have the callback diff old vs new skill set, calling `registry.Remove` + `registry.Register` accordingly. Needs a concurrency review of registry mutation under in-flight tool calls. The dashboard's restart prompt is the safe default until that lands.
- Editing builtin / embedded registry skills (filesystem-only edits in this PR).
- Multi-user collaborative editing (no file locking, no presence).
- Renaming a skill in-place (changing `name:` writes a NEW skill directory; the old directory is left as-is. The validator surfaces a warning so the operator sees the breaking-change risk.)

## Test plan

- [x] `go test ./... -count=1` in `forge-ui/` and `forge-cli/`
- [x] `golangci-lint run` against all four Go modules — 0 issues
- [x] `gofmt -w` across all four modules
- [x] New unit tests pin: list across subdir + flat + scripts forms, load 400 / 404 paths, symlink escape rejected, edit-mode chat primes prompt with on-disk content, create-mode prompt omits edit trailer, save rejects mismatched editing_name, validator suppression behavior, writer drops stale scripts on overwrite, writer refuses to wipe scripts under name mismatch.
- [ ] Manual smoke: open Skill Builder for an agent with one custom skill → list shows it → Edit → editor populated → chat about a change → Preview changes → Confirm save → list still has one entry → Restart agent → New skill resets to create flow.