### PR TITLE
feat(audit): operator surface + consolidated redact for FWS-8 payload capture (closes #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@
 
 ### Added
 
+- **Audit payload capture: operator surface + consolidated redact pass
+  (issue #163).** FWS-8 raw-payload capture (`AuditPayloadCapture`) is
+  now configurable from `forge.yaml` and `FORGE_AUDIT_CAPTURE_*` env
+  vars in addition to the existing programmatic `RunnerConfig` path —
+  closing the gap that previously made the feature unusable from a
+  container deployment without a code change. Capture stays off by
+  default; flipping any flag on emits raw `args`, `result`,
+  `prompt_messages`, or `completion_text` fields on the corresponding
+  `tool_exec` / `llm_call` events.
+  - New env vars: `FORGE_AUDIT_CAPTURE_TOOL_ARGS`,
+    `FORGE_AUDIT_CAPTURE_TOOL_RESULT`,
+    `FORGE_AUDIT_CAPTURE_LLM_MESSAGES`,
+    `FORGE_AUDIT_CAPTURE_LLM_RESPONSE`,
+    `FORGE_AUDIT_CAPTURE_REDACT` (default `true`),
+    `FORGE_AUDIT_CAPTURE_MAX_BYTES` (single-knob 16 KiB default).
+  - New `forge.yaml` block under `audit.capture:` with per-field
+    `*bool` semantics (nil = fall through to env). Precedence:
+    `forge.yaml` > env > default.
+  - New `Redact` field on `coreruntime.AuditPayloadCapture`. ON by
+    default. When on, captured fields run through the shared
+    vendor-secret regex scrub (`PrepareCapturedContent`) BEFORE
+    truncation so a token an LLM glued into a `cli_execute` command
+    surfaces in audit as `[REDACTED]`, not verbatim. Set `false` only
+    when a downstream sink runs its own scrubber.
+  - New shared helper `coreruntime.PrepareCapturedContent(s, redact,
+    maxBytes)`. The FWS-8 capture hooks (`registerAuditHooks`),
+    guardrail evidence pipeline (`prepareEvidence`), and OTel span
+    content pipeline (`PrepareSpanContent`) now ALL delegate to this
+    one helper so a fix to the regex set propagates to every
+    content-capture path. Removes 3 independent copies of the
+    vendor-secret regex set.
+  - Pinned by `TestAuditPayloadCaptureFromEnv_{Defaults,FlagsParsed,
+    RedactEscapeHatch,MaxBytesIsSingleKnob,MaxBytesIgnoresInvalid,
+    RejectsZeroAndNegativeMaxBytes}`,
+    `TestPrepareCapturedContent_{RedactScrubsVendorTokens,
+    NoRedactKeepsSecretsVerbatim,TruncatesAtCap,RedactBeforeTruncate,
+    EmptyFastPath,DefaultCap}`,
+    `TestPrepareSpanContent_StillDelegatesAndUsesItsOwnDefault`,
+    `TestResolveAuditPayloadCapture_{EnvOnly,YAMLWinsOverEnv,
+    YAMLNilDoesNotClobberEnv,MaxBytesUniform,AllSurfacesOff}`,
+    `TestRegisterAuditHooks_{DefaultPostureOmitsCaptureFields,
+    CaptureToolArgs_OnlyStartEventCarries,CaptureRedactsVendorTokens,
+    CaptureRedactFalseLeavesSecretsVerbatim,
+    CaptureToolResult_Truncates}`.
+
 - **Skill Builder edit mode (issue #193).** The dashboard's Skill Builder
   can now iterate on an already-attached custom skill instead of only
   creating new ones. A new **Skills attached to this agent** panel lists

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -555,16 +555,59 @@ the baseline contract every operator can rely on regardless of
 configuration.
 
 Customers who need raw payloads in audit (debugging incidents,
-supervised-learning corpora, compliance replay) opt in field by field
-via `AuditPayloadCapture` on the runner config:
+supervised-learning corpora, compliance replay) opt in field by field.
+Operators configure capture via `forge.yaml`, env vars, or programmatic
+runner config; the three layers stack with the following precedence:
+
+| Layer | Knob | Wins over |
+|---|---|---|
+| `forge.yaml` `audit.capture` | per-field `*bool`, `max_bytes` | env + default |
+| `FORGE_AUDIT_CAPTURE_*` env | per-field bool, `MAX_BYTES` | default |
+| Built-in default | all flags off, `Redact=true` | — |
+
+### `forge.yaml` block
+
+```yaml
+audit:
+  capture:
+    tool_args: true         # capture raw tool input on tool_exec start
+    tool_result: true       # capture raw tool output on tool_exec end
+    llm_messages: false     # capture chat messages on llm_call
+    llm_response: false     # capture completion text on llm_call
+    redact: true            # scrub vendor-secret token shapes (ON by default)
+    max_bytes: 16384        # per-field byte cap (16 KiB default)
+```
+
+Every flag in the block is optional. An omitted field falls through to
+the env layer; an explicit `false` overrides env. The default-deploy
+case (no block at all) is metadata-only auditing — byte-for-byte
+identical to pre-#163 output.
+
+### Env vars
+
+| Env var | Type | Default | Meaning |
+|---|---|---|---|
+| `FORGE_AUDIT_CAPTURE_TOOL_ARGS` | bool | `false` | Capture raw tool input on `tool_exec phase=start` |
+| `FORGE_AUDIT_CAPTURE_TOOL_RESULT` | bool | `false` | Capture raw tool output on `tool_exec phase=end` |
+| `FORGE_AUDIT_CAPTURE_LLM_MESSAGES` | bool | `false` | Capture chat-messages array on `llm_call` |
+| `FORGE_AUDIT_CAPTURE_LLM_RESPONSE` | bool | `false` | Capture completion text on `llm_call` |
+| `FORGE_AUDIT_CAPTURE_REDACT` | bool | `true` | Vendor-secret regex scrub before emission |
+| `FORGE_AUDIT_CAPTURE_MAX_BYTES` | int | `16384` | Single-knob per-field byte cap |
+
+`MAX_BYTES` is a single knob: when set it applies uniformly across all
+four `CapXxxBytes` fields. Operators who need divergent per-field caps
+embed Forge as a library and set `AuditPayloadCapture` programmatically.
+
+### Programmatic (library) config
 
 ```go
 RunnerConfig{
   AuditPayloadCapture: coreruntime.AuditPayloadCapture{
-    LLMMessages: true,             // prompt messages in llm_call
-    LLMResponse: true,             // completion text in llm_call
-    ToolArgs:    true,             // raw tool input in tool_exec
-    ToolResult:  true,             // raw tool output in tool_exec
+    LLMMessages: true,
+    LLMResponse: true,
+    ToolArgs:    true,
+    ToolResult:  true,
+    Redact:      true,
     // Per-field byte caps; 0 = use DefaultPayloadCaptureCapBytes (16 KiB)
     CapLLMMessagesBytes: 32 << 10,
     CapToolResultBytes:  64 << 10,
@@ -572,17 +615,75 @@ RunnerConfig{
 }
 ```
 
-Captured strings are truncated to a per-field byte cap (default 16 KiB)
-with a `…[truncated:N]` marker so a runaway prompt or gigabyte tool
-output can't bloat one audit event. The cap is enforced by
-`coreruntime.TruncateForAudit`.
+### What gets scrubbed
 
-**Security note.** Once any capture flag is enabled, the audit
-transport (FWS-7 sink or stderr safety net) lands captured payloads
-verbatim — including any PII or secret that flowed through the prompt
-or completion. Operators are responsible for routing the audit stream
-to a store appropriate to the captured payloads' sensitivity. Forge
-does not redact captured content.
+When `redact: true` (the default), captured fields run through
+`coreruntime.PrepareCapturedContent` which scrubs known vendor token
+shapes before truncation. The same regex set protects OTel span
+content (#130) and guardrail evidence (#155 / #156) — fix once,
+flow everywhere. Current shapes:
+
+| Shape | Pattern (illustrative) | Replacement |
+|---|---|---|
+| Anthropic API key | `sk-ant-…` | `[REDACTED]` |
+| OpenAI API key | `sk-…` (20+ chars) | `[REDACTED]` |
+| GitHub PAT / OAuth / server / fine-grained | `ghp_…` `gho_…` `ghs_…` `github_pat_…` | `[REDACTED]` |
+| AWS access key | `AKIA…` | `[REDACTED]` |
+| Slack bot / user tokens | `xoxb-…` `xoxp-…` | `[REDACTED]` |
+| Private-key PEM block | `-----BEGIN … KEY-----…-----END … KEY-----` | `[REDACTED]` |
+| Telegram bot token | `<digits>:…` | `[REDACTED]` |
+
+Redact runs BEFORE truncation so the truncation cut cannot split a
+`[REDACTED]` marker mid-string.
+
+Disable redact (`redact: false` / `FORGE_AUDIT_CAPTURE_REDACT=false`)
+ONLY when a downstream sink runs its own scrubber — typically a
+platform-side SIEM normalizer or a sidecar that mutates events before
+storage.
+
+Captured strings are truncated to the configured per-field byte cap
+with a `…[truncated:N]` marker so a runaway prompt or gigabyte tool
+output can't bloat one audit event.
+
+### Verbosity guidance
+
+Capture is expensive. The same agent that emits ~1 MB / day of
+metadata-only audit can emit 25–80 MB / day with both `tool_args` and
+`tool_result` on — a 25–80× factor depending on payload size.
+
+| Posture | Per `tool_exec` event |
+|---|---|
+| Default (metadata only) | ~150–300 bytes |
+| `tool_args` + `tool_result` on | up to ~32 KiB (capped) |
+| Realistic average for a tool-heavy agent | 5–15 KiB |
+
+For a tool-heavy agent doing 1000 invocations/day with 5 tool calls each:
+
+- Metadata-only: ~1 MB/day
+- Both captures on: 25–80 MB/day
+
+Recommended usage patterns:
+
+- **Debug a misbehaving tool**: turn `tool_args + tool_result` on for
+  the affected session only, then turn off. Don't ship it as
+  always-on.
+- **Compliance evidence**: `tool_args` is usually enough (the inputs
+  the agent produced); `tool_result` is rarely needed and is the
+  largest of the four captures.
+- **Long-running production**: leave default off unless a specific
+  audit need surfaces. The size-only metadata (`args_size`,
+  `result_size`, `prompt_messages_count`) is still emitted, so
+  observability dashboards keep working without capture.
+
+### Security note
+
+Even with `redact: true`, a captured payload may carry PII, customer
+data, or secrets the regex set doesn't recognize. The transport (FWS-7
+sink or the stderr safety net) lands captured payloads verbatim.
+Operators are responsible for routing the audit stream to a store
+appropriate to the captured payloads' sensitivity. `redact: false`
+means the regex set is bypassed entirely; reach for it only when a
+downstream scrubber is known to run.
 
 ### What each flag turns on
 
@@ -604,6 +705,8 @@ configuration so consumers can size-check even without raw bodies.
   (complexity around key management, rotation, and customer-side
   verification). Sequence numbers cover gap detection in the
   meantime. Tracked as a follow-up.
-- **Per-agent capture flags in `forge.yaml`.** Capture is set via
+- ~~**Per-agent capture flags in `forge.yaml`.** Capture is set via
   `RunnerConfig` programmatically today. A YAML surface can be added
-  if customers ask; the runtime semantics are already in place.
+  if customers ask; the runtime semantics are already in place.~~
+  *Shipped in issue #163 — see [Payload capture](#payload-capture-fws-8)
+  above for the `forge.yaml` + env-var operator surface.*

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -167,6 +167,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 		auditExport.WriteTimeout = runAuditWriteTimeout
 	}
 
+	// Resolve audit payload-capture config (issue #163). Start with
+	// env-derived defaults (FORGE_AUDIT_CAPTURE_*, Redact=true) and
+	// layer the forge.yaml `audit.capture` block on top — yaml wins
+	// over env, env wins over the safe default. Empty after the merge
+	// means metadata-only (the pre-#163 behavior).
+	auditCapture := runtime.ResolveAuditPayloadCapture(
+		coreruntime.AuditPayloadCaptureFromEnv(),
+		cfg.Audit.Capture,
+	)
+
 	// FWS-10 — assemble the CLI-side rate-limit override. Only
 	// explicitly-set flags propagate; everything else stays nil so
 	// the resolver falls through to env → yaml → defaults.
@@ -179,27 +189,28 @@ func runRun(cmd *cobra.Command, args []string) error {
 	tracingFlags := buildTracingFlags(cmd)
 
 	runner, err := runtime.NewRunner(runtime.RunnerConfig{
-		Config:            cfg,
-		WorkDir:           workDir,
-		Port:              runPort,
-		Host:              runHost,
-		ShutdownTimeout:   runShutdownTimeout,
-		MockTools:         runMockTools,
-		EnforceGuardrails: enforceGuardrails,
-		ModelOverride:     runModel,
-		ProviderOverride:  runProvider,
-		EnvFilePath:       resolveEnvPath(workDir, runEnvFile),
-		Verbose:           verbose,
-		Channels:          activeChannels,
-		NoAuth:            runNoAuth,
-		AuthToken:         runAuthToken,
-		AuthURL:           runAuthURL,
-		AuthOrgID:         runAuthOrgID,
-		CORSOrigins:       corsOrigins,
-		AuditExport:       auditExport,
-		RateLimitOverride: rateLimitOverride,
-		TracingFlags:      tracingFlags,
-		RuntimeVersion:    appVersion,
+		Config:              cfg,
+		WorkDir:             workDir,
+		Port:                runPort,
+		Host:                runHost,
+		ShutdownTimeout:     runShutdownTimeout,
+		MockTools:           runMockTools,
+		EnforceGuardrails:   enforceGuardrails,
+		ModelOverride:       runModel,
+		ProviderOverride:    runProvider,
+		EnvFilePath:         resolveEnvPath(workDir, runEnvFile),
+		Verbose:             verbose,
+		Channels:            activeChannels,
+		NoAuth:              runNoAuth,
+		AuthToken:           runAuthToken,
+		AuthURL:             runAuthURL,
+		AuthOrgID:           runAuthOrgID,
+		CORSOrigins:         corsOrigins,
+		AuditExport:         auditExport,
+		AuditPayloadCapture: auditCapture,
+		RateLimitOverride:   rateLimitOverride,
+		TracingFlags:        tracingFlags,
+		RuntimeVersion:      appVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("creating runner: %w", err)

--- a/forge-cli/runtime/audit_capture_resolver.go
+++ b/forge-cli/runtime/audit_capture_resolver.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// ResolveAuditPayloadCapture merges a forge.yaml `audit.capture` block
+// on top of an env-derived `AuditPayloadCapture` and returns the
+// effective config the runner should hand to registerAuditHooks.
+//
+// Precedence (high → low):
+//
+//  1. forge.yaml `audit.capture.*` — any non-nil bool / non-zero int
+//     wins over the env layer below.
+//  2. Env vars `FORGE_AUDIT_CAPTURE_*` — already baked into the env
+//     parameter via AuditPayloadCaptureFromEnv.
+//  3. Zero / safe defaults — every capture flag false, Redact true.
+//
+// Why `*bool` in the yaml layer: an operator who writes
+// `tool_args: false` in forge.yaml is making an explicit choice, not
+// "fall through to env." Booleans need a nullable representation to
+// preserve that distinction; ints get the same treatment via 0=unset
+// for MaxBytes.
+//
+// MaxBytes when set populates all four CapXxxBytes fields uniformly
+// (matching the env-layer single-knob semantic). Operators who need
+// different caps per field embed Forge as a library and set
+// AuditPayloadCapture programmatically; per-field env / yaml knobs
+// would inflate the operator surface without clear demand. See
+// issue #163.
+func ResolveAuditPayloadCapture(env coreruntime.AuditPayloadCapture, yaml types.AuditCaptureConfig) coreruntime.AuditPayloadCapture {
+	out := env
+	if yaml.ToolArgs != nil {
+		out.ToolArgs = *yaml.ToolArgs
+	}
+	if yaml.ToolResult != nil {
+		out.ToolResult = *yaml.ToolResult
+	}
+	if yaml.LLMMessages != nil {
+		out.LLMMessages = *yaml.LLMMessages
+	}
+	if yaml.LLMResponse != nil {
+		out.LLMResponse = *yaml.LLMResponse
+	}
+	if yaml.Redact != nil {
+		out.Redact = *yaml.Redact
+	}
+	if yaml.MaxBytes > 0 {
+		out.CapLLMMessagesBytes = yaml.MaxBytes
+		out.CapLLMResponseBytes = yaml.MaxBytes
+		out.CapToolArgsBytes = yaml.MaxBytes
+		out.CapToolResultBytes = yaml.MaxBytes
+	}
+	return out
+}

--- a/forge-cli/runtime/audit_capture_resolver_test.go
+++ b/forge-cli/runtime/audit_capture_resolver_test.go
@@ -1,0 +1,107 @@
+package runtime
+
+import (
+	"testing"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestResolveAuditPayloadCapture_EnvOnly is the baseline: with no
+// forge.yaml block, the env-derived config flows through unchanged.
+// The default Redact=true from AuditPayloadCaptureFromEnv survives.
+func TestResolveAuditPayloadCapture_EnvOnly(t *testing.T) {
+	env := coreruntime.AuditPayloadCapture{
+		ToolArgs: true,
+		Redact:   true,
+	}
+	got := ResolveAuditPayloadCapture(env, types.AuditCaptureConfig{})
+	if !got.ToolArgs || !got.Redact {
+		t.Errorf("env-only path lost flags: %+v", got)
+	}
+}
+
+// TestResolveAuditPayloadCapture_YAMLWinsOverEnv pins the
+// precedence direction. forge.yaml is the highest layer; an operator
+// who writes `tool_args: false` MUST be able to override an env var
+// that says true (e.g. a corporate-wide debug toggle a per-agent
+// deployment wants to disable).
+func TestResolveAuditPayloadCapture_YAMLWinsOverEnv(t *testing.T) {
+	env := coreruntime.AuditPayloadCapture{
+		ToolArgs:   true,
+		ToolResult: true,
+		Redact:     true,
+	}
+	yaml := types.AuditCaptureConfig{
+		ToolArgs: boolPtr(false),
+		Redact:   boolPtr(false),
+	}
+	got := ResolveAuditPayloadCapture(env, yaml)
+	if got.ToolArgs {
+		t.Errorf("yaml tool_args=false did not override env=true")
+	}
+	if got.Redact {
+		t.Errorf("yaml redact=false did not override env=true")
+	}
+	// Fields the yaml DIDN'T touch retain env values.
+	if !got.ToolResult {
+		t.Errorf("yaml omission must not clobber env: ToolResult lost")
+	}
+}
+
+// TestResolveAuditPayloadCapture_YAMLNilDoesNotClobberEnv is the
+// `*bool` nullable-field invariant. An operator who writes
+// `audit.capture: {}` (or just doesn't write the block at all) leaves
+// every yaml field nil. Nil MUST mean "fall through to env", never
+// "false."
+func TestResolveAuditPayloadCapture_YAMLNilDoesNotClobberEnv(t *testing.T) {
+	env := coreruntime.AuditPayloadCapture{
+		ToolArgs:    true,
+		ToolResult:  true,
+		LLMMessages: true,
+		LLMResponse: true,
+		Redact:      true,
+	}
+	got := ResolveAuditPayloadCapture(env, types.AuditCaptureConfig{})
+	if !got.ToolArgs || !got.ToolResult || !got.LLMMessages || !got.LLMResponse {
+		t.Errorf("nil yaml fields clobbered env capture flags: %+v", got)
+	}
+	if !got.Redact {
+		t.Errorf("nil yaml.Redact clobbered env Redact=true")
+	}
+}
+
+// TestResolveAuditPayloadCapture_MaxBytesUniform pins the single-knob
+// semantic on the yaml layer too: max_bytes when set propagates
+// uniformly across all four CapXxxBytes fields, matching the env-
+// layer behavior. Operators don't reason about four caps; they
+// reason about one.
+func TestResolveAuditPayloadCapture_MaxBytesUniform(t *testing.T) {
+	env := coreruntime.AuditPayloadCapture{}
+	yaml := types.AuditCaptureConfig{MaxBytes: 8192}
+	got := ResolveAuditPayloadCapture(env, yaml)
+	for name, v := range map[string]int{
+		"CapToolArgsBytes":    got.CapToolArgsBytes,
+		"CapToolResultBytes":  got.CapToolResultBytes,
+		"CapLLMMessagesBytes": got.CapLLMMessagesBytes,
+		"CapLLMResponseBytes": got.CapLLMResponseBytes,
+	} {
+		if v != 8192 {
+			t.Errorf("%s = %d, want 8192 (yaml max_bytes should propagate uniformly)", name, v)
+		}
+	}
+}
+
+// TestResolveAuditPayloadCapture_AllSurfacesOff is the default-deploy
+// canary: no env, no yaml → every capture flag stays false, but
+// Redact stays at whatever the env layer set (zero value from
+// FromEnv()) so an operator who later flips a flag on doesn't get a
+// surprise unscrubbed event.
+func TestResolveAuditPayloadCapture_AllSurfacesOff(t *testing.T) {
+	got := ResolveAuditPayloadCapture(coreruntime.AuditPayloadCapture{}, types.AuditCaptureConfig{})
+	if got.AnyEnabled() {
+		t.Errorf("default deploy must have AnyEnabled()=false; got %+v", got)
+	}
+}

--- a/forge-cli/runtime/audit_payload_capture_hook_test.go
+++ b/forge-cli/runtime/audit_payload_capture_hook_test.go
@@ -1,0 +1,181 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// fireToolExec replays the BeforeToolExec / AfterToolExec hook pair the
+// runner fires for a single tool call and returns the parsed events.
+// Shared by the issue #163 capture tests below so each test focuses on
+// what it's asserting rather than wire-up boilerplate.
+func fireToolExec(t *testing.T, capture coreruntime.AuditPayloadCapture, input, output string) []coreruntime.AuditEvent {
+	t.Helper()
+	var buf bytes.Buffer
+	al := coreruntime.NewAuditLogger(&buf)
+	r := &Runner{cfg: RunnerConfig{AuditPayloadCapture: capture}}
+	hooks := coreruntime.NewHookRegistry()
+	r.registerAuditHooks(hooks, al)
+
+	ctx := coreruntime.WithCorrelationID(context.Background(), "corr")
+	ctx = coreruntime.WithTaskID(ctx, "task")
+	ctx = coreruntime.WithSequenceCounter(ctx, new(coreruntime.SequenceCounter))
+
+	if err := hooks.Fire(ctx, coreruntime.BeforeToolExec, &coreruntime.HookContext{
+		ToolName:  "cli_execute",
+		ToolInput: input,
+	}); err != nil {
+		t.Fatalf("BeforeToolExec: %v", err)
+	}
+	if err := hooks.Fire(ctx, coreruntime.AfterToolExec, &coreruntime.HookContext{
+		ToolName:         "cli_execute",
+		ToolInput:        input,
+		ToolOutput:       output,
+		ToolExecDuration: 10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AfterToolExec: %v", err)
+	}
+
+	var events []coreruntime.AuditEvent
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev coreruntime.AuditEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	if got := len(events); got != 2 {
+		t.Fatalf("got %d events, want 2 (BeforeToolExec + AfterToolExec)", got)
+	}
+	return events
+}
+
+// TestRegisterAuditHooks_DefaultPostureOmitsCaptureFields is the
+// schema-golden pin for the default-deploy case: with capture flags
+// off, neither BeforeToolExec nor AfterToolExec event carries an
+// `args` or `result` key. The metadata `args_size` / `result_size`
+// keys MUST still land — operators can graph payload volume without
+// capturing the payloads themselves. Issue #163 verification step 1.
+func TestRegisterAuditHooks_DefaultPostureOmitsCaptureFields(t *testing.T) {
+	events := fireToolExec(t,
+		coreruntime.AuditPayloadCapture{}, // every flag off
+		`{"cmd":"ls -la /tmp"}`,
+		`drwxr-xr-x  ...`,
+	)
+	before, after := events[0], events[1]
+
+	if _, ok := before.Fields["args"]; ok {
+		t.Errorf("default posture leaked args field: %+v", before.Fields)
+	}
+	if _, ok := after.Fields["result"]; ok {
+		t.Errorf("default posture leaked result field: %+v", after.Fields)
+	}
+	// Size metadata MUST be present so observability dashboards
+	// still work without capture.
+	if before.Fields["args_size"] == nil {
+		t.Errorf("args_size missing in default posture: %+v", before.Fields)
+	}
+	if after.Fields["result_size"] == nil {
+		t.Errorf("result_size missing in default posture: %+v", after.Fields)
+	}
+}
+
+// TestRegisterAuditHooks_CaptureToolArgs_OnlyStartEventCarries is
+// the FWS-8 rule: ToolArgs capture lands on the start event, never
+// the end event (the input doesn't change between hooks; double-
+// emitting would inflate the audit footprint for no value).
+func TestRegisterAuditHooks_CaptureToolArgs_OnlyStartEventCarries(t *testing.T) {
+	events := fireToolExec(t,
+		coreruntime.AuditPayloadCapture{ToolArgs: true},
+		`{"cmd":"ls"}`,
+		`fileA fileB`,
+	)
+	before, after := events[0], events[1]
+
+	if before.Fields["args"] != `{"cmd":"ls"}` {
+		t.Errorf("BeforeToolExec args = %q, want %q",
+			before.Fields["args"], `{"cmd":"ls"}`)
+	}
+	if _, ok := after.Fields["args"]; ok {
+		t.Errorf("AfterToolExec MUST NOT carry args; got %+v", after.Fields)
+	}
+}
+
+// TestRegisterAuditHooks_CaptureRedactsVendorTokens is the core
+// issue #163 invariant manifesting at the hook layer: an LLM that
+// glues an API key into a `cli_execute` command produces a
+// tool_exec event with `[REDACTED]` in place of the secret, not
+// the raw token. Verification step 3 of the issue.
+func TestRegisterAuditHooks_CaptureRedactsVendorTokens(t *testing.T) {
+	input := `{"cmd":"curl -H 'Authorization: Bearer sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa' https://api"}`
+	events := fireToolExec(t,
+		coreruntime.AuditPayloadCapture{ToolArgs: true, Redact: true},
+		input, "",
+	)
+	args, ok := events[0].Fields["args"].(string)
+	if !ok {
+		t.Fatalf("args field missing or not a string: %+v", events[0].Fields)
+	}
+	if strings.Contains(args, "sk-ant-aaa") {
+		t.Errorf("vendor secret leaked into captured args: %q", args)
+	}
+	if !strings.Contains(args, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in captured args; got %q", args)
+	}
+}
+
+// TestRegisterAuditHooks_CaptureRedactFalseLeavesSecretsVerbatim is
+// the documented escape hatch: REDACT=false (typically because a
+// downstream sink has its own scrubber) keeps the raw token in the
+// captured args. Verification step 4 of the issue.
+func TestRegisterAuditHooks_CaptureRedactFalseLeavesSecretsVerbatim(t *testing.T) {
+	input := `{"cmd":"echo sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`
+	events := fireToolExec(t,
+		coreruntime.AuditPayloadCapture{ToolArgs: true, Redact: false},
+		input, "",
+	)
+	args, _ := events[0].Fields["args"].(string)
+	if !strings.Contains(args, "sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+		t.Errorf("Redact=false should leave raw token; got %q", args)
+	}
+}
+
+// TestRegisterAuditHooks_CaptureToolResult_Truncates pins the
+// large-output truncation behavior. A 100 KiB output captured at the
+// default 16 KiB cap MUST end with `…[truncated:N]` carrying the
+// original size — the audit stream NEVER blocks streaming because of
+// a runaway tool output. Verification step 6 of the issue.
+func TestRegisterAuditHooks_CaptureToolResult_Truncates(t *testing.T) {
+	big := strings.Repeat("a", 100*1024)
+	events := fireToolExec(t,
+		coreruntime.AuditPayloadCapture{ToolResult: true, Redact: false},
+		`{"cmd":"cat big"}`,
+		big,
+	)
+	result, ok := events[1].Fields["result"].(string)
+	if !ok {
+		t.Fatalf("result field missing: %+v", events[1].Fields)
+	}
+	if len(result) >= len(big) {
+		t.Errorf("result not truncated; in=%d out=%d", len(big), len(result))
+	}
+	if !strings.Contains(result, "…[truncated:") {
+		t.Errorf("truncation marker missing: tail=%q", result[max(0, len(result)-40):])
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/forge-cli/runtime/guardrails_audit.go
+++ b/forge-cli/runtime/guardrails_audit.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/initializ/guardrails"
@@ -81,50 +80,24 @@ func GuardrailAuditConfigFromEnv() GuardrailAuditConfig {
 	return cfg
 }
 
-// secretRedactPatterns are the vendor token shapes scrubbed when
-// GuardrailAuditConfig.Redact is on. Same set as the OTel content
-// redaction pass (issue #130) so the audit and trace pipelines stay
-// consistent. Defence-in-depth only: the guardrail library may already
-// have masked these, but an unmasked input that hit a different rule
-// (e.g. moderation) would otherwise carry secrets through verbatim.
-var secretRedactPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`sk-ant-[A-Za-z0-9\-]{20,}`),
-	regexp.MustCompile(`sk-[A-Za-z0-9]{20,}`),
-	regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`),
-	regexp.MustCompile(`gho_[A-Za-z0-9]{36}`),
-	regexp.MustCompile(`ghs_[A-Za-z0-9]{36}`),
-	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`),
-	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
-	regexp.MustCompile(`xox[bp]-[0-9]{10,}-[A-Za-z0-9-]+`),
-	regexp.MustCompile(`-----BEGIN (RSA|EC|OPENSSH|PRIVATE) .*KEY-----`),
-	regexp.MustCompile(`[0-9]{8,10}:[A-Za-z0-9_-]{35,}`),
-}
-
-// redactSecrets replaces any known secret-token shape with [REDACTED].
-// Mirrors the marker used by the FWS-8 capture path so audit consumers
-// see one consistent token across both pipelines.
-func redactSecrets(s string) string {
-	for _, re := range secretRedactPatterns {
-		s = re.ReplaceAllString(s, "[REDACTED]")
-	}
-	return s
-}
-
 // prepareEvidence applies redact (if on) then byte-truncates to the
-// configured cap. Returns "" when input is "" so callers can drop the
-// field cleanly.
+// configured cap, delegating to the shared content-capture pipeline
+// (coreruntime.PrepareCapturedContent) so the vendor-secret regex set
+// and the truncation marker stay in lockstep with the FWS-8 payload-
+// capture path and the #130 OTel content path. Pre-#163 this function
+// carried its own copy of the redact regex set — see the issue for
+// the consolidation rationale.
+//
+// Returns "" when input is "" so callers can drop the field cleanly.
 func prepareEvidence(s string, cfg GuardrailAuditConfig) string {
 	if s == "" {
 		return ""
-	}
-	if cfg.Redact {
-		s = redactSecrets(s)
 	}
 	cap := cfg.MaxBytes
 	if cap <= 0 {
 		cap = DefaultGuardrailEvidenceCapBytes
 	}
-	return coreruntime.TruncateForAudit(s, cap)
+	return coreruntime.PrepareCapturedContent(s, cfg.Redact, cap)
 }
 
 // emitGuardrailEvent builds and emits a guardrail_check audit event

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1994,8 +1994,13 @@ func (r *Runner) registerAuditHooks(hooks *coreruntime.HookRegistry, auditLogger
 		if hctx.ToolInput != "" {
 			fields["args_size"] = len(hctx.ToolInput)
 			if capture.ToolArgs {
-				fields["args"] = coreruntime.TruncateForAudit(hctx.ToolInput,
-					coreruntime.CapOrDefault(capture.CapToolArgsBytes))
+				// FWS-8 raw tool args, routed through the shared
+				// redact-then-truncate pipeline (issue #163) so an
+				// API key the LLM glued into a `cli_execute`
+				// command is scrubbed before it lands on the audit
+				// stream.
+				fields["args"] = coreruntime.PrepareCapturedContent(hctx.ToolInput,
+					capture.Redact, coreruntime.CapOrDefault(capture.CapToolArgsBytes))
 			}
 		}
 		auditLogger.EmitFromContext(ctxStart, coreruntime.AuditEvent{
@@ -2017,10 +2022,10 @@ func (r *Runner) registerAuditHooks(hooks *coreruntime.HookRegistry, auditLogger
 		}
 		if hctx.ToolOutput != "" {
 			fields["result_size"] = len(hctx.ToolOutput)
-			// FWS-8: opt-in raw tool result.
 			if capture.ToolResult {
-				fields["result"] = coreruntime.TruncateForAudit(hctx.ToolOutput,
-					coreruntime.CapOrDefault(capture.CapToolResultBytes))
+				// Same redact-then-truncate pipeline as tool args.
+				fields["result"] = coreruntime.PrepareCapturedContent(hctx.ToolOutput,
+					capture.Redact, coreruntime.CapOrDefault(capture.CapToolResultBytes))
 			}
 		}
 		ms := hctx.ToolExecDuration.Milliseconds()
@@ -2052,16 +2057,16 @@ func (r *Runner) registerAuditHooks(hooks *coreruntime.HookRegistry, auditLogger
 				fields = map[string]any{}
 			}
 			marshaled, _ := json.Marshal(hctx.Messages)
-			fields["prompt_messages"] = coreruntime.TruncateForAudit(string(marshaled),
-				coreruntime.CapOrDefault(capture.CapLLMMessagesBytes))
+			fields["prompt_messages"] = coreruntime.PrepareCapturedContent(string(marshaled),
+				capture.Redact, coreruntime.CapOrDefault(capture.CapLLMMessagesBytes))
 			fields["prompt_messages_count"] = len(hctx.Messages)
 		}
 		if capture.LLMResponse && hctx.Response != nil && hctx.Response.Message.Content != "" {
 			if fields == nil {
 				fields = map[string]any{}
 			}
-			fields["completion_text"] = coreruntime.TruncateForAudit(hctx.Response.Message.Content,
-				coreruntime.CapOrDefault(capture.CapLLMResponseBytes))
+			fields["completion_text"] = coreruntime.PrepareCapturedContent(hctx.Response.Message.Content,
+				capture.Redact, coreruntime.CapOrDefault(capture.CapLLMResponseBytes))
 		}
 		auditLogger.EmitLLMCall(ctx, coreruntime.LLMCallAuditArgs{
 			Model:     hctx.Model,

--- a/forge-core/runtime/audit_payload_capture.go
+++ b/forge-core/runtime/audit_payload_capture.go
@@ -1,11 +1,16 @@
 package runtime
 
+import (
+	"os"
+	"strconv"
+)
+
 // AuditPayloadCapture controls whether the audit pipeline emits raw
 // LLM prompt / completion text and raw tool args / results in audit
-// events. Every field defaults to false; the default audit posture is
-// "metadata only" (size + type + token counts + duration). This
-// matches the security commitment baked into the audit emission sites
-// today and codified by FWS-8 (issue #91).
+// events. Every capture flag defaults to false; the default audit
+// posture is "metadata only" (size + type + token counts + duration).
+// This matches the security commitment baked into the audit emission
+// sites today and codified by FWS-8 (issue #91).
 //
 // Customers who need raw payloads in audit (debugging, replay,
 // supervised-learning corpora) opt in field by field, NEVER globally.
@@ -19,11 +24,17 @@ package runtime
 // settings — it just emits what the AuditEvent says.
 //
 // THIS IS A SECURITY-RELEVANT CONFIGURATION. Operators who enable
-// any capture flag must ensure the audit transport (the FWS-7 sink
-// or the stderr safety net) lands in a store that respects the
-// captured payloads' sensitivity (PII, secrets that may end up in
-// prompts, etc.). The Forge codebase does not redact; what flows
-// from the LLM call site flows verbatim into the event.
+// any capture flag should keep Redact on (the default) so vendor
+// secrets that an LLM glues into a `cli_execute` command (a real
+// failure mode — the model remembers a token from the prompt and
+// inlines it into a shell invocation) are scrubbed before the event
+// lands on the audit stream. Set Redact=false ONLY when a downstream
+// sink runs its own scrubber. See PrepareCapturedContent in
+// content_redact.go.
+//
+// Beyond redact: operators must also ensure the audit transport (the
+// FWS-7 sink or the stderr safety net) lands in a store that respects
+// the captured payloads' sensitivity (PII, prompts, etc.).
 type AuditPayloadCapture struct {
 	// LLMMessages controls whether each `llm_call` event carries the
 	// list of inbound chat messages (role + content) the agent sent
@@ -38,6 +49,20 @@ type AuditPayloadCapture struct {
 	// ToolResult controls whether `tool_exec` carries the raw
 	// output the tool returned. Off by default.
 	ToolResult bool
+
+	// Redact runs the vendor-secret regex scrub
+	// (content_redact.go:RedactSecrets) on each captured field
+	// before truncation. The struct's zero value has Redact=false
+	// purely as a Go-zero-value artifact — operators MUST go through
+	// AuditPayloadCaptureFromEnv (which defaults Redact=true) or
+	// explicitly set the field. The runner's resolver enforces this
+	// by always passing through FromEnv before applying any
+	// forge.yaml overrides.
+	//
+	// Disabling redact is a deliberate escape hatch: operators whose
+	// downstream sink has its own scrubber and who explicitly want to
+	// see the raw bytes for tuning. See issue #163.
+	Redact bool
 
 	// CapLLMMessagesBytes is the max bytes serialized for the
 	// captured chat messages array. 0 = use the package default
@@ -105,6 +130,73 @@ func TruncateForAudit(s string, max int) string {
 		prefixCap = len(s)
 	}
 	return s[:prefixCap] + marker + itoa(len(s)) + tail
+}
+
+// Environment variable names for AuditPayloadCaptureFromEnv. Mirrors
+// the AuditExportConfig / GuardrailAuditConfig env naming so operators
+// see one consistent `FORGE_AUDIT_*` namespace across the audit
+// subsystem. See issue #163.
+const (
+	EnvAuditCaptureToolArgs    = "FORGE_AUDIT_CAPTURE_TOOL_ARGS"
+	EnvAuditCaptureToolResult  = "FORGE_AUDIT_CAPTURE_TOOL_RESULT"
+	EnvAuditCaptureLLMMessages = "FORGE_AUDIT_CAPTURE_LLM_MESSAGES"
+	EnvAuditCaptureLLMResponse = "FORGE_AUDIT_CAPTURE_LLM_RESPONSE"
+	EnvAuditCaptureRedact      = "FORGE_AUDIT_CAPTURE_REDACT"
+	EnvAuditCaptureMaxBytes    = "FORGE_AUDIT_CAPTURE_MAX_BYTES"
+)
+
+// AuditPayloadCaptureFromEnv reads the FORGE_AUDIT_CAPTURE_* env vars
+// and returns a populated config. Redact defaults to TRUE so flipping
+// any capture flag on without touching Redact keeps the safer posture
+// — the same default the GuardrailAuditConfig.Redact uses for
+// guardrail evidence and the OTel tracing CaptureContent path uses
+// for span content. See issue #163 for the consolidation rationale.
+//
+// FORGE_AUDIT_CAPTURE_MAX_BYTES is the single-knob per-field cap: when
+// set it populates all four CapXxxBytes fields uniformly. Operators
+// who need different caps per field set the struct directly (Forge
+// embedded as a library) — env-var coverage is intentionally
+// single-knob to keep the operator surface small.
+//
+// Parse failures (non-boolean strings for the flags, non-integer for
+// the cap) fall through to defaults. Same forgiving posture as the
+// other Audit*FromEnv constructors.
+func AuditPayloadCaptureFromEnv() AuditPayloadCapture {
+	cfg := AuditPayloadCapture{Redact: true}
+	if v := os.Getenv(EnvAuditCaptureToolArgs); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.ToolArgs = b
+		}
+	}
+	if v := os.Getenv(EnvAuditCaptureToolResult); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.ToolResult = b
+		}
+	}
+	if v := os.Getenv(EnvAuditCaptureLLMMessages); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.LLMMessages = b
+		}
+	}
+	if v := os.Getenv(EnvAuditCaptureLLMResponse); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.LLMResponse = b
+		}
+	}
+	if v := os.Getenv(EnvAuditCaptureRedact); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.Redact = b
+		}
+	}
+	if v := os.Getenv(EnvAuditCaptureMaxBytes); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.CapLLMMessagesBytes = n
+			cfg.CapLLMResponseBytes = n
+			cfg.CapToolArgsBytes = n
+			cfg.CapToolResultBytes = n
+		}
+	}
+	return cfg
 }
 
 // itoa avoids fmt.Sprintf("%d", n) so TruncateForAudit stays tight.

--- a/forge-core/runtime/audit_payload_capture_test.go
+++ b/forge-core/runtime/audit_payload_capture_test.go
@@ -1,0 +1,258 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAuditPayloadCaptureFromEnv_Defaults pins the safe-default
+// posture: zero env vars in the process give back a config with every
+// capture flag false and Redact = true. An operator who flips ToolArgs
+// on via env without touching Redact must keep the scrubber on by
+// default — issue #163 is largely about closing the "secret leaked to
+// audit because nobody set Redact" gap.
+func TestAuditPayloadCaptureFromEnv_Defaults(t *testing.T) {
+	t.Setenv(EnvAuditCaptureToolArgs, "")
+	t.Setenv(EnvAuditCaptureToolResult, "")
+	t.Setenv(EnvAuditCaptureLLMMessages, "")
+	t.Setenv(EnvAuditCaptureLLMResponse, "")
+	t.Setenv(EnvAuditCaptureRedact, "")
+	t.Setenv(EnvAuditCaptureMaxBytes, "")
+
+	cfg := AuditPayloadCaptureFromEnv()
+	if cfg.ToolArgs || cfg.ToolResult || cfg.LLMMessages || cfg.LLMResponse {
+		t.Errorf("expected every capture flag false; got %+v", cfg)
+	}
+	if !cfg.Redact {
+		t.Errorf("Redact must default true; got false")
+	}
+	if cfg.AnyEnabled() {
+		t.Errorf("AnyEnabled should be false in default posture; got true")
+	}
+}
+
+// TestAuditPayloadCaptureFromEnv_FlagsParsed walks each capture flag
+// and confirms the env var flips it. The cases use the strconv.ParseBool
+// vocabulary ("true", "1", "false") because that's what the
+// constructor uses — different from "yes"/"on" some other shells
+// accept.
+func TestAuditPayloadCaptureFromEnv_FlagsParsed(t *testing.T) {
+	cases := []struct {
+		envVar string
+		field  func(AuditPayloadCapture) bool
+		name   string
+	}{
+		{EnvAuditCaptureToolArgs, func(c AuditPayloadCapture) bool { return c.ToolArgs }, "ToolArgs"},
+		{EnvAuditCaptureToolResult, func(c AuditPayloadCapture) bool { return c.ToolResult }, "ToolResult"},
+		{EnvAuditCaptureLLMMessages, func(c AuditPayloadCapture) bool { return c.LLMMessages }, "LLMMessages"},
+		{EnvAuditCaptureLLMResponse, func(c AuditPayloadCapture) bool { return c.LLMResponse }, "LLMResponse"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(c.envVar, "true")
+			cfg := AuditPayloadCaptureFromEnv()
+			if !c.field(cfg) {
+				t.Errorf("env %s=true did not flip %s; got %+v", c.envVar, c.name, cfg)
+			}
+		})
+	}
+}
+
+// TestAuditPayloadCaptureFromEnv_RedactEscapeHatch is the explicit
+// override path — operators with their own downstream scrubber set
+// FORGE_AUDIT_CAPTURE_REDACT=false and the runner stops scrubbing.
+// Documented escape hatch; tested here so regressions land in red.
+func TestAuditPayloadCaptureFromEnv_RedactEscapeHatch(t *testing.T) {
+	t.Setenv(EnvAuditCaptureRedact, "false")
+	cfg := AuditPayloadCaptureFromEnv()
+	if cfg.Redact {
+		t.Errorf("FORGE_AUDIT_CAPTURE_REDACT=false must flip Redact to false; got true")
+	}
+}
+
+// TestAuditPayloadCaptureFromEnv_MaxBytesIsSingleKnob confirms the
+// per-field-uniform semantic: FORGE_AUDIT_CAPTURE_MAX_BYTES applies
+// the same cap across all four CapXxxBytes fields. Operators who
+// genuinely need divergent caps embed Forge as a library; the env
+// surface stays single-knob.
+func TestAuditPayloadCaptureFromEnv_MaxBytesIsSingleKnob(t *testing.T) {
+	t.Setenv(EnvAuditCaptureMaxBytes, "8192")
+	cfg := AuditPayloadCaptureFromEnv()
+	for _, got := range []int{
+		cfg.CapToolArgsBytes,
+		cfg.CapToolResultBytes,
+		cfg.CapLLMMessagesBytes,
+		cfg.CapLLMResponseBytes,
+	} {
+		if got != 8192 {
+			t.Errorf("MAX_BYTES=8192 did not propagate uniformly; cap=%d", got)
+		}
+	}
+}
+
+// TestAuditPayloadCaptureFromEnv_MaxBytesIgnoresInvalid pins the
+// forgiving parse posture — garbage values leave the default-zero so
+// CapOrDefault falls through. Matches the AuditExportConfigFromEnv
+// pattern: a typo in env doesn't kill the agent at startup.
+func TestAuditPayloadCaptureFromEnv_MaxBytesIgnoresInvalid(t *testing.T) {
+	t.Setenv(EnvAuditCaptureMaxBytes, "not-a-number")
+	cfg := AuditPayloadCaptureFromEnv()
+	if cfg.CapToolArgsBytes != 0 {
+		t.Errorf("invalid MAX_BYTES should leave cap zero; got %d", cfg.CapToolArgsBytes)
+	}
+	// And the per-field default still applies via CapOrDefault.
+	if eff := CapOrDefault(cfg.CapToolArgsBytes); eff != DefaultPayloadCaptureCapBytes {
+		t.Errorf("CapOrDefault should fall back to default; got %d", eff)
+	}
+}
+
+// TestAuditPayloadCaptureFromEnv_RejectsZeroAndNegativeMaxBytes
+// confirms the boundary: 0 means "not set" so per-field defaults
+// apply; negative means "obviously invalid input" same outcome.
+func TestAuditPayloadCaptureFromEnv_RejectsZeroAndNegativeMaxBytes(t *testing.T) {
+	for _, v := range []string{"0", "-100"} {
+		t.Setenv(EnvAuditCaptureMaxBytes, v)
+		cfg := AuditPayloadCaptureFromEnv()
+		if cfg.CapToolArgsBytes != 0 {
+			t.Errorf("MAX_BYTES=%q should leave cap zero; got %d", v, cfg.CapToolArgsBytes)
+		}
+	}
+}
+
+// TestAnyEnabled_CoversAllFlags is the regression pin for FWS-8's
+// "skip the hook overhead when nothing is captured" optimization in
+// runner.registerAuditHooks. Each flag individually must surface
+// through AnyEnabled or the runner won't install the hook and the
+// captured payload silently never reaches the audit stream.
+func TestAnyEnabled_CoversAllFlags(t *testing.T) {
+	cases := []AuditPayloadCapture{
+		{ToolArgs: true},
+		{ToolResult: true},
+		{LLMMessages: true},
+		{LLMResponse: true},
+	}
+	for i, c := range cases {
+		if !c.AnyEnabled() {
+			t.Errorf("case %d: AnyEnabled() returned false for %+v", i, c)
+		}
+	}
+	if (AuditPayloadCapture{}).AnyEnabled() {
+		t.Errorf("zero value reports AnyEnabled() true")
+	}
+}
+
+// TestPrepareCapturedContent_RedactScrubsVendorTokens is the core
+// issue #163 invariant: a captured payload carrying a vendor secret
+// has the secret replaced by [REDACTED] before it can land on the
+// audit stream. Walks the regex set so every supported vendor token
+// shape stays covered through consolidation.
+func TestPrepareCapturedContent_RedactScrubsVendorTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"anthropic", "key=sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa here"},
+		{"openai", "key=sk-AAAAAAAAAAAAAAAAAAAA here"},
+		{"github_pat", "tok=ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA here"},
+		{"aws_access", "id=AKIAAAAAAAAAAAAAAAAA here"},
+		{"slack_bot", "tok=xoxb-1234567890-AAAAAAAAAAAA here"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := PrepareCapturedContent(c.in, true, 1024)
+			if !strings.Contains(out, RedactionMarker) {
+				t.Errorf("expected [REDACTED] in %q for input %q", out, c.in)
+			}
+		})
+	}
+}
+
+// TestPrepareCapturedContent_NoRedactKeepsSecretsVerbatim is the
+// escape-hatch confirmation — REDACT=false leaves the raw secret in
+// the captured content. This is the path operators with a downstream
+// SIEM scrubber take.
+func TestPrepareCapturedContent_NoRedactKeepsSecretsVerbatim(t *testing.T) {
+	in := "tok=sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	out := PrepareCapturedContent(in, false, 1024)
+	if !strings.Contains(out, "sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+		t.Errorf("redact=false should leave the raw token; got %q", out)
+	}
+	if strings.Contains(out, RedactionMarker) {
+		t.Errorf("redact=false should NOT emit [REDACTED]; got %q", out)
+	}
+}
+
+// TestPrepareCapturedContent_TruncatesAtCap pins the byte-cap behavior
+// — issue #163 verification step 6 (100 KB output, 16 KiB cap).
+func TestPrepareCapturedContent_TruncatesAtCap(t *testing.T) {
+	in := strings.Repeat("a", 100*1024)
+	out := PrepareCapturedContent(in, false, 16*1024)
+	if len(out) >= len(in) {
+		t.Errorf("output not truncated; in=%d out=%d", len(in), len(out))
+	}
+	if !strings.HasSuffix(out, "]") || !strings.Contains(out, "…[truncated:") {
+		t.Errorf("output missing truncation marker; tail=%q", out[len(out)-32:])
+	}
+}
+
+// TestPrepareCapturedContent_RedactBeforeTruncate is the ordering pin
+// — the truncation cut must not split a [REDACTED] marker mid-string.
+// Concretely: build a payload where the cap would land inside the
+// REDACTED substring and assert the marker stays intact.
+func TestPrepareCapturedContent_RedactBeforeTruncate(t *testing.T) {
+	in := strings.Repeat("x", 100) + "sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa" + strings.Repeat("y", 100)
+	// Cap chosen so the redacted output (which is shorter than the
+	// raw input) still fits comfortably — confirming redact happened
+	// before any cap reasoning kicked in.
+	out := PrepareCapturedContent(in, true, 1024)
+	if strings.Contains(out, "sk-ant-aaa") {
+		t.Errorf("raw token leaked past redact: %q", out)
+	}
+	if !strings.Contains(out, RedactionMarker) {
+		t.Errorf("[REDACTED] marker missing: %q", out)
+	}
+}
+
+// TestPrepareCapturedContent_EmptyFastPath confirms the empty-input
+// short-circuit — callers can use the empty return as the signal to
+// drop the field entirely from the AuditEvent.
+func TestPrepareCapturedContent_EmptyFastPath(t *testing.T) {
+	if out := PrepareCapturedContent("", true, 1024); out != "" {
+		t.Errorf("empty input should return empty; got %q", out)
+	}
+}
+
+// TestPrepareCapturedContent_DefaultCap pins the maxBytes <= 0
+// fallback — the larger 16 KiB payload cap applies (not the span
+// path's 4 KiB) when the caller leaves the cap unset.
+func TestPrepareCapturedContent_DefaultCap(t *testing.T) {
+	in := strings.Repeat("a", DefaultPayloadCaptureCapBytes+1024)
+	out := PrepareCapturedContent(in, false, 0)
+	// Output should be roughly cap-sized (marker + digits add a few
+	// bytes). A delta of 64 covers the marker overhead generously.
+	if len(out) > DefaultPayloadCaptureCapBytes+64 {
+		t.Errorf("default cap not applied; in=%d out=%d cap=%d",
+			len(in), len(out), DefaultPayloadCaptureCapBytes)
+	}
+}
+
+// TestPrepareSpanContent_StillDelegatesAndUsesItsOwnDefault confirms
+// the #130 contract survives the #163 consolidation: span content
+// still gets the 4 KiB default (not the 16 KiB payload-capture
+// default), and redact+marker behavior is byte-identical to
+// PrepareCapturedContent for matched-cap calls.
+func TestPrepareSpanContent_StillDelegatesAndUsesItsOwnDefault(t *testing.T) {
+	in := strings.Repeat("a", DefaultSpanContentCapBytes+1024)
+	spanOut := PrepareSpanContent(in, false, 0)
+	if len(spanOut) > DefaultSpanContentCapBytes+64 {
+		t.Errorf("span default cap not applied; in=%d out=%d cap=%d",
+			len(in), len(spanOut), DefaultSpanContentCapBytes)
+	}
+
+	// Same input, both helpers with matched cap = identical output.
+	bothCap := 512
+	if PrepareSpanContent("tok=sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa", true, bothCap) !=
+		PrepareCapturedContent("tok=sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaa", true, bothCap) {
+		t.Errorf("PrepareSpanContent and PrepareCapturedContent diverged for matched-cap input")
+	}
+}

--- a/forge-core/runtime/content_redact.go
+++ b/forge-core/runtime/content_redact.go
@@ -117,23 +117,31 @@ func serializeChatMessages(messages []llm.ChatMessage) string {
 	return string(b)
 }
 
-// PrepareSpanContent runs the redact (when redact=true) and
-// byte-cap-with-truncation-marker pipeline for content destined for
-// an OTel span attribute. The pipeline is:
+// PrepareCapturedContent is the shared redact-then-truncate pipeline
+// for any content the runtime captures into a long-lived artifact —
+// audit events (FWS-8 payload capture), OTel span attributes (#130
+// content capture), guardrail evidence (#155 / #156). All three call
+// sites previously open-coded a near-identical redact + truncate flow
+// with three independent copies of the vendor-secret regex set; this
+// helper consolidates them onto one implementation so a fix to the
+// regex set propagates to every capture path (issue #163).
 //
-//  1. Apply RedactSecrets when redact=true.
-//  2. TruncateForAudit (the same byte-cap helper the audit path uses)
-//     so a runaway prompt can't blow past the backend attribute limit
-//     and silently drop the marker.
+// Pipeline:
 //
-// maxBytes <= 0 falls back to DefaultSpanContentCapBytes. The
-// truncation marker is identical to what AuditPayloadCapture writes,
-// so an operator who sees a `…[truncated:N]` suffix on an audit
-// payload-captured field sees the same suffix on the linked span
-// attribute for the same logical event.
+//  1. Empty input is returned unchanged (fast path; callers can use
+//     the empty return as the signal to drop the field cleanly).
+//  2. If redact=true, RedactSecrets scrubs known vendor token shapes.
+//  3. maxBytes <= 0 falls back to DefaultPayloadCaptureCapBytes
+//     (16 KiB). Each call site that wants a different default (the
+//     span path uses DefaultSpanContentCapBytes=4 KiB; the guardrail
+//     evidence path uses DefaultGuardrailEvidenceCapBytes=4 KiB) MUST
+//     pass its own explicit cap.
+//  4. TruncateForAudit applies the byte cap and writes the
+//     `…[truncated:N]` marker the audit and OTel paths share.
 //
-// Returns the empty string when s is empty (skipping the pipeline).
-func PrepareSpanContent(s string, redact bool, maxBytes int) string {
+// Order matters: redact runs BEFORE truncate so the truncation
+// boundary can never split a `[REDACTED]` marker mid-string.
+func PrepareCapturedContent(s string, redact bool, maxBytes int) string {
 	if s == "" {
 		return s
 	}
@@ -141,7 +149,26 @@ func PrepareSpanContent(s string, redact bool, maxBytes int) string {
 		s = RedactSecrets(s)
 	}
 	if maxBytes <= 0 {
-		maxBytes = DefaultSpanContentCapBytes
+		maxBytes = DefaultPayloadCaptureCapBytes
 	}
 	return TruncateForAudit(s, maxBytes)
+}
+
+// PrepareSpanContent is the OTel-span-attribute-specific adapter over
+// PrepareCapturedContent. It applies the span-attribute default cap
+// (DefaultSpanContentCapBytes, 4 KiB — comfortably under common
+// observability backend per-attribute limits) when the caller passes
+// maxBytes <= 0. Behavior is otherwise identical to
+// PrepareCapturedContent and the truncation marker is shared so an
+// operator correlating an audit `…[truncated:N]` substring with the
+// linked span attribute sees the same suffix on both.
+//
+// Issue #130 shipped this helper; issue #163 collapses it onto
+// PrepareCapturedContent so all three content-capture paths share
+// one implementation.
+func PrepareSpanContent(s string, redact bool, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = DefaultSpanContentCapBytes
+	}
+	return PrepareCapturedContent(s, redact, maxBytes)
 }

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -33,6 +33,56 @@ type ForgeConfig struct {
 	Server         ServerConfig        `yaml:"server,omitempty"`
 	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
 	Security       SecurityConfig      `yaml:"security,omitempty"`
+	Audit          AuditConfig         `yaml:"audit,omitempty"`
+}
+
+// AuditConfig groups audit-pipeline knobs that are operator-visible in
+// forge.yaml. Today it carries the FWS-8 payload-capture block (issue
+// #163); the export-sink knobs (#95 / FWS-7) are CLI flags and env
+// vars only because they correspond to deployment-platform choices,
+// not per-agent configuration.
+type AuditConfig struct {
+	Capture AuditCaptureConfig `yaml:"capture,omitempty"`
+}
+
+// AuditCaptureConfig is the forge.yaml-facing payload-capture
+// configuration. Each capture flag is a `*bool` so an operator can
+// distinguish "unset, fall through to env" from "explicitly false";
+// the env layer is the next layer below, and the `FORGE_AUDIT_CAPTURE_*`
+// defaults sit at the bottom.
+//
+// Precedence (high → low): forge.yaml `audit.capture` > env var > default.
+// Same pattern the export config and guardrail audit config use.
+//
+// Off by default per the FWS-8 commitment: an absent `audit.capture`
+// block leaves every flag false and emits metadata-only events.
+// Operators turn capture on for one of:
+//   - debugging a misbehaving tool (set `tool_args + tool_result` for
+//     the session, then turn off);
+//   - compliance evidence (typically just `tool_args` — the inputs
+//     the agent produced);
+//   - supervised-learning corpora collection (probably `llm_messages`
+//     and `tool_result` together).
+//
+// See docs/security/audit-logging.md `Raw payload capture` section
+// for the verbosity table and operator guidance.
+type AuditCaptureConfig struct {
+	// ToolArgs captures the raw input on `tool_exec phase=start`.
+	ToolArgs *bool `yaml:"tool_args,omitempty"`
+	// ToolResult captures the raw output on `tool_exec phase=end`.
+	ToolResult *bool `yaml:"tool_result,omitempty"`
+	// LLMMessages captures the chat-messages array on `llm_call`.
+	LLMMessages *bool `yaml:"llm_messages,omitempty"`
+	// LLMResponse captures the model completion text on `llm_call`.
+	LLMResponse *bool `yaml:"llm_response,omitempty"`
+	// Redact runs the vendor-secret regex scrub on captured fields
+	// before truncation. ON by default — only flip OFF if a
+	// downstream sink scrubs.
+	Redact *bool `yaml:"redact,omitempty"`
+	// MaxBytes is the single-knob per-field cap (16 KiB default).
+	// Zero leaves whichever value the env layer or per-field default
+	// resolved to.
+	MaxBytes int `yaml:"max_bytes,omitempty"`
 }
 
 // SecurityConfig groups build-time security knobs. Today it carries


### PR DESCRIPTION
## Summary

- Adds env vars (`FORGE_AUDIT_CAPTURE_*`) and a `forge.yaml` `audit.capture:` block so operators can turn FWS-8 raw-payload capture on without rebuilding Forge. Precedence: yaml > env > default.
- Adds a `Redact` field on `AuditPayloadCapture` (default ON) so captured `args` / `result` / `prompt_messages` / `completion_text` fields get a vendor-secret regex scrub before truncation. Closes the gap where an LLM-glued API key in a `cli_execute` command leaked verbatim to audit.
- Collapses the three previously-duplicated redact-and-truncate paths (FWS-8 capture, guardrail evidence, OTel span content) onto a single `coreruntime.PrepareCapturedContent` helper. One regex set, one truncation marker — fix once, flow everywhere.

## Why

Issue #163 documents two gaps in the FWS-8 capture path that made it unusable in production today: no operator surface, and no redact pass. PRs #154 and #156 closed the same gap for OTel span content and guardrail evidence respectively; the FWS-8 capture path missed the consolidation. This PR consolidates all three onto one helper.

## Configuration

### `forge.yaml`

```yaml
audit:
  capture:
    tool_args: true         # capture raw tool input on tool_exec start
    tool_result: true       # capture raw tool output on tool_exec end
    llm_messages: false     # capture chat messages on llm_call
    llm_response: false     # capture completion text on llm_call
    redact: true            # ON by default; only flip OFF if a downstream sink scrubs
    max_bytes: 16384        # per-field byte cap (16 KiB default)
```

### Env vars

| Env var | Default | Meaning |
|---|---|---|
| `FORGE_AUDIT_CAPTURE_TOOL_ARGS` | `false` | Capture raw tool input on `tool_exec phase=start` |
| `FORGE_AUDIT_CAPTURE_TOOL_RESULT` | `false` | Capture raw tool output on `tool_exec phase=end` |
| `FORGE_AUDIT_CAPTURE_LLM_MESSAGES` | `false` | Capture chat messages on `llm_call` |
| `FORGE_AUDIT_CAPTURE_LLM_RESPONSE` | `false` | Capture completion text on `llm_call` |
| `FORGE_AUDIT_CAPTURE_REDACT` | `true` | Vendor-secret regex scrub before emission |
| `FORGE_AUDIT_CAPTURE_MAX_BYTES` | `16384` | Single-knob per-field byte cap |

## Safety

- **Default posture unchanged**: an absent `audit.capture` block and zero env vars produce byte-identical output to pre-#163 — `tool_exec` events carry `args_size` / `result_size` metadata but no raw `args` / `result` keys. Pinned by `TestRegisterAuditHooks_DefaultPostureOmitsCaptureFields`.
- **Redact-then-truncate ordering**: the truncation cut can never split a `[REDACTED]` marker mid-string. Pinned by `TestPrepareCapturedContent_RedactBeforeTruncate`.
- **`*bool` nullable yaml fields**: an operator who writes `tool_args: false` explicitly overrides env; omitting the field falls through to env. Pinned by `TestResolveAuditPayloadCapture_YAMLNilDoesNotClobberEnv`.
- **`Redact=true` default at every layer**: env's `FromEnv()` initializes Redact=true so flipping a capture flag on without touching Redact keeps the safer posture. Pinned by `TestAuditPayloadCaptureFromEnv_Defaults`.

## Schema impact

`tool_exec` grows two opt-in fields: `args` (on phase=start when `ToolArgs` is on) and `result` (on phase=end when `ToolResult` is on). `llm_call` grows `prompt_messages` + `prompt_messages_count` and `completion_text`. All four use `omitempty`; deployments without capture flags keep emitting the pre-capture JSON shape verbatim. `schema_version` is NOT bumped — additive optional fields are schema-compatible per the documented policy.

## Out of scope (deferred)

- **Per-tool capture filtering** (e.g. "capture only for `cli_execute`, not for `web_search`"). All-or-nothing per agent run; the operator-surface complexity isn't justified until customers ask.
- **Capture rotation / sampling** (emit raw payloads on 1% of events). Same reasoning.
- **Encrypted-at-rest captured payloads** — operators route the FWS-7 sidecar audit socket to an encrypted sink. Not a Forge-side feature.

## Test plan

- [x] `golangci-lint run ./forge-core/... ./forge-cli/...` — 0 issues
- [x] `gofmt -w` across all modules
- [x] `go test ./...` in `forge-core/` and `forge-cli/` — all green
- [x] New unit tests pin: env defaults + per-flag parsing, REDACT escape hatch, MAX_BYTES single-knob propagation, redact scrub across vendor token shapes, redact-before-truncate ordering, default-posture schema golden, capture-on schema with secret → `[REDACTED]`, REDACT=false leaves raw token, large-output truncation marker carries original size.
- [ ] Manual smoke: set `FORGE_AUDIT_CAPTURE_TOOL_RESULT=true` on `forge run`, exercise a tool, confirm `tool_exec phase=end` carries a `result` field with redact + truncate behavior matching the docs.