### PR TITLE
feat(guardrails): fail-loud DB mode + seed/validate helpers + exclusivity warning (closes #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@
 
 ### Added
 
+- **Guardrails DB mode hardening: fail-loud + seed helpers + exclusivity
+  warning (issue #166).** Three quiet behaviors in the
+  `BuildGuardrailChecker` resolution ladder that mismatched what
+  operators expect from a "production-grade guardrails" deploy are now
+  addressable from the operator surface:
+  - New `FORGE_GUARDRAILS_DB_REQUIRED=true` env var: when DB mode is
+    selected (`FORGE_GUARDRAILS_DB` set) and the Mongo connect fails,
+    the runner logs an Error and returns a non-nil startup error
+    instead of silently downgrading to file mode or defaults. Off by
+    default for back-compat; recommended ON for platform deployments
+    where DB-mode guardrails are security-critical. `BuildGuardrailChecker`
+    now returns `(GuardrailChecker, error)` so the runner can propagate
+    the failure as a non-zero exit.
+  - New `forge guardrails seed-defaults` subcommand: prints
+    `DefaultStructuredGuardrails` as JSON suitable for piping into
+    MongoDB. Round-trips through `models.StructuredGuardrails` so the
+    output is library-consumable verbatim. Closes the
+    "DB mode bypasses built-in defaults" footgun — operators have a
+    one-line baseline seed.
+  - New `forge guardrails validate-db` subcommand: connects to
+    `FORGE_GUARDRAILS_DB`, fetches the agent's `AgentConfig` document,
+    and reports on baseline coverage (PII config, jailbreak / prompt-
+    injection / command-injection thresholds, secret-pattern rule count,
+    core gate enablement). Warns when fewer than 5 secret-pattern rules
+    are present or PII config is missing. Exits non-zero on missing
+    document so CI / deployment hooks can fail rollout.
+  - One-shot startup warning when both `FORGE_GUARDRAILS_DB` is set
+    AND a `guardrails.json` is present in the workdir. Repo readers
+    previously saw the file and assumed it was active; in DB-mode
+    deploys it was dead config that drifted. The warning fires through
+    the ops logger (not the audit stream) exactly once per process,
+    pointing at the specific path being ignored.
+  - DB connect timeout in `NewDBGuardrailEngine` trimmed from 10s to
+    3s — short enough that a misconfigured URI surfaces during startup,
+    long enough to absorb DNS jitter + TLS on a healthy cluster.
+  - Pinned by `TestBuildGuardrailChecker_{DBRequired_FailsLoudOnUnreachable,
+    DBUnreachable_FallsBackByDefault,DBRequiredAcceptsForgivingParse,
+    DBAndFile_WarnsOnce,DBOnly_NoFile_NoExclusivityWarn,
+    FileOnly_NoWarn,HonorsCustomGuardrailsPath}`,
+    `TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel`,
+    `TestScoreAgentConfig_{FullDefaultsHaveNoWarnings,SnakeCaseCompat,
+    EmptyDocFlagsEverything,FewerThan5SecretRulesWarns}`,
+    `TestExtractCustomRules_DefensiveOnShape`.
+
 - **Audit payload capture: operator surface + consolidated redact pass
   (issue #163).** FWS-8 raw-payload capture (`AuditPayloadCapture`) is
   now configurable from `forge.yaml` and `FORGE_AUDIT_CAPTURE_*` env

--- a/docs/security/guardrails.md
+++ b/docs/security/guardrails.md
@@ -22,7 +22,7 @@ Guardrails are implemented as a `GuardrailChecker` interface in forge-core, with
 | # | Trigger | Outcome | What happens to lower-priority sources |
 |---|---|---|---|
 | 1 | `FORGE_GUARDRAILS_DB` set **and** MongoDB connect + ping succeed | **DB mode** — config loaded per-request from the `AgentConfig` collection in the `Initializ` database, keyed by `(FORGE_AGENT_ID, FORGE_ORG_ID)`. Audit records written back to MongoDB (`EnableAudit: true`). | `guardrails.json` is ignored at runtime even if present in the image. |
-| 2 | `FORGE_GUARDRAILS_DB` set **but** connect or ping fails (10-second timeout) | Warns `failed to connect guardrails DB, falling back to file` and continues to row 3. | Falls through. |
+| 2 | `FORGE_GUARDRAILS_DB` set **but** connect or ping fails (3-second timeout) | Default: warns `failed to connect guardrails DB, falling back to file` and continues to row 3. With `FORGE_GUARDRAILS_DB_REQUIRED=true`: logs an Error and returns a non-nil startup error — the agent refuses to serve. See [Fail-loud mode](#fail-loud-mode). | Falls through (default) / no fallback (REQUIRED). |
 | 3 | `guardrails.json` exists at `<workDir>/<cfg.GuardrailsPath \|\| "guardrails.json">` and parses | **File mode** — config is the parsed `StructuredGuardrails`. | Built-in defaults discarded. |
 | 4 | File missing, unreadable, or invalid JSON | **Built-in defaults** — bundled PII (email/phone/SSN/credit-card) + jailbreak/prompt-injection/command-injection detection + 11 secret-pattern regexes (see [Default Secret Patterns](#default-secret-patterns)). | N/A — this is the floor. |
 | 5 | Engine construction itself errors (after picking 3 or 4) | Warns `failed to create file guardrail engine, using noop` and installs a `NoopGuardrailChecker`. | No checks run; messages pass through unmodified. |
@@ -30,7 +30,7 @@ Guardrails are implemented as a `GuardrailChecker` interface in forge-core, with
 Notable consequences of the order:
 
 - **MongoDB mode bypasses `guardrails.json` entirely** — the file still gets baked into `/app/guardrails.json` by the build, but the runner never opens it when `FORGE_GUARDRAILS_DB` is set. You can flip an agent between modes at runtime by setting / unsetting the env var without rebuilding.
-- **DB failure is non-fatal.** A misconfigured URI or transient network issue drops to file mode with a warning, not a hard exit. If you need a hard requirement, monitor the warning in your log pipeline (`failed to connect guardrails DB, falling back to file`).
+- **DB failure is non-fatal by default.** A misconfigured URI or transient network issue drops to file mode with a warning, not a hard exit. Set `FORGE_GUARDRAILS_DB_REQUIRED=true` to flip this — recommended for production. See [Fail-loud mode](#fail-loud-mode).
 - **DB mode requires `FORGE_ORG_ID`** to scope the `AgentConfig` lookup. Forgetting to set it usually surfaces as the library returning no config and decisions defaulting through; check that org ID is populated alongside the URI.
 - **`cfg.GuardrailsPath`** in `forge.yaml` overrides the default `"guardrails.json"` filename for file mode only — it has no effect in DB mode.
 - **Audit sinks differ.** DB mode writes via the library's `EnableAudit` path into MongoDB. File mode emits Forge's normal `guardrail_check` audit events through the configured audit sinks (see [Audit Events](#audit-events)).
@@ -359,13 +359,66 @@ export FORGE_ORG_ID="my-org"
 forge run
 ```
 
-The library queries `AgentConfig` with `{agent_id, org_id}` to load the `StructuredGuardrails` config. If the DB is unreachable, it falls back to file mode.
+The library queries `AgentConfig` with `{agent_id, org_id}` to load the `StructuredGuardrails` config.
 
-| Environment Variable | Description |
-|---------------------|-------------|
-| `FORGE_GUARDRAILS_DB` | MongoDB connection URI |
-| `FORGE_AGENT_ID` | Agent identifier (falls back to `agent_id` in `forge.yaml`) |
-| `FORGE_ORG_ID` | Organization identifier |
+| Environment Variable | Default | Description |
+|---|---|---|
+| `FORGE_GUARDRAILS_DB` | unset | MongoDB connection URI. Setting this activates DB mode. |
+| `FORGE_GUARDRAILS_DB_REQUIRED` | `false` | When `true`, an unreachable DB at startup makes the agent refuse to serve instead of silently downgrading. **Recommended for production.** See [Fail-loud mode](#fail-loud-mode). |
+| `FORGE_AGENT_ID` | from `forge.yaml` `agent_id` | Agent identifier the library uses to look up the `AgentConfig` document. |
+| `FORGE_ORG_ID` | unset | Organization identifier scoping the lookup. |
+
+### Why DB mode is strictly more dangerous than file mode
+
+This is the most common operator footgun in the guardrails subsystem and deserves an explicit callout.
+
+The runtime selection is mutually exclusive (see the [resolution ladder](#source-precedence) above) — there is no merging. When `FORGE_GUARDRAILS_DB` is set:
+
+- The operator's MongoDB `AgentConfig` document is the **only** source of policy.
+- The built-in `DefaultStructuredGuardrails` (11 vendor-secret patterns, PII config, jailbreak / prompt-injection / command-injection thresholds) is **NOT** applied. It is only a fallback in file mode when `guardrails.json` is absent.
+- Any `guardrails.json` checked into the repo is **silently ignored** at runtime. Repo readers see the file and assume it's active; it isn't.
+
+The consequence: a DB-mode deploy with an empty or incomplete `AgentConfig` document is **strictly less protective** than a file-mode deploy with no file at all. A clean default deploy gets the built-in baseline; a DB-mode deploy that forgot to seed PII detection or didn't load the secret-pattern rules has no baseline at all.
+
+Operators MUST seed `AgentConfig` with the equivalent of `DefaultStructuredGuardrails`. Forge ships a CLI helper that produces ready-to-pipe JSON:
+
+```bash
+forge guardrails seed-defaults > defaults.json
+# load into MongoDB, e.g.:
+mongoimport --uri "$FORGE_GUARDRAILS_DB" \
+  --db Initializ --collection AgentConfig \
+  --file <(jq --arg id "$FORGE_AGENT_ID" '. + {agent_id:$id}' defaults.json)
+```
+
+After seeding, validate coverage:
+
+```bash
+forge guardrails validate-db
+```
+
+The validator connects to `FORGE_GUARDRAILS_DB`, fetches the agent's document, and reports on baseline coverage. Warnings surface when fewer than 5 secret-pattern rules are present, PII config is missing, or core gates are disabled — the common signs of an incomplete seed. Exits non-zero when no document exists at all, so CI / deployment hooks can fail the rollout.
+
+### Fail-loud mode
+
+When DB mode is security-critical (the platform deploy default), set `FORGE_GUARDRAILS_DB_REQUIRED=true`. The agent's startup behavior on an unreachable Mongo flips:
+
+| `FORGE_GUARDRAILS_DB_REQUIRED` | DB unreachable at startup |
+|---|---|
+| unset / `false` | Logs a warning, falls through to file mode (current default — back-compat). |
+| `true` | Logs an error, returns a non-nil error from runner startup, the agent process exits non-zero. |
+
+The fail-loud posture matches the FWS-7 audit-sink and security-policy expectations: a misconfigured Mongo URI or a transient Mongo outage at startup MUST NOT silently downgrade protection. Platform deployments running guardrails under DB mode should set this in the deployment manifest by default; one-off `FORGE_GUARDRAILS_DB=mongodb://...` dev usage without the flag keeps the warn-and-fallback behavior.
+
+A startup warning also fires (exactly once) when both `FORGE_GUARDRAILS_DB` is set AND a `guardrails.json` is present in the workdir, pointing at the specific file being ignored. Remove the file or unset the env var to avoid drift.
+
+### Helper subcommands
+
+| Command | Purpose |
+|---|---|
+| `forge guardrails seed-defaults` | Print `DefaultStructuredGuardrails` as JSON suitable for MongoDB seeding. Round-trips through `models.StructuredGuardrails` so the output is library-consumable verbatim. |
+| `forge guardrails validate-db` | Connect to `FORGE_GUARDRAILS_DB`, fetch the agent's `AgentConfig`, and report on baseline coverage (PII config, security thresholds, secret-pattern rule count, gate enablement). Exits non-zero on missing document. |
+
+Both commands honor the `FORGE_GUARDRAILS_DB` / `FORGE_AGENT_ID` env vars and accept `--mongo-uri` / `--agent-id` flag overrides for ad-hoc invocations.
 
 ## Runtime
 

--- a/forge-cli/cmd/guardrails.go
+++ b/forge-cli/cmd/guardrails.go
@@ -1,0 +1,341 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/initializ/forge/forge-cli/runtime"
+)
+
+// guardrailsCmd groups the operator-facing commands for the
+// MongoDB-backed guardrails subsystem. The runtime selection between
+// DB mode and file mode is documented in docs/security/guardrails.md;
+// these subcommands help operators seed a fresh AgentConfig and
+// validate an existing one. Issue #166.
+var guardrailsCmd = &cobra.Command{
+	Use:   "guardrails",
+	Short: "Manage guardrails configuration (DB mode operator helpers)",
+	Long: `Operator helpers for the MongoDB-backed guardrails subsystem.
+
+Forge can run guardrails in two mutually-exclusive modes:
+
+  - File mode (default): reads guardrails.json from the agent's
+    workdir; falls back to built-in DefaultStructuredGuardrails when
+    the file is absent.
+  - DB mode (FORGE_GUARDRAILS_DB set): loads AgentConfig from
+    MongoDB. The library reads the document on every gate call.
+
+In DB mode the operator's MongoDB seed is the ONLY source of policy —
+the built-in DefaultStructuredGuardrails is NOT applied. An incomplete
+seed (missing PII config, no secret-pattern rules, no jailbreak
+threshold) leaves the agent strictly less protected than a file-mode
+deploy with no file at all. These subcommands help operators avoid
+that footgun.
+
+See docs/security/guardrails.md for the full resolution ladder.`,
+}
+
+var guardrailsSeedDefaultsCmd = &cobra.Command{
+	Use:   "seed-defaults",
+	Short: "Print DefaultStructuredGuardrails as JSON suitable for MongoDB seeding",
+	Long: `Print the built-in DefaultStructuredGuardrails as pretty-printed JSON.
+
+The output matches the library's models.StructuredGuardrails schema
+and is suitable for loading directly into MongoDB as the agent's
+AgentConfig.structured_guardrails document. Pipe to a file and edit
+before seeding if you want to tweak thresholds or add rules.
+
+  forge guardrails seed-defaults > agent-config.json
+
+The built-in defaults cover 11 vendor-secret patterns (Anthropic /
+OpenAI / GitHub / AWS / Slack / Telegram tokens, private-key PEM
+blocks), four PII categories (email / phone / SSN / credit card), and
+jailbreak / prompt-injection / command-injection thresholds. DB-mode
+deploys SHOULD use this as their seed baseline; an empty AgentConfig
+document is strictly less protected than file mode with no file.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		sg := runtime.DefaultStructuredGuardrails()
+		out, err := json.MarshalIndent(sg, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling defaults: %w", err)
+		}
+		// Trailing newline so shell redirection produces a
+		// well-formed file. cobra writes to OutOrStdout so tests
+		// can capture stdout via SetOut.
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+// guardrailsValidateDBOpts holds the resolved connection settings for
+// `forge guardrails validate-db`. Defaults pulled from env so a CI
+// run with the deployment env set "just works."
+type guardrailsValidateDBOpts struct {
+	mongoURI  string
+	agentID   string
+	dbName    string
+	colName   string
+	timeoutMs int
+}
+
+var validateDBOpts guardrailsValidateDBOpts
+
+var guardrailsValidateDBCmd = &cobra.Command{
+	Use:   "validate-db",
+	Short: "Connect to FORGE_GUARDRAILS_DB and report on the agent's seeded config",
+	Long: `Connect to MongoDB and inspect the agent's AgentConfig document.
+
+Reports on baseline coverage:
+  - PII config present and enabled
+  - JailbreakDetection / PromptInjection / CommandInjection thresholds
+  - Number of custom secret-pattern rules
+  - Gate config (input / output / tool_call gates enabled)
+
+Warns when coverage is below the built-in defaults (the threshold for
+"reasonably configured" is fewer than 5 secret-pattern rules, missing
+PII config, or missing jailbreak detection — these are common signs
+of an incomplete or stale seed).
+
+Connection settings default to env:
+  --mongo-uri  $FORGE_GUARDRAILS_DB
+  --agent-id   $FORGE_AGENT_ID
+  --db         Initializ
+  --collection AgentConfig
+
+Exits with status 1 when the agent has no document at all (the most
+common deploy error) so CI / deployment hooks can fail the rollout.`,
+	RunE: runGuardrailsValidateDB,
+}
+
+func init() {
+	guardrailsCmd.AddCommand(guardrailsSeedDefaultsCmd)
+	guardrailsCmd.AddCommand(guardrailsValidateDBCmd)
+	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.mongoURI, "mongo-uri", "",
+		"MongoDB URI (default: $FORGE_GUARDRAILS_DB)")
+	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.agentID, "agent-id", "",
+		"agent_id to look up (default: $FORGE_AGENT_ID)")
+	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.dbName, "db", "Initializ",
+		"MongoDB database name")
+	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.colName, "collection", "AgentConfig",
+		"AgentConfig collection name")
+	guardrailsValidateDBCmd.Flags().IntVar(&validateDBOpts.timeoutMs, "timeout-ms", 5000,
+		"connect timeout in milliseconds")
+}
+
+// runGuardrailsValidateDB is the validate-db handler. Returning an
+// error from RunE makes cobra exit non-zero; the CI signal is the
+// whole point of the command.
+func runGuardrailsValidateDB(cmd *cobra.Command, _ []string) error {
+	uri := validateDBOpts.mongoURI
+	if uri == "" {
+		uri = os.Getenv(runtime.EnvGuardrailsDB)
+	}
+	if uri == "" {
+		return errors.New("no MongoDB URI: pass --mongo-uri or set FORGE_GUARDRAILS_DB")
+	}
+	agentID := validateDBOpts.agentID
+	if agentID == "" {
+		agentID = os.Getenv("FORGE_AGENT_ID")
+	}
+	if agentID == "" {
+		return errors.New("no agent_id: pass --agent-id or set FORGE_AGENT_ID")
+	}
+
+	timeout := time.Duration(validateDBOpts.timeoutMs) * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		return fmt.Errorf("mongo connect: %w", err)
+	}
+	defer func() { _ = client.Disconnect(context.Background()) }()
+
+	if err := client.Ping(ctx, nil); err != nil {
+		return fmt.Errorf("mongo ping: %w", err)
+	}
+
+	col := client.Database(validateDBOpts.dbName).Collection(validateDBOpts.colName)
+	var doc bson.M
+	if err := col.FindOne(ctx, bson.M{"agent_id": agentID}).Decode(&doc); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return fmt.Errorf("no AgentConfig document for agent_id=%q in %s.%s; seed it via `forge guardrails seed-defaults | mongoimport`",
+				agentID, validateDBOpts.dbName, validateDBOpts.colName)
+		}
+		return fmt.Errorf("fetching AgentConfig: %w", err)
+	}
+
+	report := scoreAgentConfig(doc)
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "AgentConfig for %q in %s.%s\n", agentID, validateDBOpts.dbName, validateDBOpts.colName)
+	for _, line := range report.lines {
+		_, _ = fmt.Fprintln(out, "  "+line)
+	}
+	if len(report.warnings) > 0 {
+		_, _ = fmt.Fprintln(out, "\nWARNINGS:")
+		for _, w := range report.warnings {
+			_, _ = fmt.Fprintln(out, "  - "+w)
+		}
+		_, _ = fmt.Fprintln(out, "\nReseed with `forge guardrails seed-defaults` to restore baseline coverage.")
+	} else {
+		_, _ = fmt.Fprintln(out, "\nOK — baseline coverage matches DefaultStructuredGuardrails.")
+	}
+	return nil
+}
+
+// agentConfigReport summarizes a validate-db inspection in a form
+// the test can assert on cleanly. Lines are the human-readable
+// summary; warnings are the actionable below-baseline findings.
+type agentConfigReport struct {
+	lines    []string
+	warnings []string
+}
+
+// scoreAgentConfig walks the BSON document and reports coverage. The
+// "fewer than 5 secret rules / missing PII / missing jailbreak"
+// threshold is the issue #166 baseline — anything below that is
+// strictly less protective than the built-in defaults and the
+// operator probably didn't intend it.
+//
+// Forgiving on shape: missing nested objects are reported as missing
+// (not an error). The library's struct tags use camelCase, but
+// historical seeds in the wild may use snake_case (older library
+// versions or hand-written seeds based on docs). lookupMap accepts
+// either spelling so the validator works against both shapes.
+func scoreAgentConfig(doc bson.M) agentConfigReport {
+	r := agentConfigReport{}
+
+	// Custom rules — secret-pattern coverage.
+	rules := extractCustomRules(doc)
+	r.lines = append(r.lines, fmt.Sprintf("custom_rules: %d rule(s)", len(rules)))
+	secretRules := 0
+	for _, name := range rules {
+		// Same convention DefaultStructuredGuardrails uses.
+		if len(name) >= 6 && name[:6] == "secret" {
+			secretRules++
+		}
+	}
+	r.lines = append(r.lines, fmt.Sprintf("secret_pattern_rules: %d (default seed ships 11)", secretRules))
+	if secretRules < 5 {
+		r.warnings = append(r.warnings,
+			fmt.Sprintf("fewer than 5 secret-pattern rules (%d found) — vendor token leakage in outbound responses likely unmasked", secretRules))
+	}
+
+	// PII config.
+	if pii, ok := lookupMap(doc, "pii"); ok {
+		enabled, _ := pii["enabled"].(bool)
+		r.lines = append(r.lines, fmt.Sprintf("pii.enabled: %v", enabled))
+		if !enabled {
+			r.warnings = append(r.warnings, "PII config present but disabled — email / phone / SSN / credit card in prompts will not be masked")
+		}
+	} else {
+		r.lines = append(r.lines, "pii: <missing>")
+		r.warnings = append(r.warnings, "no PII config — PII in prompts will not be masked")
+	}
+
+	// Security thresholds. Walk both camelCase (library struct
+	// tags) and snake_case (legacy seeds).
+	if sec, ok := lookupMap(doc, "security"); ok {
+		for _, names := range [][]string{
+			{"jailbreakDetection", "jailbreak_detection"},
+			{"promptInjection", "prompt_injection"},
+			{"commandInjection", "command_injection"},
+		} {
+			label := names[1]
+			t, ok := lookupMap(sec, names...)
+			if ok {
+				enabled, _ := t["enabled"].(bool)
+				r.lines = append(r.lines, fmt.Sprintf("security.%s.enabled: %v", label, enabled))
+				if !enabled {
+					r.warnings = append(r.warnings, fmt.Sprintf("security.%s present but disabled", label))
+				}
+			} else {
+				r.lines = append(r.lines, fmt.Sprintf("security.%s: <missing>", label))
+				r.warnings = append(r.warnings, fmt.Sprintf("security.%s missing — this attack class is not screened", label))
+			}
+		}
+	} else {
+		r.lines = append(r.lines, "security: <missing>")
+		r.warnings = append(r.warnings,
+			"no security config — jailbreak / prompt-injection / command-injection detection is OFF")
+	}
+
+	// Gate config.
+	if gc, ok := lookupMap(doc, "gateConfig", "gate_config"); ok {
+		input, _ := lookupBool(gc, "inputGate", "input_gate")
+		output, _ := lookupBool(gc, "outputGate", "output_gate")
+		toolCall, _ := lookupBool(gc, "toolCallGate", "tool_call_gate")
+		r.lines = append(r.lines, fmt.Sprintf("gates: input=%v output=%v tool_call=%v", input, output, toolCall))
+		if !input || !output || !toolCall {
+			r.warnings = append(r.warnings,
+				"one or more core gates disabled (input / output / tool_call) — partial enforcement")
+		}
+	} else {
+		r.lines = append(r.lines, "gate_config: <missing>")
+		r.warnings = append(r.warnings, "no gate_config — falling back to library defaults")
+	}
+
+	return r
+}
+
+// extractCustomRules pulls the rule ids out of the
+// `customRules.rules` array (with snake_case fallback), defensive
+// against shape drift. Returns empty when the path is absent or any
+// node along the way is the wrong type.
+func extractCustomRules(doc bson.M) []string {
+	cr, ok := lookupMap(doc, "customRules", "custom_rules")
+	if !ok {
+		return nil
+	}
+	rawRules, ok := cr["rules"].(bson.A)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(rawRules))
+	for _, r := range rawRules {
+		rule, ok := r.(bson.M)
+		if !ok {
+			continue
+		}
+		if id, ok := rule["id"].(string); ok {
+			out = append(out, id)
+			continue
+		}
+		if name, ok := rule["name"].(string); ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// lookupMap returns the first BSON map child of doc that matches one
+// of the supplied keys. Used to tolerate both camelCase (library
+// struct tags) and snake_case (older seed conventions) without
+// duplicating each lookup.
+func lookupMap(doc bson.M, keys ...string) (bson.M, bool) {
+	for _, k := range keys {
+		if v, ok := doc[k].(bson.M); ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// lookupBool is the bool-leaf counterpart of lookupMap.
+func lookupBool(doc bson.M, keys ...string) (bool, bool) {
+	for _, k := range keys {
+		if v, ok := doc[k].(bool); ok {
+			return v, true
+		}
+	}
+	return false, false
+}

--- a/forge-cli/cmd/guardrails_test.go
+++ b/forge-cli/cmd/guardrails_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/initializ/guardrails/models"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel is the
+// canary the issue calls out: pipe `forge guardrails seed-defaults`
+// into a JSON consumer, and the JSON MUST unmarshal into the
+// library's models.StructuredGuardrails. If we ever drift from the
+// library schema this test fails in red. Verification step 4 of #166.
+func TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := guardrailsSeedDefaultsCmd
+	cmd.SetOut(&buf)
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("seed-defaults: %v", err)
+	}
+	out := buf.String()
+	// Library JSON tags are camelCase (customRules, jailbreakDetection,
+	// promptInjection, …). The round-trip assertion below is the
+	// strict invariant; this substring check is just a fast canary
+	// against a totally-empty marshal.
+	if !strings.Contains(out, "customRules") {
+		t.Errorf("seed-defaults output missing customRules section; got:\n%s", out)
+	}
+
+	var sg models.StructuredGuardrails
+	if err := json.Unmarshal(buf.Bytes(), &sg); err != nil {
+		t.Fatalf("seed-defaults output does not round-trip through models.StructuredGuardrails: %v\noutput:\n%s",
+			err, out)
+	}
+	// Sanity: the defaults must carry the canonical baseline. Below
+	// 5 secret-pattern rules would mean the upstream defaults
+	// regressed and the issue #166 baseline check would break too.
+	if sg.CustomRules == nil || len(sg.CustomRules.Rules) < 5 {
+		t.Errorf("seed-defaults dropped below baseline rule count; got %d", func() int {
+			if sg.CustomRules == nil {
+				return 0
+			}
+			return len(sg.CustomRules.Rules)
+		}())
+	}
+	if sg.PII == nil || !sg.PII.Enabled {
+		t.Errorf("seed-defaults missing or-disabled PII config: %+v", sg.PII)
+	}
+}
+
+// TestScoreAgentConfig_FullDefaultsHaveNoWarnings is the inverse-side
+// test: a doc constructed from DefaultStructuredGuardrails (via the
+// seed-defaults JSON round-tripped through BSON) must produce zero
+// warnings from scoreAgentConfig. If a future schema drift means the
+// validate-db pass starts flagging the canonical seed, this test
+// catches it before operators see false positives.
+//
+// Uses the camelCase key shape that matches the library struct tags
+// (what production MongoDB documents actually carry). The
+// snake_case fallback is exercised by TestScoreAgentConfig_SnakeCaseCompat
+// below.
+func TestScoreAgentConfig_FullDefaultsHaveNoWarnings(t *testing.T) {
+	doc := bson.M{
+		"customRules": bson.M{
+			"rules": bson.A{
+				bson.M{"id": "secret_anthropic", "name": "Anthropic API Key"},
+				bson.M{"id": "secret_openai", "name": "OpenAI"},
+				bson.M{"id": "secret_github_pat", "name": "GitHub PAT"},
+				bson.M{"id": "secret_aws", "name": "AWS Access Key"},
+				bson.M{"id": "secret_slack_bot", "name": "Slack Bot Token"},
+				bson.M{"id": "secret_private_key", "name": "Private Key"},
+			},
+		},
+		"pii": bson.M{"enabled": true},
+		"security": bson.M{
+			"jailbreakDetection": bson.M{"enabled": true},
+			"promptInjection":    bson.M{"enabled": true},
+			"commandInjection":   bson.M{"enabled": true},
+		},
+		"gateConfig": bson.M{
+			"inputGate":    true,
+			"outputGate":   true,
+			"toolCallGate": true,
+		},
+	}
+	r := scoreAgentConfig(doc)
+	if len(r.warnings) != 0 {
+		t.Errorf("full-defaults doc produced warnings: %v", r.warnings)
+	}
+}
+
+// TestScoreAgentConfig_SnakeCaseCompat confirms the validator also
+// accepts the snake_case spelling — legacy seeds and hand-written
+// configs based on old docs use that convention. Same input as the
+// camelCase case above, no warnings expected.
+func TestScoreAgentConfig_SnakeCaseCompat(t *testing.T) {
+	doc := bson.M{
+		"custom_rules": bson.M{
+			"rules": bson.A{
+				bson.M{"id": "secret_a"}, bson.M{"id": "secret_b"},
+				bson.M{"id": "secret_c"}, bson.M{"id": "secret_d"},
+				bson.M{"id": "secret_e"},
+			},
+		},
+		"pii": bson.M{"enabled": true},
+		"security": bson.M{
+			"jailbreak_detection": bson.M{"enabled": true},
+			"prompt_injection":    bson.M{"enabled": true},
+			"command_injection":   bson.M{"enabled": true},
+		},
+		"gate_config": bson.M{
+			"input_gate":     true,
+			"output_gate":    true,
+			"tool_call_gate": true,
+		},
+	}
+	r := scoreAgentConfig(doc)
+	if len(r.warnings) != 0 {
+		t.Errorf("snake_case-shaped doc produced warnings: %v", r.warnings)
+	}
+}
+
+// TestScoreAgentConfig_EmptyDocFlagsEverything is the operator-error
+// canary: an empty AgentConfig document (or one missing all the
+// baseline blocks) must flag every coverage gap the issue documents.
+// This is the most common deploy error — a developer creates an
+// AgentConfig with just an agent_id field and assumes the library
+// applies defaults. It doesn't.
+func TestScoreAgentConfig_EmptyDocFlagsEverything(t *testing.T) {
+	r := scoreAgentConfig(bson.M{})
+	wantWarns := []string{
+		"fewer than 5 secret-pattern rules",
+		"no PII config",
+		"no security config",
+		"no gate_config",
+	}
+	for _, want := range wantWarns {
+		found := false
+		for _, w := range r.warnings {
+			if strings.Contains(w, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected warning containing %q; got warnings=%v", want, r.warnings)
+		}
+	}
+}
+
+// TestScoreAgentConfig_FewerThan5SecretRulesWarns pins the explicit
+// threshold the issue calls out: a doc with 4 secret-pattern rules
+// (one below baseline) MUST warn about secret-pattern coverage, but
+// nothing else if PII / security / gates are otherwise healthy.
+func TestScoreAgentConfig_FewerThan5SecretRulesWarns(t *testing.T) {
+	doc := bson.M{
+		"customRules": bson.M{
+			"rules": bson.A{
+				bson.M{"id": "secret_one"},
+				bson.M{"id": "secret_two"},
+				bson.M{"id": "secret_three"},
+				bson.M{"id": "secret_four"},
+			},
+		},
+		"pii": bson.M{"enabled": true},
+		"security": bson.M{
+			"jailbreakDetection": bson.M{"enabled": true},
+			"promptInjection":    bson.M{"enabled": true},
+			"commandInjection":   bson.M{"enabled": true},
+		},
+		"gateConfig": bson.M{
+			"inputGate":    true,
+			"outputGate":   true,
+			"toolCallGate": true,
+		},
+	}
+	r := scoreAgentConfig(doc)
+	if len(r.warnings) != 1 {
+		t.Errorf("expected exactly 1 warning (secret-pattern coverage); got %d: %v",
+			len(r.warnings), r.warnings)
+	}
+	if len(r.warnings) > 0 && !strings.Contains(r.warnings[0], "secret-pattern") {
+		t.Errorf("warning should be about secret-pattern coverage; got %q", r.warnings[0])
+	}
+}
+
+// TestExtractCustomRules_DefensiveOnShape walks the BSON-shape edge
+// cases scoreAgentConfig must survive: missing custom_rules,
+// custom_rules present but rules array wrong type, individual rule
+// entries missing id, etc. The function MUST never panic and MUST
+// fall back to an empty result so the warning surfaces correctly.
+func TestExtractCustomRules_DefensiveOnShape(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  bson.M
+		want int
+	}{
+		{"absent customRules", bson.M{}, 0},
+		{"customRules not a map", bson.M{"customRules": "string"}, 0},
+		{"rules not an array", bson.M{"customRules": bson.M{"rules": "oops"}}, 0},
+		{"rule missing id", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{}}}}, 0},
+		{"rule has id camelCase", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{"id": "secret_x"}}}}, 1},
+		{"rule has id snake_case fallback", bson.M{"custom_rules": bson.M{"rules": bson.A{bson.M{"id": "secret_x"}}}}, 1},
+		{"rule has name fallback", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{"name": "X"}}}}, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractCustomRules(c.doc)
+			if len(got) != c.want {
+				t.Errorf("extractCustomRules(%+v) = %v, want length %d", c.doc, got, c.want)
+			}
+		})
+	}
+}

--- a/forge-cli/cmd/root.go
+++ b/forge-cli/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	rootCmd.AddCommand(uiCmd)
 	rootCmd.AddCommand(mcpCmd)
 	rootCmd.AddCommand(authCmd)
+	rootCmd.AddCommand(guardrailsCmd)
 }
 
 // SetVersionInfo sets the version and commit for display.

--- a/forge-cli/runtime/guardrails_engine.go
+++ b/forge-cli/runtime/guardrails_engine.go
@@ -76,8 +76,15 @@ func NewFileGuardrailEngine(sg *models.StructuredGuardrails, enforce bool, logge
 
 // NewDBGuardrailEngine creates a guardrail engine backed by MongoDB.
 // Config is loaded from the AgentConfig collection; audit logging is enabled.
+//
+// Connect timeout is 3s. Long enough to absorb DNS jitter and a slow
+// TLS handshake on a healthy cluster, short enough that a
+// misconfigured URI or a downed Mongo surfaces during startup rather
+// than holding up the agent process. Issue #166: shorter timeout
+// also makes the fail-loud REQUIRED-mode path surface in seconds,
+// not tens of seconds.
 func NewDBGuardrailEngine(mongoURI, agentID, orgID string, enforce bool, logger coreruntime.Logger) (*LibraryGuardrailEngine, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))

--- a/forge-cli/runtime/guardrails_engine_test.go
+++ b/forge-cli/runtime/guardrails_engine_test.go
@@ -109,7 +109,10 @@ func TestFileGuardrailEngine_CheckToolOutput(t *testing.T) {
 // TestBuildGuardrailChecker_FileMode tests the builder with file-based config.
 func TestBuildGuardrailChecker_FileMode(t *testing.T) {
 	logger := &grTestLogger{}
-	checker := BuildGuardrailChecker(nil, "/nonexistent", false, logger, nil, GuardrailAuditConfig{}, observability.TracingConfig{})
+	checker, err := BuildGuardrailChecker(nil, "/nonexistent", false, logger, nil, GuardrailAuditConfig{}, observability.TracingConfig{})
+	if err != nil {
+		t.Fatalf("BuildGuardrailChecker default path should not error; got %v", err)
+	}
 	if checker == nil {
 		t.Fatal("BuildGuardrailChecker should return a non-nil checker")
 	}

--- a/forge-cli/runtime/guardrails_loader.go
+++ b/forge-cli/runtime/guardrails_loader.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 
 	"github.com/initializ/guardrails/models"
 
@@ -13,6 +15,31 @@ import (
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
 	"github.com/initializ/forge/forge-core/types"
 )
+
+// Environment variable names for guardrails resolution hardening
+// (issue #166). Mirrors the FORGE_* convention used elsewhere in the
+// security subsystem.
+const (
+	// EnvGuardrailsDB is the existing MongoDB URI selector that
+	// activates DB mode. Documented here for grep-ability — the
+	// loader still reads the raw string at the FORGE_GUARDRAILS_DB
+	// callsite below.
+	EnvGuardrailsDB = "FORGE_GUARDRAILS_DB"
+	// EnvGuardrailsDBRequired flips the silent-fallback to a
+	// startup-time abort when DB mode is selected but Mongo is
+	// unreachable. Off by default (back-compat); platform deploys
+	// that consider DB mode security-critical should set this to
+	// fail loud instead of quietly downgrading to file mode or
+	// defaults.
+	EnvGuardrailsDBRequired = "FORGE_GUARDRAILS_DB_REQUIRED"
+)
+
+// dbFileExclusivityOnce guards the one-shot startup warning emitted
+// when both FORGE_GUARDRAILS_DB and a guardrails.json are present.
+// Package-scoped so the warning fires exactly once per process even
+// if BuildGuardrailChecker is called multiple times (it isn't in
+// production, but tests do). Reset in tests via resetDBFileWarning.
+var dbFileExclusivityOnce sync.Once
 
 // LoadPolicyScaffold reads policy-scaffold.json from the output directory.
 // Returns nil (no error) if the file does not exist.
@@ -50,6 +77,20 @@ func DefaultPolicyScaffold() *agentspec.PolicyScaffold {
 // redact-then-truncate pipeline the LLM-call content capture uses.
 // When auditLogger is nil the engine is silent on the audit pipeline
 // (used by tests).
+//
+// Issue #166: the function now returns an error rather than always
+// falling back to a noop checker. The non-nil-error paths are:
+//
+//   - FORGE_GUARDRAILS_DB is set, FORGE_GUARDRAILS_DB_REQUIRED is
+//     truthy, AND the Mongo connect fails. Without REQUIRED the
+//     loader still warns and falls through to file mode for
+//     back-compat (the platform deploy should set REQUIRED so a
+//     misconfigured Mongo URI fails loud at startup instead of
+//     silently downgrading to a less-protective posture).
+//
+// Other failure paths (file-engine construction error, etc.) continue
+// to log and return a NoopGuardrailChecker — they're rare and the
+// recovery path is well-understood.
 func BuildGuardrailChecker(
 	cfg *types.ForgeConfig,
 	workDir string,
@@ -58,7 +99,7 @@ func BuildGuardrailChecker(
 	auditLogger *coreruntime.AuditLogger,
 	auditCfg GuardrailAuditConfig,
 	tracingCfg observability.TracingConfig,
-) coreruntime.GuardrailChecker {
+) (coreruntime.GuardrailChecker, error) {
 	attach := func(e *LibraryGuardrailEngine) coreruntime.GuardrailChecker {
 		if auditLogger != nil {
 			e.WithAuditLogger(auditLogger, auditCfg)
@@ -67,8 +108,26 @@ func BuildGuardrailChecker(
 		return e
 	}
 
+	// One-shot exclusivity warning: when DB mode is selected AND a
+	// guardrails.json sits in the workdir, the file is silently
+	// ignored. Repo readers see a file checked in and assume it's
+	// active; in DB-mode deploys it's dead config that drifts. Issue
+	// #166. Fires through the ops logger (not the audit stream — this
+	// is a config-shape warning, not an audited event), exactly once
+	// per process via dbFileExclusivityOnce.
+	mongoURI := os.Getenv(EnvGuardrailsDB)
+	if mongoURI != "" {
+		if filePath, ok := guardrailsFilePathIfPresent(cfg, workDir); ok {
+			dbFileExclusivityOnce.Do(func() {
+				logger.Warn("guardrails: DB mode active but guardrails.json also present — the file is IGNORED. DB and file are mutually exclusive. Remove the file or unset FORGE_GUARDRAILS_DB to avoid drift.", map[string]any{
+					"file": filePath,
+				})
+			})
+		}
+	}
+
 	// DB mode: connect to MongoDB for config + audit
-	if mongoURI := os.Getenv("FORGE_GUARDRAILS_DB"); mongoURI != "" {
+	if mongoURI != "" {
 		agentID := os.Getenv("FORGE_AGENT_ID")
 		if agentID == "" && cfg != nil {
 			agentID = cfg.AgentID
@@ -79,7 +138,19 @@ func BuildGuardrailChecker(
 			logger.Info("guardrails: using MongoDB-backed config", map[string]any{
 				"agent_id": agentID,
 			})
-			return attach(engine)
+			return attach(engine), nil
+		}
+		// FAIL-LOUD path. When REQUIRED is set, the agent refuses
+		// to serve rather than quietly downgrade. Platform deploys
+		// running guardrails under DB mode should set this in the
+		// deployment manifest so a misconfigured URI or a
+		// transient Mongo outage doesn't silently downgrade
+		// protection.
+		if dbModeRequired() {
+			logger.Error("guardrails: DB mode required (FORGE_GUARDRAILS_DB_REQUIRED=true) but DB unreachable; refusing to start", map[string]any{
+				"error": err.Error(),
+			})
+			return nil, fmt.Errorf("guardrails DB required but unreachable: %w", err)
 		}
 		logger.Warn("failed to connect guardrails DB, falling back to file", map[string]any{
 			"error": err.Error(),
@@ -97,9 +168,42 @@ func BuildGuardrailChecker(
 		logger.Warn("failed to create file guardrail engine, using noop", map[string]any{
 			"error": err.Error(),
 		})
-		return &coreruntime.NoopGuardrailChecker{}
+		return &coreruntime.NoopGuardrailChecker{}, nil
 	}
-	return attach(engine)
+	return attach(engine), nil
+}
+
+// dbModeRequired reads FORGE_GUARDRAILS_DB_REQUIRED and returns true
+// when the operator has opted into fail-loud behavior. Parse failure
+// or empty value yields false (back-compat) — same forgiving posture
+// as the other guardrails env vars.
+func dbModeRequired() bool {
+	v := os.Getenv(EnvGuardrailsDBRequired)
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}
+
+// guardrailsFilePathIfPresent returns the resolved guardrails.json
+// path (relative to workDir, honoring cfg.GuardrailsPath) and a bool
+// reporting whether the file actually exists on disk. Used by the
+// exclusivity warning to give the operator an actionable message
+// pointing at the specific file that's being ignored.
+func guardrailsFilePathIfPresent(cfg *types.ForgeConfig, workDir string) (string, bool) {
+	filename := "guardrails.json"
+	if cfg != nil && cfg.GuardrailsPath != "" {
+		filename = cfg.GuardrailsPath
+	}
+	path := filepath.Join(workDir, filename)
+	if _, err := os.Stat(path); err == nil {
+		return path, true
+	}
+	return path, false
 }
 
 // LoadGuardrailsJSON reads guardrails.json from the project directory.

--- a/forge-cli/runtime/guardrails_loader_test.go
+++ b/forge-cli/runtime/guardrails_loader_test.go
@@ -1,0 +1,227 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/observability"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// resetDBFileWarning lets a test re-arm the one-shot exclusivity
+// warning between assertions. Lives only in _test.go so production
+// callers can't accidentally rearm it. Issue #166.
+func resetDBFileWarning() {
+	dbFileExclusivityOnce = sync.Once{}
+}
+
+// captureLogger records the highest-severity message emitted plus
+// every Warn/Error line so tests can assert what surfaced through
+// the ops logger (NOT the audit stream — the exclusivity warning
+// and the fail-loud abort both go through Logger, never the
+// AuditLogger).
+type captureLogger struct {
+	infos  []string
+	warns  []string
+	errors []string
+}
+
+func (l *captureLogger) Debug(msg string, _ map[string]any) {}
+func (l *captureLogger) Info(msg string, _ map[string]any)  { l.infos = append(l.infos, msg) }
+func (l *captureLogger) Warn(msg string, _ map[string]any)  { l.warns = append(l.warns, msg) }
+func (l *captureLogger) Error(msg string, _ map[string]any) { l.errors = append(l.errors, msg) }
+
+// TestBuildGuardrailChecker_DBRequired_FailsLoudOnUnreachable is the
+// core issue #166 invariant: with FORGE_GUARDRAILS_DB pointing at an
+// unreachable host AND FORGE_GUARDRAILS_DB_REQUIRED=true, startup
+// MUST return a non-nil error rather than quietly downgrading to
+// file mode or defaults. The runner propagates the error so the
+// agent process exits non-zero and the platform deploy can surface
+// the failure.
+func TestBuildGuardrailChecker_DBRequired_FailsLoudOnUnreachable(t *testing.T) {
+	resetDBFileWarning()
+	// 127.0.0.1:1 is reliably unreachable on test hosts.
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+	t.Setenv(EnvGuardrailsDBRequired, "true")
+
+	logger := &captureLogger{}
+	checker, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+
+	if err == nil {
+		t.Fatalf("expected error in REQUIRED mode with unreachable DB; got checker=%v", checker)
+	}
+	if checker != nil {
+		t.Errorf("REQUIRED-mode failure must return nil checker; got %T", checker)
+	}
+	if !strings.Contains(err.Error(), "DB required but unreachable") {
+		t.Errorf("error must mention REQUIRED-mode; got %q", err.Error())
+	}
+	// Logger should carry an Error line (not just Warn) so platform
+	// ops can grep for the specific failure mode.
+	if len(logger.errors) == 0 {
+		t.Errorf("expected an Error log line in REQUIRED-mode failure; got warns=%v", logger.warns)
+	}
+}
+
+// TestBuildGuardrailChecker_DBUnreachable_FallsBackByDefault pins
+// the back-compat path: with DB set but REQUIRED unset, an
+// unreachable DB still warn-and-falls-back to file mode. Operators
+// who deliberately want the safer fail-loud posture set REQUIRED.
+func TestBuildGuardrailChecker_DBUnreachable_FallsBackByDefault(t *testing.T) {
+	resetDBFileWarning()
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+	// REQUIRED deliberately unset.
+
+	logger := &captureLogger{}
+	checker, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if err != nil {
+		t.Fatalf("default (non-REQUIRED) path must not error on DB unreachable; got %v", err)
+	}
+	if checker == nil {
+		t.Errorf("default path must return a non-nil fallback checker")
+	}
+	// At least one Warn should describe the fallback. Tests are
+	// loose on the exact message wording so a future log tweak
+	// doesn't break the invariant.
+	foundWarn := false
+	for _, w := range logger.warns {
+		if strings.Contains(w, "guardrails") || strings.Contains(w, "fall") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected a fallback warning; got warns=%v", logger.warns)
+	}
+}
+
+// TestBuildGuardrailChecker_DBRequiredAcceptsForgivingParse confirms
+// the env-parse posture matches the rest of the FORGE_* env layer:
+// garbage values fall back to "not set" (safe default — same as
+// AuditPayloadCaptureFromEnv). A typo in FORGE_GUARDRAILS_DB_REQUIRED
+// doesn't accidentally enable fail-loud mode in deployments that
+// didn't intend to opt in.
+func TestBuildGuardrailChecker_DBRequiredAcceptsForgivingParse(t *testing.T) {
+	resetDBFileWarning()
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+	t.Setenv(EnvGuardrailsDBRequired, "not-a-bool")
+
+	logger := &captureLogger{}
+	_, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if err != nil {
+		t.Errorf("malformed REQUIRED must not flip fail-loud; got err=%v", err)
+	}
+}
+
+// TestBuildGuardrailChecker_DBAndFile_WarnsOnce is the Part 3
+// invariant: when an operator has BOTH FORGE_GUARDRAILS_DB set AND a
+// guardrails.json checked into the workdir, the file is silently
+// ignored today — repo readers see it and assume it's active. The
+// one-shot warning makes the dead-config drift visible without
+// spamming the log on every BuildGuardrailChecker call.
+func TestBuildGuardrailChecker_DBAndFile_WarnsOnce(t *testing.T) {
+	resetDBFileWarning()
+	wd := t.TempDir()
+	guardrailsPath := filepath.Join(wd, "guardrails.json")
+	if err := os.WriteFile(guardrailsPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+
+	logger := &captureLogger{}
+	// First call — warning should fire.
+	_, _ = BuildGuardrailChecker(nil, wd, false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	exclusivityWarns := countWarnsContaining(logger.warns, "DB and file are mutually exclusive")
+	if exclusivityWarns != 1 {
+		t.Errorf("expected exactly 1 exclusivity warning on first build; got %d (warns=%v)",
+			exclusivityWarns, logger.warns)
+	}
+
+	// Second call — warning must NOT re-fire. One-shot semantics so
+	// the message doesn't spam ops logs in tests that build the
+	// checker repeatedly or in any code path that ever calls
+	// BuildGuardrailChecker more than once.
+	logger2 := &captureLogger{}
+	_, _ = BuildGuardrailChecker(nil, wd, false, logger2, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if countWarnsContaining(logger2.warns, "DB and file are mutually exclusive") != 0 {
+		t.Errorf("exclusivity warning re-fired on second build; got warns=%v", logger2.warns)
+	}
+}
+
+// TestBuildGuardrailChecker_DBOnly_NoFile_NoExclusivityWarn confirms
+// the warning ONLY fires when both are present. A clean DB-mode
+// deploy with no leftover guardrails.json must not see a spurious
+// "file is ignored" line.
+func TestBuildGuardrailChecker_DBOnly_NoFile_NoExclusivityWarn(t *testing.T) {
+	resetDBFileWarning()
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+
+	logger := &captureLogger{}
+	_, _ = BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 0 {
+		t.Errorf("exclusivity warning fired without guardrails.json; got warns=%v", logger.warns)
+	}
+}
+
+// TestBuildGuardrailChecker_FileOnly_NoWarn confirms the file-only
+// path is unchanged — no DB env, no exclusivity warning.
+func TestBuildGuardrailChecker_FileOnly_NoWarn(t *testing.T) {
+	resetDBFileWarning()
+	wd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wd, "guardrails.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// FORGE_GUARDRAILS_DB deliberately unset via Setenv("").
+	t.Setenv(EnvGuardrailsDB, "")
+
+	logger := &captureLogger{}
+	_, _ = BuildGuardrailChecker(nil, wd, false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 0 {
+		t.Errorf("exclusivity warning fired in file-only mode; got warns=%v", logger.warns)
+	}
+}
+
+// TestBuildGuardrailChecker_HonorsCustomGuardrailsPath confirms the
+// exclusivity check resolves cfg.GuardrailsPath, not just the
+// default `guardrails.json` filename. Operators who renamed the
+// file via forge.yaml must still see the warning when it conflicts
+// with DB mode.
+func TestBuildGuardrailChecker_HonorsCustomGuardrailsPath(t *testing.T) {
+	resetDBFileWarning()
+	wd := t.TempDir()
+	customPath := "policies/custom-guardrails.json"
+	if err := os.MkdirAll(filepath.Join(wd, "policies"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, customPath), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
+
+	cfg := &types.ForgeConfig{GuardrailsPath: customPath}
+	logger := &captureLogger{}
+	_, _ = BuildGuardrailChecker(cfg, wd, false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 1 {
+		t.Errorf("expected exclusivity warning for custom GuardrailsPath; got warns=%v", logger.warns)
+	}
+}
+
+func countWarnsContaining(warns []string, substr string) int {
+	n := 0
+	for _, w := range warns {
+		if strings.Contains(w, substr) {
+			n++
+		}
+	}
+	return n
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -355,7 +355,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	// evidence stamping (#161); the spans themselves are opened
 	// unconditionally — when tracing is disabled, the noop tracer
 	// short-circuits.
-	guardrails := BuildGuardrailChecker(r.cfg.Config, r.cfg.WorkDir, r.cfg.EnforceGuardrails, r.logger, auditLogger, GuardrailAuditConfigFromEnv(), tracingCfgEarly)
+	guardrails, err := BuildGuardrailChecker(r.cfg.Config, r.cfg.WorkDir, r.cfg.EnforceGuardrails, r.logger, auditLogger, GuardrailAuditConfigFromEnv(), tracingCfgEarly)
+	if err != nil {
+		// Only the fail-loud DB-required path produces a non-nil
+		// error here. The runner refuses to serve so the agent
+		// process exits non-zero and the platform deploy can
+		// surface the failure to operators. Issue #166.
+		return err
+	}
 	// Periodic audit_export_status — one event every 60s with per-sink
 	// health counters. Operators tail the audit stream to answer
 	// "is my sidecar healthy?". The stop func blocks until the


### PR DESCRIPTION
## Summary

Closes the three quiet behaviors in `BuildGuardrailChecker`'s DB-mode resolution ladder that made the feature unusable for production-grade guardrails deploys:

- **Fail-loud knob** — `FORGE_GUARDRAILS_DB_REQUIRED=true` makes an unreachable Mongo at startup a hard error instead of a silent downgrade. `BuildGuardrailChecker` now returns `(GuardrailChecker, error)`; the runner propagates the failure as a non-zero exit.
- **Seed + validate subcommands** — `forge guardrails seed-defaults` prints `DefaultStructuredGuardrails` as JSON; `forge guardrails validate-db` inspects the agent's `AgentConfig` and warns when below baseline. Closes the "DB mode bypasses built-in defaults" footgun without library-side coordination.
- **Exclusivity warning** — one-shot startup warning when both `FORGE_GUARDRAILS_DB` is set AND a `guardrails.json` is present, pointing at the specific path being ignored.

## Why

`DefaultStructuredGuardrails` ships 11 vendor-secret patterns, four PII categories, and three threat-detection thresholds — none of which are applied in DB mode (the operator's MongoDB `AgentConfig` is the ONLY source). An empty or partial seed leaves the agent **strictly less protected** than a clean default deploy, and the silent fall-back path masked the failure. This PR makes both surfaces actionable.

## Operator-facing changes

### Env vars

| Var | Default | Behavior |
|---|---|---|
| `FORGE_GUARDRAILS_DB_REQUIRED` | `false` | New. When `true` and `FORGE_GUARDRAILS_DB` is set, unreachable DB at startup → runner returns non-nil error, agent refuses to serve. |

### CLI

```bash
forge guardrails seed-defaults > defaults.json
# pipe into MongoDB as the agent's AgentConfig seed

forge guardrails validate-db
# connects to FORGE_GUARDRAILS_DB, fetches the agent's AgentConfig,
# reports coverage; warns on missing PII / security / fewer than 5
# secret-pattern rules; exits non-zero on missing document.
```

### Connect timeout

Trimmed `NewDBGuardrailEngine` Mongo connect timeout from 10s to 3s. Production fails fast on misconfigured URIs; tests measurably faster too.

## Schema-shape compatibility

`scoreAgentConfig` tolerates both camelCase (the library struct tags — what production MongoDB carries) and snake_case (legacy seeds / hand-written docs from older guidance) without operator intervention. Pinned by `TestScoreAgentConfig_SnakeCaseCompat`.

## Out of scope (deferred)

- **Option A: library-side config merge** — requires coordinating a stable merge-semantics contract with the guardrails library. Issue notes this; the seed-defaults subcommand is the issue's recommended "Option B" for first cut.
- **Hot-reload of DB config** — separate concern.
- **Per-agent DB connection multiplexing** — multi-agent single-Mongo deploy still holds one client per agent.

## Test plan

- [x] `golangci-lint run ./forge-core/... ./forge-cli/... ./forge-plugins/...` — 0 issues
- [x] `gofmt -w` across all modules
- [x] `go test ./...` in `forge-core/` and `forge-cli/` — all green
- [x] New unit tests pin: REQUIRED-mode fail-loud, default warn-and-fallback, forgiving-parse on REQUIRED, one-shot exclusivity warning (fires once across multiple builds, doesn't fire when only one source is present, honors `cfg.GuardrailsPath`), seed-defaults round-trips through `models.StructuredGuardrails`, `scoreAgentConfig` flags empty docs / fewer-than-5 secret rules / snake_case compat / camelCase-default-no-warnings, `extractCustomRules` defensive across BSON shape edge cases.
- [ ] Manual smoke: `FORGE_GUARDRAILS_DB=mongodb://127.0.0.1:1 FORGE_GUARDRAILS_DB_REQUIRED=true forge run` — assert non-zero exit + Error log line referencing the env var.