### PR TITLE
feat(workflow): split X-Workflow-ID into definition + execution headers (closes #185)

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -200,7 +200,8 @@ FWS-1), `policy_loaded` per non-empty layer (FWS-5/6),
 **Workflow correlation headers** (FWS-2) — extracted on every request,
 threaded into context, stamped on every audit event:
 
-- `X-Workflow-ID` — orchestrator workflow run
+- `X-Workflow-ID` — workflow DEFINITION (stable across runs of the same workflow). Use for definition-level rollups ("top failing workflows").
+- `X-Workflow-Execution-ID` — per-run instance (unique per workflow execution). Use for per-run timelines ("show me every event in this specific run"). Split from the formerly-overloaded `X-Workflow-ID` in FORGE-2 / issue #185.
 - `X-Workflow-Stage-ID` — workflow stage
 - `X-Workflow-Step-ID` — workflow step
 - `X-Invocation-Caller` — upstream caller identifier
@@ -544,8 +545,10 @@ fan-out across configured sinks.
 - `ts` (RFC3339 UTC), `event` (constant string), `schema_version`
   (`"1.0"`) on every event
 - `correlation_id`, `task_id` on every request-scoped event
-- `workflow_id` / `stage_id` / `step_id` / `invocation_caller` when
-  the orchestrator sent the matching `X-Workflow-*` headers (FWS-2)
+- `workflow_id` (definition) / `workflow_execution_id` (per-run) /
+  `stage_id` / `step_id` / `invocation_caller` when the orchestrator
+  sent the matching `X-Workflow-*` headers (FWS-2; the
+  definition/execution split landed in FORGE-2 / #185)
 - `seq` (monotonic int64) on every event emitted inside an
   invocation; absent on startup events (`policy_loaded`,
   `agent_card_published`, `audit_export_status`)
@@ -1026,7 +1029,7 @@ Every event also carries `schema_version: "1.0"` (FWS-8) and `seq`
 | # | Issue | Title | Doc |
 |---|---|---|---|
 | **FWS-1** | #85 | A2A 0.3.0 Agent Card conformance — canonical `/.well-known/agent-card.json` path + required fields + auth-chain-derived `securitySchemes` + SKILL.md → `AgentSkill` bridge + `agent_card_published` audit | `docs/reference/a2a-agent-card.md` |
-| **FWS-2** | #86 | Workflow correlation ID threading — `X-Workflow-*` / `X-Invocation-Caller` headers stamped on every audit event | `docs/security/workflow-correlation.md` |
+| **FWS-2** | #86, FORGE-2 / #185 | Workflow correlation ID threading — `X-Workflow-ID` (definition) + `X-Workflow-Execution-ID` (per-run) + stage / step / caller headers stamped on every audit event | `docs/security/workflow-correlation.md` |
 | **FWS-3** | #87 | Token usage + execution duration emission — OTel-aligned field names, `X-Forge-*` response headers, `invocation_complete` event with totals | `docs/security/audit-logging.md` § Token usage |
 | **FWS-4** | #88 | Cancellation signal handling — `tasks/cancel` actually cancels via `context.CancelCauseFunc`; `invocation_cancelled` audit event with classified reason + partial token counts | `docs/security/audit-logging.md` § Cancellation |
 | **FWS-5** | #89 | Platform policy enforcement at runtime — workspace-level deploy-time bounds (egress / tools / models / sizes); `forge package` policy-ready manifests | `docs/security/platform-policy.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@
 
 ### Added
 
+- **FORGE-2: split workflow definition from per-run execution (issue
+  #185).** The previously-overloaded `X-Workflow-ID` header now
+  carries the workflow DEFINITION id (stable across every run); a new
+  `X-Workflow-Execution-ID` header carries the per-run instance id.
+  Both surface as top-level fields on every audit event under a
+  workflow run (`workflow_id`, `workflow_execution_id`), so SIEM
+  consumers can answer "show me every event in this specific run"
+  (join on `workflow_execution_id`) AND "top failing workflows" /
+  "latency by workflow definition" (group by `workflow_id`) without
+  joining on opaque ids. Industry precedent for the split: GitHub
+  Actions (workflow + workflow_run_id), Tekton (Pipeline +
+  PipelineRun), Argo (Workflow + WorkflowRun).
+  - `WorkflowContext` gains `WorkflowExecutionID`;
+    `WorkflowContextFromHTTPHeaders` reads both headers,
+    `ApplyToHTTPHeaders` writes both for outbound A2A propagation.
+  - `AuditEvent` gains `WorkflowExecutionID` with
+    `json:"workflow_execution_id,omitempty"`. `EmitFromContext`
+    stamps both fields from the request context.
+  - New OTel span attribute `forge.workflow.execution.id` stamped on
+    `agent.execute` and dispatcher spans, alongside the existing
+    `forge.workflow.id`.
+  - Both fields use `omitempty` — direct A2A invocations without
+    orchestrator headers continue to emit byte-identical JSON to
+    pre-FWS-2 consumers. `schema_version` stays `1.0` (additive
+    schema-compatible change).
+  - Clean break — no backward-compatibility alias (per the issue;
+    the contract is pre-production). Orchestrators sending only the
+    old `X-Workflow-Id` continue to populate `workflow_id` with run
+    semantics; they should switch to the split contract before
+    cutting workflow timelines on the new field.
+  - Pinned by `TestWorkflowContextFromHTTPHeaders_{DefinitionAndExecutionAreIndependent,ExtractsAllFour}`,
+    `TestApplyToHTTPHeaders_PopulatesExecutionID`,
+    `TestRoundTripHTTPHeaders`,
+    `TestEmitFromContext_{TagsWorkflowFieldsWhenContextHasThem,TagsBothWorkflowDefinitionAndExecution,OmitsWorkflowFieldsWhenContextEmpty}`.
+
 - **Guardrails DB mode hardening: fail-loud + seed helpers + exclusivity
   warning (issue #166).** Three quiet behaviors in the
   `BuildGuardrailChecker` resolution ladder that mismatched what

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -44,7 +44,7 @@ The `source` field distinguishes in-process enforcer events from subprocess prox
 
 ### Workflow correlation
 
-When the inbound A2A request carries the orchestrator's correlation headers (`X-Workflow-ID`, `X-Workflow-Stage-ID`, `X-Workflow-Step-ID`, `X-Invocation-Caller`), every audit event emitted during that invocation is tagged with the matching `workflow_id` / `stage_id` / `step_id` / `invocation_caller` fields. Header names are vendor-neutral so any A2A-compatible orchestrator can populate them. Direct A2A invocations (no orchestrator) omit the fields entirely — emitted JSON is byte-identical to the pre-correlation shape. See [Workflow correlation IDs](workflow-correlation.md) for the full reference, including outbound propagation for agent-to-agent flows.
+When the inbound A2A request carries the orchestrator's correlation headers (`X-Workflow-ID`, `X-Workflow-Execution-ID`, `X-Workflow-Stage-ID`, `X-Workflow-Step-ID`, `X-Invocation-Caller`), every audit event emitted during that invocation is tagged with the matching `workflow_id` / `workflow_execution_id` / `stage_id` / `step_id` / `invocation_caller` fields. `workflow_id` is the workflow DEFINITION (stable across runs); `workflow_execution_id` is the per-run instance (split from the formerly-overloaded header in FORGE-2 / issue #185). Header names are vendor-neutral so any A2A-compatible orchestrator can populate them. Direct A2A invocations (no orchestrator) omit the fields entirely — emitted JSON is byte-identical to the pre-correlation shape. See [Workflow correlation IDs](workflow-correlation.md) for the full reference, including outbound propagation for agent-to-agent flows.
 
 ### Tenancy stamping
 
@@ -142,7 +142,7 @@ Every `llm_call` audit event carries the normalized token counts the provider re
 
 Each `tool_exec` event (phase=end) carries `duration_ms` for the tool execution plus structured arg-shape metadata (`args_size`, `result_size`) — raw arg values are deliberately not included (payload stripping is FWS-8's concern). One `invocation_complete` event closes each A2A invocation with the total wall-clock duration and aggregated token totals across all LLM calls in the invocation.
 
-Workflow correlation fields (`workflow_id` / `stage_id` / `step_id` / `invocation_caller` from FWS-2) also auto-tag every `llm_call` / `tool_exec` / `invocation_complete` event when the inbound request carried orchestrator headers — billing and audit consumers can attribute cost not just to a task but to a specific workflow run / stage / step.
+Workflow correlation fields (`workflow_id` / `workflow_execution_id` / `stage_id` / `step_id` / `invocation_caller` from FWS-2) also auto-tag every `llm_call` / `tool_exec` / `invocation_complete` event when the inbound request carried orchestrator headers — billing and audit consumers can attribute cost not just to a task but to a specific workflow run / stage / step. `workflow_id` rollups answer "cost per workflow definition over time"; `workflow_execution_id` joins answer "cost for this specific run."
 
 A2A response headers carry the same per-invocation totals inline so an orchestrator can ceiling-check cost during parallel workflow execution without subscribing to the audit stream:
 
@@ -469,7 +469,7 @@ Every emitted event carries:
 | `seq` | int64 | per-invocation only | Monotonic per-invocation counter. Absent on startup events (`policy_loaded`, `agent_card_published`, `audit_export_status`). |
 | `correlation_id` | string | request-scoped only | Per-invocation ID; groups all events for one A2A invocation |
 | `task_id` | string | request-scoped only | A2A task identifier (`params.id` on `tasks/send`) |
-| `workflow_id` / `stage_id` / `step_id` / `invocation_caller` | string | optional | Populated when the request carried `X-Workflow-*` headers (FWS-2) |
+| `workflow_id` / `workflow_execution_id` / `stage_id` / `step_id` / `invocation_caller` | string | optional | Populated when the request carried `X-Workflow-*` headers (FWS-2). `workflow_id` is the workflow definition (stable across runs); `workflow_execution_id` is the per-run instance (FORGE-2 / #185 split). |
 | `model` / `provider` | string | optional | LLM call attribution (FWS-3) |
 | `input_tokens` / `output_tokens` / `tokens_unavailable` | int / bool | optional | LLM call usage (FWS-3) |
 | `duration_ms` | int64 | optional | Wall-clock duration (FWS-3) |

--- a/docs/security/workflow-correlation.md
+++ b/docs/security/workflow-correlation.md
@@ -6,7 +6,7 @@ order: 7
 
 # Workflow correlation IDs
 
-Forge agents accept orchestration headers on every inbound A2A call and tag every audit event emitted during that invocation with the matching workflow / stage / step / invocation-caller identifiers. This lets a platform orchestrator (initializ Command, or any A2A-compatible orchestrator) correlate audit events across the multiple agents that participate in one workflow run.
+Forge agents accept orchestration headers on every inbound A2A call and tag every audit event emitted during that invocation with the matching workflow / execution / stage / step / invocation-caller identifiers. This lets a platform orchestrator (initializ Command, or any A2A-compatible orchestrator) correlate audit events across the multiple agents that participate in one workflow run.
 
 Direct A2A invocations (no orchestrator) leave the fields unset — emitted JSON matches the pre-correlation shape exactly, so existing audit consumers keep working.
 
@@ -14,12 +14,22 @@ Direct A2A invocations (no orchestrator) leave the fields unset — emitted JSON
 
 | Header | Audit field | Identifies |
 |---|---|---|
-| `X-Workflow-ID` | `workflow_id` | The orchestrator-level workflow run |
-| `X-Workflow-Stage-ID` | `stage_id` | A stage within the workflow (a group of steps that may run in parallel) |
+| `X-Workflow-ID` | `workflow_id` | The workflow DEFINITION — stable across every run of the same workflow. Join here for definition-level rollups ("top failing workflows", "latency by workflow definition"). |
+| `X-Workflow-Execution-ID` | `workflow_execution_id` | The per-run instance — unique per workflow execution. Join here for per-run timelines ("show me every event in this specific run, across every agent the orchestrator dispatched to"). Added in FORGE-2 / issue #185. |
+| `X-Workflow-Stage-ID` | `stage_id` | A stage within the workflow run (a group of steps that may run in parallel) |
 | `X-Workflow-Step-ID` | `step_id` | The specific step that invoked this agent |
 | `X-Invocation-Caller` | `invocation_caller` | The upstream caller (orchestrator identity, or upstream agent in an agent-to-agent flow) |
 
-All four are optional. Forge extracts whichever are present and leaves the rest empty. The header names are vendor-neutral by design — any A2A-compatible orchestrator (initializ Command, custom registries, third-party platforms) can drive Forge's correlation surface without adopting a vendor prefix.
+All five are optional. Forge extracts whichever are present and leaves the rest empty. The header names are vendor-neutral by design — any A2A-compatible orchestrator (initializ Command, custom registries, third-party platforms) can drive Forge's correlation surface without adopting a vendor prefix.
+
+### Why definition + execution
+
+Pre-FORGE-2, `X-Workflow-ID` was overloaded — the code comment said "orchestrator workflow run" but the name read like a definition identifier. The split disambiguates two distinct queries operators actually want:
+
+- "Show me this specific run" → join on `workflow_execution_id`
+- "Show me every run of this workflow" / "Top failing workflows" → group by `workflow_id`
+
+Industry precedent for the split: GitHub Actions (`workflow` + `workflow_run_id`), Tekton (`Pipeline` + `PipelineRun`), Argo (`Workflow` + `WorkflowRun`).
 
 ## How it flows
 
@@ -34,7 +44,7 @@ JSON-RPC / REST handler receives ctx with WorkflowContext baked in
   ↓
 auditLogger.EmitFromContext(ctx, event)
   ├─ reads WorkflowContext from ctx
-  └─ stamps workflow_id / stage_id / step_id / invocation_caller onto event
+  └─ stamps workflow_id / workflow_execution_id / stage_id / step_id / invocation_caller onto event
 ```
 
 Every event from `session_start` through `session_end`, every `tool_exec` / `llm_call` / `egress_allowed` / `egress_blocked` emitted under that ctx carries the same workflow tags — letting an audit consumer reconstruct the full workflow-step → agent-execution → tool-call tree.
@@ -49,7 +59,8 @@ Every event from `session_start` through `session_end`, every `tool_exec` / `llm
   "event": "session_start",
   "correlation_id": "9b3d…",
   "task_id": "task-42",
-  "workflow_id": "wf-deploy-prod-001",
+  "workflow_id": "wf-deploy-prod",
+  "workflow_execution_id": "wfrun-2026-06-04-canary-001",
   "stage_id": "rollout",
   "step_id": "canary-bake",
   "invocation_caller": "initializ-orchestrator"
@@ -93,7 +104,7 @@ client.Do(req)
 | File | Role |
 |---|---|
 | `forge-core/runtime/workflow.go` | `WorkflowContext` type, `WithWorkflowContext` / `WorkflowContextFromContext` ctx helpers, `WorkflowContextFromHTTPHeaders` + `ApplyToHTTPHeaders` header marshalers |
-| `forge-core/runtime/audit.go` | `AuditEvent` extended with `workflow_id` / `stage_id` / `step_id` / `invocation_caller` fields; `AuditLogger.EmitFromContext` auto-tags from ctx |
+| `forge-core/runtime/audit.go` | `AuditEvent` extended with `workflow_id` / `workflow_execution_id` / `stage_id` / `step_id` / `invocation_caller` fields; `AuditLogger.EmitFromContext` auto-tags from ctx |
 | `forge-cli/server/a2a_server.go` | JSON-RPC dispatcher extracts headers at boundary and injects WorkflowContext into ctx |
 | `forge-cli/runtime/runner.go` | REST `POST /tasks/send` + `POST /tasks/sendSubscribe` handlers extract headers; in-request audit emit sites migrated to `EmitFromContext` |
 | auth audit callback | Pulls headers directly from `req.Header` (runs before the dispatcher in middleware order) and stamps the four fields onto `auth_verify` / `auth_fail` events |

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -2573,15 +2573,16 @@ func makeAuthAuditCallback(auditLogger *coreruntime.AuditLogger) func(*http.Requ
 				"remote_addr":  req.RemoteAddr,
 			}
 			auditLogger.EmitFromContext(req.Context(), coreruntime.AuditEvent{
-				Event:            coreruntime.EventAuthVerify,
-				CorrelationID:    correlationID,
-				WorkflowID:       wc.WorkflowID,
-				StageID:          wc.StageID,
-				StepID:           wc.StepID,
-				InvocationCaller: wc.InvocationCaller,
-				OrgID:            tc.OrgID,
-				WorkspaceID:      tc.WorkspaceID,
-				Fields:           fields,
+				Event:               coreruntime.EventAuthVerify,
+				CorrelationID:       correlationID,
+				WorkflowID:          wc.WorkflowID,
+				WorkflowExecutionID: wc.WorkflowExecutionID,
+				StageID:             wc.StageID,
+				StepID:              wc.StepID,
+				InvocationCaller:    wc.InvocationCaller,
+				OrgID:               tc.OrgID,
+				WorkspaceID:         tc.WorkspaceID,
+				Fields:              fields,
 			})
 			return
 		}

--- a/forge-cli/server/a2a_server.go
+++ b/forge-cli/server/a2a_server.go
@@ -338,12 +338,21 @@ func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
 	if wf := coreruntime.WorkflowContextFromContext(ctx); !wf.IsZero() {
 		// FWS-2 orchestrator correlation surfaces on the span so a
 		// trace browser can pivot from a workflow run to every Forge
-		// agent invocation that workflow triggered.
-		span.SetAttributes(
+		// agent invocation that workflow triggered. Both definition
+		// and execution ids land so observability backends can build
+		// "all spans for this run" and "all spans for this workflow
+		// over time" views without a join on opaque ids. FORGE-2 /
+		// issue #185.
+		attrs := []attribute.KeyValue{
 			attribute.String(observability.AttrForgeWorkflowID, wf.WorkflowID),
 			attribute.String(observability.AttrForgeWorkflowStageID, wf.StageID),
 			attribute.String(observability.AttrForgeWorkflowStepID, wf.StepID),
-		)
+		}
+		if wf.WorkflowExecutionID != "" {
+			attrs = append(attrs,
+				attribute.String(observability.AttrForgeWorkflowExecutionID, wf.WorkflowExecutionID))
+		}
+		span.SetAttributes(attrs...)
 	}
 
 	// Check SSE handlers first (for streaming methods)

--- a/forge-core/observability/attrs.go
+++ b/forge-core/observability/attrs.go
@@ -67,14 +67,20 @@ const (
 	// boundary so a span can be tied back to the inbound request.
 	AttrForgeCorrelationID = "forge.correlation_id"
 
-	// AttrForgeWorkflowID / Stage / Step are the FWS-2 orchestrator
-	// correlation ids extracted from inbound X-Workflow-* headers.
-	// Spans get these when the inbound request was issued by an
-	// orchestrator (otherwise the keys are absent — backends should
-	// treat missing keys as "ad-hoc invocation").
-	AttrForgeWorkflowID      = "forge.workflow.id"
-	AttrForgeWorkflowStageID = "forge.workflow.stage.id"
-	AttrForgeWorkflowStepID  = "forge.workflow.step.id"
+	// AttrForgeWorkflow* are the FWS-2 orchestrator correlation ids
+	// extracted from inbound X-Workflow-* headers. Spans get these
+	// when the inbound request was issued by an orchestrator
+	// (otherwise the keys are absent — backends should treat missing
+	// keys as "ad-hoc invocation").
+	//
+	// AttrForgeWorkflowID is the workflow DEFINITION id (stable
+	// across runs); AttrForgeWorkflowExecutionID is the per-run
+	// instance id. FORGE-2 / issue #185 split — see the
+	// HeaderWorkflow* docs in forge-core/runtime/workflow.go.
+	AttrForgeWorkflowID          = "forge.workflow.id"
+	AttrForgeWorkflowExecutionID = "forge.workflow.execution.id"
+	AttrForgeWorkflowStageID     = "forge.workflow.stage.id"
+	AttrForgeWorkflowStepID      = "forge.workflow.step.id"
 
 	// AttrForgeA2AMethod is the JSON-RPC method name on the inbound
 	// span — "tasks/send", "tasks/get", "tasks/cancel". Span name is

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -119,12 +119,18 @@ const (
 
 // AuditEvent is a single structured audit record emitted as NDJSON.
 //
-// Workflow correlation fields (WorkflowID, StageID, StepID,
-// InvocationCaller) are tagged onto every event emitted via
-// EmitFromContext when the request carries `X-Workflow-*` /
-// `X-Invocation-Caller` headers from any A2A-compatible orchestrator.
-// Direct A2A invocations omit them entirely so the JSON shape matches
-// the pre-FWS-2 audit consumers.
+// Workflow correlation fields (WorkflowID, WorkflowExecutionID,
+// StageID, StepID, InvocationCaller) are tagged onto every event
+// emitted via EmitFromContext when the request carries `X-Workflow-*`
+// / `X-Invocation-Caller` headers from any A2A-compatible
+// orchestrator. Direct A2A invocations omit them entirely so the JSON
+// shape matches the pre-FWS-2 audit consumers.
+//
+// WorkflowID / WorkflowExecutionID split (FORGE-2 / issue #185):
+// `workflow_id` carries the workflow DEFINITION id (stable across all
+// runs), `workflow_execution_id` carries the PER-RUN instance id.
+// Audit consumers join on `workflow_execution_id` for per-run
+// timelines and on `workflow_id` for definition-level rollups.
 //
 // Token usage, duration, model, and provider fields (issue #87 / FWS-3)
 // are populated by the LLM call site, tool execution path, and per-
@@ -170,10 +176,21 @@ type AuditEvent struct {
 	// TaskID is the A2A task identifier (params.id on tasks/send).
 	TaskID string `json:"task_id,omitempty"`
 
-	// WorkflowID identifies the orchestrator-level workflow run that
-	// invoked this agent. Sourced from X-Workflow-ID at request entry;
-	// absent for direct A2A invocations.
+	// WorkflowID identifies the workflow DEFINITION that invoked this
+	// agent. Stable across every run of the same workflow. Sourced
+	// from X-Workflow-ID at request entry; absent for direct A2A
+	// invocations. SIEM consumers join on this for definition-level
+	// rollups ("top failing workflows"). FORGE-2 / issue #185 split.
 	WorkflowID string `json:"workflow_id,omitempty"`
+
+	// WorkflowExecutionID identifies the per-run instance of the
+	// workflow that invoked this agent. Unique per workflow
+	// execution. Sourced from X-Workflow-Execution-ID at request
+	// entry; absent for direct A2A invocations. SIEM consumers join
+	// on this for per-run timelines ("every event in this specific
+	// run, across every agent the orchestrator dispatched to"). Added
+	// in FORGE-2 / issue #185.
+	WorkflowExecutionID string `json:"workflow_execution_id,omitempty"`
 
 	// StageID identifies the workflow stage that invoked this agent.
 	StageID string `json:"stage_id,omitempty"`
@@ -566,10 +583,13 @@ func (a *AuditLogger) EmitFromContext(ctx context.Context, event AuditEvent) {
 	if event.TaskID == "" {
 		event.TaskID = TaskIDFromContext(ctx)
 	}
-	if event.WorkflowID == "" || event.StageID == "" || event.StepID == "" || event.InvocationCaller == "" {
+	if event.WorkflowID == "" || event.WorkflowExecutionID == "" || event.StageID == "" || event.StepID == "" || event.InvocationCaller == "" {
 		wc := WorkflowContextFromContext(ctx)
 		if event.WorkflowID == "" {
 			event.WorkflowID = wc.WorkflowID
+		}
+		if event.WorkflowExecutionID == "" {
+			event.WorkflowExecutionID = wc.WorkflowExecutionID
 		}
 		if event.StageID == "" {
 			event.StageID = wc.StageID

--- a/forge-core/runtime/audit_workflow_test.go
+++ b/forge-core/runtime/audit_workflow_test.go
@@ -18,10 +18,11 @@ func TestEmitFromContext_TagsWorkflowFieldsWhenContextHasThem(t *testing.T) {
 	audit := NewAuditLogger(&buf)
 
 	ctx := WithWorkflowContext(context.Background(), WorkflowContext{
-		WorkflowID:       "wf-100",
-		StageID:          "stage-A",
-		StepID:           "step-1",
-		InvocationCaller: "orchestrator",
+		WorkflowID:          "wf-100",
+		WorkflowExecutionID: "wfrun-100-abc",
+		StageID:             "stage-A",
+		StepID:              "step-1",
+		InvocationCaller:    "orchestrator",
 	})
 
 	audit.EmitFromContext(ctx, AuditEvent{Event: "tool_exec"})
@@ -30,8 +31,39 @@ func TestEmitFromContext_TagsWorkflowFieldsWhenContextHasThem(t *testing.T) {
 	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &got); err != nil {
 		t.Fatalf("decode: %v\n%s", err, buf.String())
 	}
-	if got.WorkflowID != "wf-100" || got.StageID != "stage-A" || got.StepID != "step-1" || got.InvocationCaller != "orchestrator" {
+	if got.WorkflowID != "wf-100" || got.WorkflowExecutionID != "wfrun-100-abc" ||
+		got.StageID != "stage-A" || got.StepID != "step-1" ||
+		got.InvocationCaller != "orchestrator" {
 		t.Errorf("workflow fields not tagged: %+v", got)
+	}
+}
+
+// TestEmitFromContext_TagsBothWorkflowDefinitionAndExecution is the
+// snapshot golden the issue calls out: an llm_call audit event
+// emitted under a workflow run carries BOTH workflow_id (definition)
+// and workflow_execution_id (per-run) at the top level so a SIEM can
+// build per-run timelines without joining on opaque ids. FORGE-2 /
+// issue #185.
+func TestEmitFromContext_TagsBothWorkflowDefinitionAndExecution(t *testing.T) {
+	var buf bytes.Buffer
+	audit := NewAuditLogger(&buf)
+
+	ctx := WithWorkflowContext(context.Background(), WorkflowContext{
+		WorkflowID:          "compliance-review",
+		WorkflowExecutionID: "exec-2026-06-25-001",
+	})
+
+	audit.EmitFromContext(ctx, AuditEvent{Event: "llm_call"})
+
+	js := buf.String()
+	for _, want := range []string{
+		`"event":"llm_call"`,
+		`"workflow_id":"compliance-review"`,
+		`"workflow_execution_id":"exec-2026-06-25-001"`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("emitted JSON missing %s; got:\n%s", want, js)
+		}
 	}
 }
 
@@ -45,7 +77,10 @@ func TestEmitFromContext_OmitsWorkflowFieldsWhenContextEmpty(t *testing.T) {
 	audit.EmitFromContext(context.Background(), AuditEvent{Event: "session_start"})
 
 	got := buf.String()
-	for _, forbidden := range []string{`"workflow_id"`, `"stage_id"`, `"step_id"`, `"invocation_caller"`} {
+	for _, forbidden := range []string{
+		`"workflow_id"`, `"workflow_execution_id"`,
+		`"stage_id"`, `"step_id"`, `"invocation_caller"`,
+	} {
 		if strings.Contains(got, forbidden) {
 			t.Errorf("empty ctx should omit %s from JSON, got:\n%s", forbidden, got)
 		}

--- a/forge-core/runtime/workflow.go
+++ b/forge-core/runtime/workflow.go
@@ -12,27 +12,53 @@ import (
 // platforms) can drive Forge's correlation surface without adopting a
 // vendor prefix. Forge agents extract them at the request boundary,
 // stash them in context.Context, and tag every audit event with the
-// matching workflow / stage / step identifiers so audit consumers can
-// correlate events across multiple agents participating in the same
-// workflow.
+// matching workflow / execution / stage / step identifiers so audit
+// consumers can correlate events across multiple agents participating
+// in the same workflow.
+//
+// FORGE-2 / issue #185 split the previously-overloaded X-Workflow-ID
+// header into two distinct identifiers so operators can answer both
+// "show me this specific run" (per-execution) and "show me every run
+// of this workflow" / "top failing workflows" (per-definition) queries
+// without a join on opaque ids:
+//
+//   - HeaderWorkflowID:           workflow DEFINITION id, stable across all
+//     runs of the same workflow.
+//   - HeaderWorkflowExecutionID:  PER-RUN instance id, unique per
+//     workflow execution.
+//
+// Industry precedent for the split: GitHub Actions (workflow +
+// workflow_run_id), Tekton (Pipeline + PipelineRun), Argo (Workflow +
+// WorkflowRun).
 //
 // Absence of these headers is the normal case for direct A2A
 // invocations (e.g. local development, peer agents not orchestrated).
 // When absent, audit events emit without the workflow fields — full
 // backward compatibility with pre-FWS-2 audit consumers.
 const (
-	HeaderWorkflowID       = "X-Workflow-ID"
-	HeaderWorkflowStageID  = "X-Workflow-Stage-ID"
-	HeaderWorkflowStepID   = "X-Workflow-Step-ID"
-	HeaderInvocationCaller = "X-Invocation-Caller"
+	HeaderWorkflowID          = "X-Workflow-ID"
+	HeaderWorkflowExecutionID = "X-Workflow-Execution-ID"
+	HeaderWorkflowStageID     = "X-Workflow-Stage-ID"
+	HeaderWorkflowStepID      = "X-Workflow-Step-ID"
+	HeaderInvocationCaller    = "X-Invocation-Caller"
 )
 
 // WorkflowContext carries the orchestration identifiers a Forge agent
 // extracts from inbound A2A request headers. Zero value is meaningful
 // — it represents "no workflow context" (direct A2A invocation).
 type WorkflowContext struct {
-	// WorkflowID identifies the orchestrator-level workflow run.
+	// WorkflowID identifies the workflow DEFINITION — stable across
+	// all runs of the same workflow. Sourced from X-Workflow-ID.
+	// Audit consumers join on this for definition-level rollups:
+	// "top failing workflows," "latency by workflow definition."
 	WorkflowID string
+
+	// WorkflowExecutionID identifies the PER-RUN instance — unique
+	// per workflow execution. Sourced from X-Workflow-Execution-ID.
+	// Audit consumers join on this for per-run timelines: "show me
+	// every event in this specific run, across every agent the
+	// orchestrator dispatched to." Added in FORGE-2 / issue #185.
+	WorkflowExecutionID string
 
 	// StageID identifies a stage within the workflow (a group of
 	// steps that may run in parallel).
@@ -54,6 +80,7 @@ type WorkflowContext struct {
 // emitted JSON matches the pre-FWS-2 shape).
 func (w WorkflowContext) IsZero() bool {
 	return w.WorkflowID == "" &&
+		w.WorkflowExecutionID == "" &&
 		w.StageID == "" &&
 		w.StepID == "" &&
 		w.InvocationCaller == ""
@@ -64,10 +91,11 @@ func (w WorkflowContext) IsZero() bool {
 // fields; the returned WorkflowContext is `IsZero` when none are set.
 func WorkflowContextFromHTTPHeaders(h http.Header) WorkflowContext {
 	return WorkflowContext{
-		WorkflowID:       h.Get(HeaderWorkflowID),
-		StageID:          h.Get(HeaderWorkflowStageID),
-		StepID:           h.Get(HeaderWorkflowStepID),
-		InvocationCaller: h.Get(HeaderInvocationCaller),
+		WorkflowID:          h.Get(HeaderWorkflowID),
+		WorkflowExecutionID: h.Get(HeaderWorkflowExecutionID),
+		StageID:             h.Get(HeaderWorkflowStageID),
+		StepID:              h.Get(HeaderWorkflowStepID),
+		InvocationCaller:    h.Get(HeaderInvocationCaller),
 	}
 }
 
@@ -83,6 +111,9 @@ func WorkflowContextFromHTTPHeaders(h http.Header) WorkflowContext {
 func (w WorkflowContext) ApplyToHTTPHeaders(h http.Header) {
 	if w.WorkflowID != "" {
 		h.Set(HeaderWorkflowID, w.WorkflowID)
+	}
+	if w.WorkflowExecutionID != "" {
+		h.Set(HeaderWorkflowExecutionID, w.WorkflowExecutionID)
 	}
 	if w.StageID != "" {
 		h.Set(HeaderWorkflowStageID, w.StageID)

--- a/forge-core/runtime/workflow_test.go
+++ b/forge-core/runtime/workflow_test.go
@@ -24,13 +24,54 @@ func TestWorkflowContext_IsZero(t *testing.T) {
 func TestWorkflowContextFromHTTPHeaders_ExtractsAllFour(t *testing.T) {
 	h := http.Header{}
 	h.Set(HeaderWorkflowID, "wf-42")
+	h.Set(HeaderWorkflowExecutionID, "wfrun-42-abc")
 	h.Set(HeaderWorkflowStageID, "stage-rollout")
 	h.Set(HeaderWorkflowStepID, "step-canary")
 	h.Set(HeaderInvocationCaller, "orchestrator")
 
 	wc := WorkflowContextFromHTTPHeaders(h)
-	if wc.WorkflowID != "wf-42" || wc.StageID != "stage-rollout" || wc.StepID != "step-canary" || wc.InvocationCaller != "orchestrator" {
-		t.Errorf("WorkflowContext = %+v, want all four fields populated", wc)
+	if wc.WorkflowID != "wf-42" || wc.WorkflowExecutionID != "wfrun-42-abc" ||
+		wc.StageID != "stage-rollout" || wc.StepID != "step-canary" ||
+		wc.InvocationCaller != "orchestrator" {
+		t.Errorf("WorkflowContext = %+v, want all five fields populated", wc)
+	}
+}
+
+// TestWorkflowContextFromHTTPHeaders_DefinitionAndExecutionAreIndependent
+// is the FORGE-2 / issue #185 split invariant: the two ids carry
+// distinct semantics (definition stable across runs; execution unique
+// per run) and a request can populate either or both. An operator
+// query "show me all events for this run" joins on
+// WorkflowExecutionID; "top failing workflows" joins on WorkflowID.
+// Both must propagate independently — populating one MUST NOT
+// auto-derive the other.
+func TestWorkflowContextFromHTTPHeaders_DefinitionAndExecutionAreIndependent(t *testing.T) {
+	// Definition only — common when a registry surface lists workflow
+	// metadata without a specific run.
+	h := http.Header{}
+	h.Set(HeaderWorkflowID, "def-only")
+	wc := WorkflowContextFromHTTPHeaders(h)
+	if wc.WorkflowID != "def-only" {
+		t.Errorf("WorkflowID = %q, want def-only", wc.WorkflowID)
+	}
+	if wc.WorkflowExecutionID != "" {
+		t.Errorf("WorkflowExecutionID auto-populated from WorkflowID; got %q", wc.WorkflowExecutionID)
+	}
+
+	// Execution only — unusual but valid (a dispatcher with an
+	// opaque per-run id and no definition handle).
+	h = http.Header{}
+	h.Set(HeaderWorkflowExecutionID, "exec-only-99")
+	wc = WorkflowContextFromHTTPHeaders(h)
+	if wc.WorkflowExecutionID != "exec-only-99" {
+		t.Errorf("WorkflowExecutionID = %q, want exec-only-99", wc.WorkflowExecutionID)
+	}
+	if wc.WorkflowID != "" {
+		t.Errorf("WorkflowID auto-populated from WorkflowExecutionID; got %q", wc.WorkflowID)
+	}
+	// Execution-only is still a non-zero context — IsZero must reflect that.
+	if wc.IsZero() {
+		t.Errorf("execution-only ctx reports IsZero=true; got %+v", wc)
 	}
 }
 
@@ -105,6 +146,22 @@ func TestApplyToHTTPHeaders_WritesNonEmptyFields(t *testing.T) {
 	}
 }
 
+// TestApplyToHTTPHeaders_PopulatesExecutionID pins the FORGE-2 /
+// issue #185 plumbing: when a workflow context carries an execution
+// id, ApplyToHTTPHeaders writes the X-Workflow-Execution-Id header on
+// outbound A2A calls so downstream agents see the same per-run id and
+// their audit events join on it.
+func TestApplyToHTTPHeaders_PopulatesExecutionID(t *testing.T) {
+	wc := WorkflowContext{WorkflowID: "wf-9", WorkflowExecutionID: "wfrun-9-zzz"}
+	h := http.Header{}
+	wc.ApplyToHTTPHeaders(h)
+
+	if h.Get(HeaderWorkflowExecutionID) != "wfrun-9-zzz" {
+		t.Errorf("WorkflowExecutionID header = %q, want wfrun-9-zzz",
+			h.Get(HeaderWorkflowExecutionID))
+	}
+}
+
 func TestApplyToHTTPHeaders_OmitsEmptyFields(t *testing.T) {
 	// Workflow without stage — outbound headers should mirror what's
 	// set, not stamp empty values that downstream agents might
@@ -129,6 +186,7 @@ func TestRoundTripHTTPHeaders(t *testing.T) {
 	// is the contract initializ's orchestrator + Forge runner depend on.
 	in := http.Header{}
 	in.Set(HeaderWorkflowID, "wf")
+	in.Set(HeaderWorkflowExecutionID, "wfrun")
 	in.Set(HeaderWorkflowStageID, "stg")
 	in.Set(HeaderWorkflowStepID, "stp")
 	in.Set(HeaderInvocationCaller, "ic")
@@ -140,6 +198,7 @@ func TestRoundTripHTTPHeaders(t *testing.T) {
 
 	for _, k := range []string{
 		HeaderWorkflowID,
+		HeaderWorkflowExecutionID,
 		HeaderWorkflowStageID,
 		HeaderWorkflowStepID,
 		HeaderInvocationCaller,


### PR DESCRIPTION
## Summary

Splits the previously-overloaded `X-Workflow-ID` header into two distinct identifiers so audit consumers can answer per-run AND per-definition queries from one event stream without joining on opaque ids:

- `X-Workflow-ID` — workflow **definition** (stable across all runs of the same workflow)
- `X-Workflow-Execution-ID` — **per-run** instance (unique per workflow execution) — new

Mirrored on every audit event as top-level `workflow_id` (definition semantics) + new `workflow_execution_id` (per-run semantics).

## Why

The code comment said "orchestrator workflow run" but the field name read like a definition identifier — a SIEM looking at the stream couldn't tell whether `workflow_id` was the join column for "this specific run" or "this workflow over time." This PR disambiguates the two axes following industry precedent:

- GitHub Actions: `workflow` + `workflow_run_id`
- Tekton: `Pipeline` + `PipelineRun`
- Argo: `Workflow` + `WorkflowRun`

Both forms surface so operators get both queries cheaply:

- "Show me every event for this run" → join on `workflow_execution_id`
- "Top failing workflows" / "Latency by workflow definition" → group by `workflow_id`

## Changes

### Header convention

| Header | Audit field | Semantics |
|---|---|---|
| `X-Workflow-ID` | `workflow_id` | Workflow definition — stable across runs |
| `X-Workflow-Execution-ID` (new) | `workflow_execution_id` (new) | Per-run instance — unique per execution |
| `X-Workflow-Stage-ID` | `stage_id` | unchanged |
| `X-Workflow-Step-ID` | `step_id` | unchanged |
| `X-Invocation-Caller` | `invocation_caller` | unchanged |

### Code

- `forge-core/runtime/workflow.go` — `HeaderWorkflowExecutionID` const; `WorkflowContext.WorkflowExecutionID` field; `WorkflowContextFromHTTPHeaders` / `ApplyToHTTPHeaders` read+write the new header; `IsZero` covers it.
- `forge-core/runtime/audit.go` — `AuditEvent.WorkflowExecutionID` (`json:"workflow_execution_id,omitempty"`); `EmitFromContext` stamps both fields from ctx.
- `forge-core/observability/attrs.go` — new `AttrForgeWorkflowExecutionID = "forge.workflow.execution.id"` span attribute.
- `forge-cli/server/a2a_server.go` — dispatcher span carries both attrs when the inbound carries the headers.
- `forge-cli/runtime/runner.go` — auth-audit emit sites pass `WorkflowExecutionID` from `wc` through to `auth_verify` / `auth_fail` events.

### Docs

- `docs/security/workflow-correlation.md` — headers table + "Why definition + execution" callout with industry precedent; updated audit-event example; updated wiring map.
- `docs/security/audit-logging.md` — schema-contract table, workflow-correlation prose, and FWS-3 attribution prose.
- `.claude/skills/forge.md` — FWS-2 reference + audit-event field list + initiative table.
- CHANGELOG — Unreleased entry.

## Safety

- **Clean break** per the issue — no backward-compat alias since the contract is pre-production.
- Both new field uses `omitempty` — direct A2A invocations without orchestrator headers continue to emit byte-identical JSON to pre-FWS-2 consumers. `schema_version` stays `1.0` (additive schema-compatible change).
- Definition and execution ids are **independent**: setting one doesn't auto-derive the other. Pinned by `TestWorkflowContextFromHTTPHeaders_DefinitionAndExecutionAreIndependent`.

## Test plan

- [x] `golangci-lint run` across all four modules — 0 issues
- [x] `gofmt -w` across all modules
- [x] `go test ./...` in `forge-core/` and `forge-cli/` — all green
- [x] New unit tests pin: definition + execution independence, full-five-field round-trip through headers → ctx → headers, `ApplyToHTTPHeaders` populates the new header, `EmitFromContext` stamps both fields, empty-ctx still omits both keys.
- [ ] Manual smoke: dispatch a `tasks/send` with both headers; confirm every emitted audit event carries both `workflow_id` and `workflow_execution_id` at the top level.

## Cross-repo coordination

- initializ/agent-orchestrator (ORCH-1): dispatcher must populate both headers.
- initializ/security (SEC-1): typed fields for the new audit column.
- initializ/console (CON-1): workflow timeline UI consumes `workflow_execution_id`.

This Forge PR is the foundational naming change the other repos plug into.