### PR TITLE
feat(workflow): opt-in auto-propagation of workflow headers on allow-listed hosts (closes #186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@
 
 ### Added
 
+- **FORGE-1: opt-in auto-propagation of workflow correlation headers
+  on outbound HTTP tool calls (issue #186).** Adds a
+  `workflow_propagation.allowed_hosts` block to `forge.yaml`. Hosts
+  matching the allow-list automatically receive the `X-Workflow-Id` /
+  `X-Workflow-Execution-Id` / `X-Workflow-Stage-Id` /
+  `X-Workflow-Step-Id` / `X-Invocation-Caller` headers from the
+  current request context when invoked from any built-in HTTP tool —
+  no per-tool code change needed. Hosts not on the list keep the
+  pre-#186 opt-in behavior; the headers stay off so workflow identity
+  never leaks to third-party APIs.
+  - New `WorkflowPropagationMatcher` mirrors the egress allow-list
+    wildcard semantics (exact + `*.suffix.com`, port-stripped,
+    lowercase-normalized). Wildcards match strictly-deeper
+    subdomains and refuse the apex — `*.agents.internal` does NOT
+    match the bare `agents.internal`.
+  - New `WrapTransportForWorkflowPropagation` wraps the egress
+    `http.Transport` once at runner startup so every HTTP tool
+    (`http_request`, `webhook_call`, `web_search_*`, future tools)
+    inherits the auto-apply via `security.EgressTransportFromContext`.
+    Empty config = the wrapper short-circuits and returns the
+    underlying transport identity-equal, zero overhead per request
+    on the default-deploy path.
+  - The wrapper clones the request before mutating headers (the
+    `http.RoundTripper` contract), so a caller's `req.Header` is
+    never modified across retries.
+  - Builds on FORGE-2 (#185) — the allow-listed propagation set
+    includes the new `X-Workflow-Execution-Id` header so downstream
+    agents' audit events join 1:1 on per-run timelines.
+  - Pinned by `TestWorkflowPropagationMatcher_{Matches,IsEmptyAndNilGuard}`,
+    `TestWorkflowPropagationTransport_{AppliesHeadersOnAllowlistedHost,
+    OmitsHeadersOnUnlistedHost,NoOpWhenContextIsZero,
+    DoesNotMutateOriginalRequest,EndToEnd,
+    PropagatesUnderlyingError}`,
+    `TestWrapTransportForWorkflowPropagation_EmptyMatcherShortCircuits`,
+    `TestNewWorkflowPropagationMatcher_RejectsBadInputCleanly`.
+
 - **FORGE-2: split workflow definition from per-run execution (issue
   #185).** The previously-overloaded `X-Workflow-ID` header now
   carries the workflow DEFINITION id (stable across every run); a new

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -52,6 +52,11 @@ egress:
 cors_origins:                       # CORS allowed origins for A2A server
   - "https://app.example.com"      # (default: localhost variants)
 
+workflow_propagation:                # Auto-propagate X-Workflow-* / X-Invocation-Caller
+  allowed_hosts:                     # headers on outbound HTTP tool calls to these hosts
+    - "orchestrator.svc"             # (FORGE-1 / issue #186; opt-in only by default).
+    - "*.agents.internal"
+
 server:                              # A2A server tuning (optional)
   rate_limit:                        # per-IP rate limits (issue #110 / FWS-10)
     read_rps: 1.0                    # GET/HEAD/OPTIONS req/sec (default 1.0 = 60/min)
@@ -263,6 +268,21 @@ absence-of-value is "no override," not "unset."
 auto-add it to `egress_allowlist.json`. No second egress edit needed.
 Disabled tracing produces no entry — turning tracing off in yaml does
 NOT leave a stale entry in the generated NetworkPolicy.
+
+## `workflow_propagation` — auto-propagate workflow correlation headers (FORGE-1)
+
+```yaml
+workflow_propagation:
+  allowed_hosts:
+    - "orchestrator.svc"
+    - "*.agents.internal"
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `allowed_hosts` | `[]` (opt-in only) | Hostnames whose outbound HTTP tool calls auto-receive the `X-Workflow-Id` / `X-Workflow-Execution-Id` / `X-Workflow-Stage-Id` / `X-Workflow-Step-Id` / `X-Invocation-Caller` headers from the current request context. Exact entries match a single host (port stripped before comparison); entries beginning with `*.` match any strictly-deeper subdomain. Empty list keeps the pre-#186 opt-in behavior — tools must call `WorkflowContext.ApplyToHTTPHeaders(req.Header)` explicitly. See [Workflow correlation IDs › Outbound propagation](../security/workflow-correlation.md#outbound-propagation-agent-to-agent). Issue #186 / FORGE-1. |
+
+The matcher is consulted by a `RoundTripper` wrapper around the egress transport at runner startup, so every built-in HTTP tool (`http_request`, `webhook_call`, `web_search_*`) inherits the auto-apply without per-tool changes. Empty config = zero-overhead pass-through.
 
 ## `security` — build-time security knobs
 

--- a/docs/security/workflow-correlation.md
+++ b/docs/security/workflow-correlation.md
@@ -82,7 +82,11 @@ Workflow fields are absent (`omitempty`) — byte-identical to pre-correlation a
 
 ## Outbound propagation (agent-to-agent)
 
-When a Forge agent calls another agent (or any peer), the workflow context is available via `runtime.WorkflowContextFromContext(ctx)`. To propagate, copy the headers onto the outbound request:
+When a Forge agent calls another agent (or any peer), the workflow context is available via `runtime.WorkflowContextFromContext(ctx)`. Forge supports two complementary propagation paths:
+
+### Explicit propagation (always available)
+
+A tool that knows its target is a workflow peer can stamp the headers itself:
 
 ```go
 wc := runtime.WorkflowContextFromContext(ctx)
@@ -91,7 +95,27 @@ wc.ApplyToHTTPHeaders(req.Header)
 client.Do(req)
 ```
 
-**Auto-propagation is deliberately off by default.** The `X-Workflow-*` / `X-Invocation-Caller` headers identify the workflow, so blanket-stamping them on every outbound HTTP request would leak workflow identity to third-party APIs (the egress proxy can't tell a peer agent from a vendor endpoint). Tools that know their target is a workflow peer call `ApplyToHTTPHeaders` explicitly.
+This is the path used by hand-written A2A tools and any code that wants per-request control.
+
+### Auto-propagation via `forge.yaml` allow-list (issue #186 / FORGE-1)
+
+Adding a `workflow_propagation` block to `forge.yaml` opts specific downstream hosts in to auto-receive the workflow headers without each tool having to call `ApplyToHTTPHeaders`. Every built-in HTTP tool (`http_request`, `webhook_call`, `web_search_*`, future tools) routes outbound requests through the egress transport, and the runner wraps that transport with a small RoundTripper that consults the allow-list per request.
+
+```yaml
+workflow_propagation:
+  allowed_hosts:
+    - "orchestrator.svc"           # exact match
+    - "*.agents.internal"          # wildcard subdomain
+```
+
+| Pattern | Matches |
+|---|---|
+| `orchestrator.svc` | exactly `orchestrator.svc` (any port) |
+| `*.agents.internal` | any strictly-deeper subdomain like `payments.agents.internal` or `worker.zone-a.agents.internal` |
+
+Match semantics mirror the egress allow-list (`security.DomainMatcher`): lowercase + port-stripped comparison, wildcards match strictly-deeper subdomains (the `*.agents.internal` entry does NOT match the bare `agents.internal` apex), and the matcher safely returns false on a nil receiver / empty list.
+
+**Auto-propagation is deliberately off by default.** The `X-Workflow-*` / `X-Invocation-Caller` headers identify the workflow, so blanket-stamping them on every outbound HTTP request would leak workflow identity to third-party APIs (the egress proxy can't tell a peer agent from a vendor endpoint). The allow-list keeps the safe default while removing the manual per-tool friction inside the trust boundary. A request to a host that isn't on the list still requires an explicit `ApplyToHTTPHeaders` call from the tool — the pre-#186 behavior.
 
 ## Backward compatibility
 
@@ -104,6 +128,9 @@ client.Do(req)
 | File | Role |
 |---|---|
 | `forge-core/runtime/workflow.go` | `WorkflowContext` type, `WithWorkflowContext` / `WorkflowContextFromContext` ctx helpers, `WorkflowContextFromHTTPHeaders` + `ApplyToHTTPHeaders` header marshalers |
+| `forge-core/runtime/workflow_propagation.go` | `WorkflowPropagationMatcher` (exact + wildcard host matching) and `WrapTransportForWorkflowPropagation` (RoundTripper wrapper that auto-applies headers on allow-listed hosts). FORGE-1 / issue #186. |
+| `forge-core/types/config.go` | `WorkflowPropagationConfig` (`forge.yaml` `workflow_propagation` block) |
+| `forge-cli/runtime/runner.go` | Builds the matcher from `cfg.WorkflowPropagation.AllowedHosts` and wraps the egress client's transport once at startup; every HTTP tool inherits the auto-apply via `security.EgressTransportFromContext` |
 | `forge-core/runtime/audit.go` | `AuditEvent` extended with `workflow_id` / `workflow_execution_id` / `stage_id` / `step_id` / `invocation_caller` fields; `AuditLogger.EmitFromContext` auto-tags from ctx |
 | `forge-cli/server/a2a_server.go` | JSON-RPC dispatcher extracts headers at boundary and injects WorkflowContext into ctx |
 | `forge-cli/runtime/runner.go` | REST `POST /tasks/send` + `POST /tasks/sendSubscribe` handlers extract headers; in-request audit emit sites migrated to `EmitFromContext` |

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -527,6 +527,18 @@ func (r *Runner) Run(ctx context.Context) error {
 		// observability.tracing.enabled.
 		egressClient = &http.Client{Transport: observability.WrapHTTPTransport(enforcer)}
 
+		// FORGE-1 (#186) — wrap the egress transport with the
+		// workflow-propagation auto-apply so HTTP tools targeting
+		// `workflow_propagation.allowed_hosts` automatically receive
+		// the X-Workflow-* / X-Invocation-Caller headers from the
+		// request's ctx. Empty config = zero-overhead pass-through
+		// (the wrapper short-circuits the wrap), so the default
+		// deploy keeps the opt-in posture.
+		propagationMatcher := coreruntime.NewWorkflowPropagationMatcher(
+			r.cfg.Config.WorkflowPropagation.AllowedHosts)
+		egressClient.Transport = coreruntime.WrapTransportForWorkflowPropagation(
+			egressClient.Transport, propagationMatcher)
+
 		// Start local proxy for subprocess egress enforcement
 		if !security.InContainer() && egressCfg.Mode != security.ModeDevOpen {
 			matcher := security.NewDomainMatcher(egressCfg.Mode, egressCfg.AllDomains)

--- a/forge-core/runtime/workflow_propagation.go
+++ b/forge-core/runtime/workflow_propagation.go
@@ -1,0 +1,163 @@
+package runtime
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Workflow auto-propagation matcher + transport wrapper (issue #186 /
+// FORGE-1). Auto-propagation is OFF by default so the X-Workflow-* /
+// X-Invocation-Caller headers — which identify the workflow run — do
+// not leak to third-party APIs when an agent calls them as a tool.
+// Operators opt specific downstream hosts in via the
+// `workflow_propagation.allowed_hosts` block in forge.yaml; matched
+// hosts auto-receive the headers, unmatched hosts continue to require
+// an explicit `WorkflowContextFromContext(ctx).ApplyToHTTPHeaders(...)`
+// call from the tool.
+//
+// Why this is a transport wrapper, not a per-tool change: every
+// built-in HTTP tool (http_request, webhook_call, web_search_*, …)
+// already routes its requests through the egress transport installed
+// on the request context. Wrapping that transport once at the runner
+// startup point picks up every current tool and every future tool
+// without touching them. The matcher short-circuits when no hosts
+// are configured (the default-deploy path), so the wrapper is
+// zero-overhead unless the operator opts in.
+
+// WorkflowPropagationMatcher decides whether a given outbound host
+// should auto-receive the workflow headers. Mirrors the wildcard
+// semantics of security.DomainMatcher (exact + `*.suffix.com`) but
+// is kept independent so this package doesn't grow a dependency on
+// forge-core/security just for matching.
+type WorkflowPropagationMatcher struct {
+	exact    map[string]bool
+	suffixes []string // ".foo.com" — leading dot kept so `bar.foo.com` matches but `foo.com` doesn't
+}
+
+// NewWorkflowPropagationMatcher parses an allow-list spec into a
+// matcher. Empty / nil input returns a matcher whose Matches() always
+// returns false — explicit safe default. Each entry is normalized to
+// lowercase and trimmed; blank entries are skipped.
+//
+// Entries beginning with `*.` register as wildcard suffix patterns;
+// every other entry is an exact host. There is deliberately no other
+// pattern syntax — Forge's hostname surface is small enough that
+// exact + suffix covers the meaningful cases and matches the existing
+// egress allow-list shape.
+func NewWorkflowPropagationMatcher(hosts []string) *WorkflowPropagationMatcher {
+	m := &WorkflowPropagationMatcher{exact: map[string]bool{}}
+	for _, h := range hosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" {
+			continue
+		}
+		if strings.HasPrefix(h, "*.") {
+			// "*.github.com" → suffix ".github.com" — keeping the
+			// leading dot means HasSuffix matches a strictly-deeper
+			// subdomain and never the bare apex.
+			m.suffixes = append(m.suffixes, h[1:])
+			continue
+		}
+		m.exact[h] = true
+	}
+	return m
+}
+
+// Matches reports whether the given host is in the allow-list. The
+// host argument may include a `:port` suffix (e.g. URL.Host on a
+// custom-port request) — the matcher strips the port before
+// comparing because propagation decisions are per-host, not per-port.
+//
+// A nil receiver returns false so callers can use the matcher pattern
+// without nil-guarding: `m.Matches(host)` is safe even on an
+// uninitialized matcher.
+func (m *WorkflowPropagationMatcher) Matches(host string) bool {
+	if m == nil {
+		return false
+	}
+	// Strip `:port`. Bracketed IPv6 hosts (`[::1]:8080`) are not in
+	// scope for the allow-list — workflow propagation targets are
+	// named services in production deploys.
+	if i := strings.LastIndexByte(host, ':'); i >= 0 && !strings.Contains(host, "]") {
+		host = host[:i]
+	}
+	host = strings.ToLower(host)
+	if m.exact[host] {
+		return true
+	}
+	for _, suffix := range m.suffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsEmpty reports whether the matcher would never match any host
+// (no exact entries, no wildcards). Lets callers short-circuit the
+// transport wrap entirely in the default-deploy path.
+func (m *WorkflowPropagationMatcher) IsEmpty() bool {
+	if m == nil {
+		return true
+	}
+	return len(m.exact) == 0 && len(m.suffixes) == 0
+}
+
+// workflowPropagationTransport wraps an http.RoundTripper and applies
+// workflow headers to outbound requests whose host matches the
+// configured allow-list. The wrapper reads the WorkflowContext from
+// the REQUEST's context (req.Context()) — that's the context the
+// agent loop installs on every tool call, so the wrapper picks up
+// the orchestrator's workflow ids automatically.
+type workflowPropagationTransport struct {
+	underlying http.RoundTripper
+	matcher    *WorkflowPropagationMatcher
+}
+
+// RoundTrip applies the workflow headers when the host is allow-listed
+// AND the request context carries a non-zero WorkflowContext. The
+// underlying transport handles the actual round-trip — this wrapper
+// only mutates headers and never blocks the request.
+//
+// Headers are applied by ApplyToHTTPHeaders, which Set()s each
+// non-empty WorkflowContext field — that means a manual
+// ApplyToHTTPHeaders call from a tool followed by this wrapper is
+// idempotent (Set, not Add). The reverse order produces the same
+// result.
+func (t *workflowPropagationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.matcher != nil && t.matcher.Matches(req.URL.Host) {
+		if wc := WorkflowContextFromContext(req.Context()); !wc.IsZero() {
+			// Cloning the request is the http.RoundTripper contract
+			// — RoundTrip MUST NOT modify the passed-in request. We
+			// only ever rewrite headers, so a shallow clone with a
+			// cloned header map is enough.
+			req2 := req.Clone(req.Context())
+			wc.ApplyToHTTPHeaders(req2.Header)
+			req = req2
+		}
+	}
+	underlying := t.underlying
+	if underlying == nil {
+		underlying = http.DefaultTransport
+	}
+	return underlying.RoundTrip(req)
+}
+
+// WrapTransportForWorkflowPropagation wraps an existing RoundTripper
+// so requests targeting allow-listed hosts auto-receive workflow
+// headers from the request context. Returns the underlying transport
+// unchanged when the matcher is empty — the default-deploy zero-
+// overhead path (no extra goroutine hops, no extra allocations per
+// request when nothing is configured).
+//
+// Hook this from the runner once, around the egress transport, before
+// the resulting client is stashed onto the request context via
+// security.WithEgressClient — every HTTP tool that reads the egress
+// transport from context (which is all of them) picks up the
+// auto-apply transparently. Issue #186.
+func WrapTransportForWorkflowPropagation(rt http.RoundTripper, matcher *WorkflowPropagationMatcher) http.RoundTripper {
+	if matcher.IsEmpty() {
+		return rt
+	}
+	return &workflowPropagationTransport{underlying: rt, matcher: matcher}
+}

--- a/forge-core/runtime/workflow_propagation_test.go
+++ b/forge-core/runtime/workflow_propagation_test.go
@@ -1,0 +1,312 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestWorkflowPropagationMatcher_Matches walks the host-matching
+// surface for issue #186 / FORGE-1. Exact entries match a single
+// host; wildcard `*.foo.com` entries match any strictly-deeper
+// subdomain but NOT the apex; ports are stripped before comparison
+// (so a `peer.svc` allow-list entry covers `peer.svc:8443`).
+func TestWorkflowPropagationMatcher_Matches(t *testing.T) {
+	m := NewWorkflowPropagationMatcher([]string{
+		"orchestrator.svc",
+		"*.agents.internal",
+		"PEER.LOCAL", // upper-case input is normalized
+	})
+
+	cases := []struct {
+		host string
+		want bool
+		note string
+	}{
+		{"orchestrator.svc", true, "exact match"},
+		{"orchestrator.svc:8443", true, "exact match strips port"},
+		{"peer.local", true, "exact normalized to lower"},
+		{"a.agents.internal", true, "wildcard suffix match"},
+		{"deep.a.agents.internal", true, "wildcard suffix multi-level"},
+		{"agents.internal", false, "wildcard does NOT match apex"},
+		{"agents.internal.evil.com", false, "suffix can't be tricked by a longer host"},
+		{"not-listed.example.com", false, "no match"},
+		{"", false, "empty host"},
+	}
+	for _, c := range cases {
+		t.Run(c.note, func(t *testing.T) {
+			if got := m.Matches(c.host); got != c.want {
+				t.Errorf("Matches(%q) = %v, want %v (%s)", c.host, got, c.want, c.note)
+			}
+		})
+	}
+}
+
+// TestWorkflowPropagationMatcher_IsEmptyAndNilGuard pins the default-
+// deploy contract: an empty allow-list (or a nil matcher) MUST report
+// IsEmpty and Matches → false. The WrapTransport helper relies on
+// IsEmpty to short-circuit the wrap so zero-config deploys pay no
+// overhead per request.
+func TestWorkflowPropagationMatcher_IsEmptyAndNilGuard(t *testing.T) {
+	if !NewWorkflowPropagationMatcher(nil).IsEmpty() {
+		t.Errorf("nil-input matcher should be IsEmpty")
+	}
+	if !NewWorkflowPropagationMatcher([]string{}).IsEmpty() {
+		t.Errorf("empty-input matcher should be IsEmpty")
+	}
+	if !NewWorkflowPropagationMatcher([]string{"", "  "}).IsEmpty() {
+		t.Errorf("blank-only-entries matcher should be IsEmpty")
+	}
+	var m *WorkflowPropagationMatcher
+	if !m.IsEmpty() {
+		t.Errorf("nil receiver IsEmpty should be true")
+	}
+	if m.Matches("foo.com") {
+		t.Errorf("nil receiver Matches should be false")
+	}
+}
+
+// recordingRoundTripper records the request it was handed to so a
+// test can assert which headers were stamped. The body is discarded
+// — these tests only care about headers + URL.
+type recordingRoundTripper struct {
+	gotReq *http.Request
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.gotReq = req
+	return &http.Response{
+		StatusCode: 204,
+		Body:       http.NoBody,
+		Header:     http.Header{},
+		Request:    req,
+	}, nil
+}
+
+// TestWorkflowPropagationTransport_AppliesHeadersOnAllowlistedHost is
+// the core issue #186 invariant: a request to an allow-listed host,
+// issued from a context that carries a non-zero WorkflowContext,
+// MUST land at the underlying transport with the X-Workflow-* /
+// X-Invocation-Caller headers populated.
+func TestWorkflowPropagationTransport_AppliesHeadersOnAllowlistedHost(t *testing.T) {
+	rec := &recordingRoundTripper{}
+	matcher := NewWorkflowPropagationMatcher([]string{"orchestrator.svc"})
+	rt := WrapTransportForWorkflowPropagation(rec, matcher)
+
+	wc := WorkflowContext{
+		WorkflowID:          "wf-deploy",
+		WorkflowExecutionID: "wfrun-001",
+		StageID:             "canary",
+		StepID:              "bake",
+		InvocationCaller:    "orchestrator",
+	}
+	ctx := WithWorkflowContext(context.Background(), wc)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://orchestrator.svc/v1/dispatch", nil)
+
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if rec.gotReq == nil {
+		t.Fatal("underlying transport never received the request")
+	}
+	wantHeaders := map[string]string{
+		HeaderWorkflowID:          "wf-deploy",
+		HeaderWorkflowExecutionID: "wfrun-001",
+		HeaderWorkflowStageID:     "canary",
+		HeaderWorkflowStepID:      "bake",
+		HeaderInvocationCaller:    "orchestrator",
+	}
+	for k, want := range wantHeaders {
+		if got := rec.gotReq.Header.Get(k); got != want {
+			t.Errorf("header %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestWorkflowPropagationTransport_OmitsHeadersOnUnlistedHost confirms
+// the default-deny posture for any host NOT on the allow-list. The
+// safe default — even with a fully-populated WorkflowContext, a
+// request to a third-party API like api.openai.com must NOT carry
+// the workflow headers, or the operator would silently leak workflow
+// identity to a vendor.
+func TestWorkflowPropagationTransport_OmitsHeadersOnUnlistedHost(t *testing.T) {
+	rec := &recordingRoundTripper{}
+	matcher := NewWorkflowPropagationMatcher([]string{"orchestrator.svc"})
+	rt := WrapTransportForWorkflowPropagation(rec, matcher)
+
+	ctx := WithWorkflowContext(context.Background(), WorkflowContext{
+		WorkflowID:          "wf-deploy",
+		WorkflowExecutionID: "wfrun-001",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.openai.com/v1/chat", nil)
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	for _, h := range []string{
+		HeaderWorkflowID, HeaderWorkflowExecutionID,
+		HeaderWorkflowStageID, HeaderWorkflowStepID, HeaderInvocationCaller,
+	} {
+		if v := rec.gotReq.Header.Get(h); v != "" {
+			t.Errorf("non-allowlisted host leaked header %s=%q", h, v)
+		}
+	}
+}
+
+// TestWorkflowPropagationTransport_NoOpWhenContextIsZero pins the
+// "no workflow context = nothing to propagate" path. A direct A2A
+// invocation (no orchestrator headers) carries an IsZero
+// WorkflowContext; the wrapper must not stamp empty values onto
+// outbound headers.
+func TestWorkflowPropagationTransport_NoOpWhenContextIsZero(t *testing.T) {
+	rec := &recordingRoundTripper{}
+	matcher := NewWorkflowPropagationMatcher([]string{"peer.svc"})
+	rt := WrapTransportForWorkflowPropagation(rec, matcher)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://peer.svc/health", nil)
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	for _, h := range []string{
+		HeaderWorkflowID, HeaderWorkflowExecutionID,
+		HeaderWorkflowStageID, HeaderWorkflowStepID, HeaderInvocationCaller,
+	} {
+		if v := rec.gotReq.Header.Get(h); v != "" {
+			t.Errorf("empty-ctx allowlisted call leaked header %s=%q", h, v)
+		}
+	}
+}
+
+// TestWrapTransportForWorkflowPropagation_EmptyMatcherShortCircuits
+// confirms the zero-overhead default-deploy path: an empty matcher
+// returns the underlying transport identity-equal, never wrapping it.
+// The reflective check uses interface comparison — if the wrapper had
+// been allocated, the returned RoundTripper would NOT equal `rec`.
+func TestWrapTransportForWorkflowPropagation_EmptyMatcherShortCircuits(t *testing.T) {
+	rec := &recordingRoundTripper{}
+	got := WrapTransportForWorkflowPropagation(rec, NewWorkflowPropagationMatcher(nil))
+	if got != http.RoundTripper(rec) {
+		t.Errorf("empty matcher should return the underlying transport unchanged; got %T", got)
+	}
+}
+
+// TestWorkflowPropagationTransport_DoesNotMutateOriginalRequest pins
+// the http.RoundTripper contract: a wrapper MUST NOT modify the
+// caller's req. We mutate headers when applying the workflow set, so
+// the wrapper must clone the request. Failing this test would mean
+// the caller's req.Header carries the propagated headers after the
+// round-trip — a leak across subsequent retries with the SAME req.
+func TestWorkflowPropagationTransport_DoesNotMutateOriginalRequest(t *testing.T) {
+	rec := &recordingRoundTripper{}
+	matcher := NewWorkflowPropagationMatcher([]string{"peer.svc"})
+	rt := WrapTransportForWorkflowPropagation(rec, matcher)
+
+	ctx := WithWorkflowContext(context.Background(), WorkflowContext{
+		WorkflowID: "wf-x",
+	})
+	original, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://peer.svc/", nil)
+	_, _ = rt.RoundTrip(original)
+
+	if original.Header.Get(HeaderWorkflowID) != "" {
+		t.Errorf("wrapper mutated caller's request headers; got %s=%q",
+			HeaderWorkflowID, original.Header.Get(HeaderWorkflowID))
+	}
+}
+
+// TestWorkflowPropagationTransport_EndToEnd is the integration check
+// the issue calls out: a stubbed HTTP server records the inbound
+// headers, the wrapper is the only thing between an http.Client and
+// that server, and the recorded headers carry the workflow ids. This
+// confirms the wrapper works end-to-end against a real net/http
+// client, not just the recording-transport unit tests.
+func TestWorkflowPropagationTransport_EndToEnd(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	// The matcher must cover the httptest server's host (127.0.0.1
+	// with an ephemeral port). The matcher strips ports, so an
+	// exact "127.0.0.1" entry covers any port the test server picks.
+	matcher := NewWorkflowPropagationMatcher([]string{"127.0.0.1"})
+	client := &http.Client{
+		Transport: WrapTransportForWorkflowPropagation(http.DefaultTransport, matcher),
+	}
+
+	ctx := WithWorkflowContext(context.Background(), WorkflowContext{
+		WorkflowID:          "wf-int",
+		WorkflowExecutionID: "exec-int-9",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got.Get(HeaderWorkflowID) != "wf-int" {
+		t.Errorf("server received WorkflowID=%q, want wf-int", got.Get(HeaderWorkflowID))
+	}
+	if got.Get(HeaderWorkflowExecutionID) != "exec-int-9" {
+		t.Errorf("server received WorkflowExecutionID=%q, want exec-int-9",
+			got.Get(HeaderWorkflowExecutionID))
+	}
+}
+
+// errRoundTripper returns a fixed error on every RoundTrip so we can
+// confirm the wrapper propagates underlying-transport failures
+// unchanged (no swallowing, no rewrap).
+type errRoundTripper struct{ err error }
+
+func (e *errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+
+// TestWorkflowPropagationTransport_PropagatesUnderlyingError confirms
+// the wrapper is transparent on error: a network error, an egress
+// block, a context-cancel — anything the underlying transport
+// returns must reach the caller unchanged so existing retry / logging
+// logic continues to fire.
+func TestWorkflowPropagationTransport_PropagatesUnderlyingError(t *testing.T) {
+	want := errors.New("simulated transport failure")
+	matcher := NewWorkflowPropagationMatcher([]string{"peer.svc"})
+	rt := WrapTransportForWorkflowPropagation(&errRoundTripper{err: want}, matcher)
+
+	ctx := WithWorkflowContext(context.Background(), WorkflowContext{WorkflowID: "wf"})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://peer.svc/", nil)
+	_, err := rt.RoundTrip(req)
+	if !errors.Is(err, want) {
+		t.Errorf("RoundTrip err = %v, want %v", err, want)
+	}
+}
+
+// TestNewWorkflowPropagationMatcher_RejectsBadInputCleanly walks the
+// boundary inputs — leading/trailing whitespace, empty strings,
+// mixed-case — and confirms the matcher normalizes consistently.
+// Spelled out here as a regression pin: an operator who copy-pastes
+// a host with a stray trailing space MUST still get a match.
+func TestNewWorkflowPropagationMatcher_RejectsBadInputCleanly(t *testing.T) {
+	m := NewWorkflowPropagationMatcher([]string{
+		"  ORCHESTRATOR.SVC  ",
+		"\t*.AGENTS.INTERNAL\n",
+		"",
+		"   ",
+	})
+	if !m.Matches("orchestrator.svc") {
+		t.Errorf("normalized exact match should hit")
+	}
+	if !m.Matches("a.agents.internal") {
+		t.Errorf("normalized wildcard should hit")
+	}
+}
+
+// keep the strings import in use across builds where the file may be
+// edited; cheap sanity that the package compiles standalone.
+var _ = strings.HasPrefix

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -34,6 +34,39 @@ type ForgeConfig struct {
 	Observability  ObservabilityConfig `yaml:"observability,omitempty"`
 	Security       SecurityConfig      `yaml:"security,omitempty"`
 	Audit          AuditConfig         `yaml:"audit,omitempty"`
+	// WorkflowPropagation gates which downstream hosts auto-receive
+	// the X-Workflow-* / X-Invocation-Caller headers when this agent
+	// calls them as a tool. See issue #186 / FORGE-1 — auto-propagation
+	// is off by default to stop workflow identity from leaking to
+	// third-party APIs.
+	WorkflowPropagation WorkflowPropagationConfig `yaml:"workflow_propagation,omitempty"`
+}
+
+// WorkflowPropagationConfig opts-in specific downstream hosts to
+// receive workflow correlation headers automatically when this agent
+// invokes them from any built-in HTTP tool. Without an entry on the
+// allow-list, the headers stay opt-in and tools must call
+// `WorkflowContextFromContext(ctx).ApplyToHTTPHeaders(req.Header)`
+// explicitly to propagate them (the pre-#186 behavior).
+//
+// Allowed entries follow the same exact + wildcard shape as the
+// egress allow-list (`security.DomainMatcher`):
+//
+//   - Exact: "orchestrator.svc"
+//   - Wildcard suffix: "*.agents.internal"
+//
+// The matcher strips ports before comparing, so an entry like
+// "peer.local" also covers "peer.local:8443".
+//
+// The auto-apply hook lives in forge-core/runtime; the runner installs
+// a transport wrapper around the egress client's transport that
+// consults this matcher per outbound request. See issue #186.
+type WorkflowPropagationConfig struct {
+	// AllowedHosts is the list of exact + wildcard hostname patterns
+	// that should auto-receive the X-Workflow-* / X-Invocation-Caller
+	// headers when the current request carries a non-zero
+	// WorkflowContext. Empty list = opt-in only (default).
+	AllowedHosts []string `yaml:"allowed_hosts,omitempty"`
 }
 
 // AuditConfig groups audit-pipeline knobs that are operator-visible in


### PR DESCRIPTION
## Summary

Adds a `workflow_propagation.allowed_hosts` block to `forge.yaml`. Outbound HTTP tool calls targeting a matching host automatically receive the workflow correlation headers (`X-Workflow-Id` / `X-Workflow-Execution-Id` / `X-Workflow-Stage-Id` / `X-Workflow-Step-Id` / `X-Invocation-Caller`) from the current request context. Hosts not on the list keep the pre-#186 opt-in posture — tools must call `ApplyToHTTPHeaders` explicitly. Empty / missing block = zero-overhead pass-through (current behavior).

```yaml
workflow_propagation:
  allowed_hosts:
    - "orchestrator.svc"         # exact host (port stripped before compare)
    - "*.agents.internal"        # wildcard suffix (strictly-deeper subdomains)
```

## Why

Forge already accepted the workflow headers inbound (FWS-2 / #185) and stamped them on every audit event. But propagation to downstream agents was manual: each HTTP tool had to call `WorkflowContextFromContext(ctx).ApplyToHTTPHeaders(req.Header)` itself. The skill correctly flagged that auto-propagation is risky (leaks workflow identity to third-party APIs like `api.openai.com`), but the manual approach broke the trace at every agent-to-agent hop where the tool author forgot.

This change keeps the safe default and adds an opt-in allow-list — the same shape as the existing egress allow-list — so operators get auto-propagation inside their trust boundary without leaking outside it.

## Implementation

- **`forge-core/types/config.go`** — new `WorkflowPropagationConfig` with `AllowedHosts []string`; attached to `ForgeConfig` under `workflow_propagation`.
- **`forge-core/runtime/workflow_propagation.go`** — new `WorkflowPropagationMatcher` (exact + wildcard, port-stripped, case-insensitive). Wildcards match strictly-deeper subdomains — `*.agents.internal` matches `payments.agents.internal` but NOT the bare `agents.internal`. `WrapTransportForWorkflowPropagation` returns the underlying transport identity-equal when the matcher is empty, so zero-config deploys pay no per-request overhead.
- **`forge-cli/runtime/runner.go`** — builds the matcher from `cfg.WorkflowPropagation.AllowedHosts` and wraps the egress client's transport once at startup. Every built-in HTTP tool (`http_request`, `webhook_call`, `web_search_*`) routes through `security.EgressTransportFromContext` so all of them inherit the auto-apply without per-tool changes.

The wrapper clones the request before stamping headers (`http.RoundTripper` contract — must not mutate the caller's request) so a caller's `req.Header` is never modified across retries.

## Safety

- **Default-deploy unchanged**: an absent `workflow_propagation` block (or `allowed_hosts: []`) returns the egress transport identity-equal — no wrapper, no header mutation, no observable change.
- **No leaks**: a request to a non-allowlisted host (e.g. `api.openai.com`) NEVER receives the workflow headers, even with a fully-populated `WorkflowContext`. Pinned by `TestWorkflowPropagationTransport_OmitsHeadersOnUnlistedHost`.
- **No mutation across retries**: caller's `req.Header` is preserved. Pinned by `TestWorkflowPropagationTransport_DoesNotMutateOriginalRequest`.
- **No spurious empty headers**: when the request ctx is `IsZero` (direct A2A invocation, no orchestrator), even allow-listed hosts get nothing — we don't stamp empty values. Pinned by `TestWorkflowPropagationTransport_NoOpWhenContextIsZero`.
- **Transparent errors**: underlying-transport errors pass through unchanged. Pinned by `TestWorkflowPropagationTransport_PropagatesUnderlyingError`.

## Dependency

Builds on FORGE-2 (#185) — the propagated header set includes the new `X-Workflow-Execution-Id` from that PR.

## Out of scope

- **Subprocess egress proxy path**: skills running in a subprocess that issue HTTP via the proxy don't route through `security.EgressTransportFromContext`. If that surface needs the same auto-apply, file a follow-up — needs proxy-side header injection, not in scope for this PR per the issue.

## Test plan

- [x] `golangci-lint run` across all four modules — 0 issues
- [x] `gofmt -w` across all modules
- [x] `go test ./...` in `forge-core/` and `forge-cli/` — all green
- [x] New unit tests pin: host matcher (exact / wildcard / no-match / port-strip / case-insensitive / apex-doesn't-match / longer-host-doesn't-trick), nil-guard + IsEmpty short-circuit, headers applied on allow-listed host, headers absent on non-allowlisted host, no-op on IsZero context, no mutation of caller's request, full end-to-end against `httptest.NewServer`, underlying error propagation.
- [ ] Manual smoke: `forge run` an agent with `workflow_propagation.allowed_hosts: ["127.0.0.1"]`, invoke a tool that POSTs to a local echo server, confirm the inbound request carries all five workflow headers; remove the entry, confirm headers are absent.