### PR TITLE
feat(observability): add auth.verify, channel.<adapter>.deliver, schedule.fire spans (closes #187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@
 
 ### Added
 
+- **Three runtime spans for previously-invisible latency / causality
+  surfaces: `auth.verify`, `channel.<adapter>.deliver`, `schedule.fire`
+  (issue #187).** All three use the existing global `Tracer()` (no new
+  install) and respect the off-by-default tracing posture — when
+  tracing is disabled the no-op tracer makes them zero-allocation.
+  Status=Error on the failure path keeps error-rate dashboards
+  consistent across span types.
+  - **`auth.verify`** wraps the `Provider.Chain.Verify` call in
+    `forge-core/auth/middleware.go`. Provider outbound HTTP calls
+    (JWKS / STS / IAP / Graph) now nest under it instead of appearing
+    as orphan roots. Attributes: `forge.auth.provider`,
+    `forge.auth.token_kind`, `forge.auth.decision`,
+    `forge.auth.user_id` / `org_id` (success), `forge.auth.fail_reason`
+    (failure). The `auth.FailReason(err) string` helper is exported
+    from `forge-core/auth` so the span and the audit `auth_fail` event
+    share one reason vocabulary; the forge-cli runtime's local
+    `authFailReason` now delegates to it.
+  - **`channel.<adapter>.deliver`** wraps the per-message handler in
+    every channel adapter (Slack / Telegram / Teams) via a new
+    `channels.StartDeliverSpan` helper. The internal A2A POST in
+    `forge-cli/channels/router.go` now injects the W3C `traceparent`
+    via the global propagator, so the downstream `a2a.tasks/send`
+    span nests under the deliver span. Attributes:
+    `forge.channel.adapter`, `forge.channel.target`,
+    `forge.channel.message_id`, `forge.channel.user_id`. Highest
+    user-visible payoff of the three — operators can now answer
+    "Slack→agent latency" from the flame graph alone.
+  - **`schedule.fire`** wraps `Scheduler.fire` in
+    `forge-core/scheduler/scheduler.go` (file backend only).
+    Attributes: `forge.schedule.id`, `forge.schedule.cron`,
+    `forge.schedule.source` (`yaml` / `llm`). K8s-backend dispatch is
+    out of scope for v1 — the trigger Pod is a separate curl-based
+    Pod and needs `traceparent` injected into the rendered CronJob
+    YAML at `forge package` time (follow-up).
+  - Pinned by `TestAuthVerifySpan_{SuccessRecordsProviderTokenKindDecision,
+    FailureSetsErrorStatusAndFailReason,
+    MissingBearerOpensZeroDurationSpan,
+    ParentsProviderHTTPClientSpans}`,
+    `TestStartDeliverSpan_{StampsAdapterAndEventAttributes,
+    ErrorSetsStatus,AdapterNameDrivesSpanName,
+    ChildContextCarriesActiveSpan,NilEventDoesNotCrash}`,
+    `TestScheduleFireSpan_{StampsAttributesAndParentsDispatch,
+    ErrorSetsStatusError,SourceSurfacesLLMOriginatedSchedules}`.
+
 - **FORGE-1: opt-in auto-propagation of workflow correlation headers
   on outbound HTTP tool calls (issue #186).** Adds a
   `workflow_propagation.allowed_hosts` block to `forge.yaml`. Hosts

--- a/docs/core-concepts/channels.md
+++ b/docs/core-concepts/channels.md
@@ -269,3 +269,10 @@ type ChannelPlugin interface {
 2. Implement `ChannelPlugin`.
 3. Register the plugin in the channel registry.
 4. Add config generation in `generateChannelConfig()` and env vars in `generateEnvVars()`.
+5. Wrap your per-message handler with `channels.StartDeliverSpan(ctx, "<adapter>", event)` so the dispatch lands in traces as `channel.<adapter>.deliver` and the downstream A2A POST nests under it via the W3C `traceparent` injected by the router. See [Observability — Tracing › `channel.<adapter>.deliver`](../core-concepts/observability-tracing.md#channeladapterdeliver).
+
+## Tracing
+
+When tracing is enabled, each inbound message produces a `channel.<adapter>.deliver` span that wraps the adapter's per-message handler. The internal A2A POST in `forge-cli/channels/router.go` injects the W3C `traceparent` from that span's context, so the agent server's `a2a.tasks/send` span nests under the deliver span. Operators can finally answer "how long does Slack→agent take?" from the flame graph alone, without correlating two unconnected trace roots.
+
+Attributes (Slack / Telegram / Teams alike): `forge.channel.adapter`, `forge.channel.target` (Slack channel ID / Telegram chat ID / Teams chat ID), `forge.channel.message_id` (pivot back to the upstream system), `forge.channel.user_id`. Span Status is set to `Error` on handler / send failure. See [Observability — Tracing](../core-concepts/observability-tracing.md#channeladapterdeliver) for the full attribute reference.

--- a/docs/core-concepts/observability-tracing.md
+++ b/docs/core-concepts/observability-tracing.md
@@ -123,13 +123,64 @@ Name parsing is case-insensitive and whitespace-tolerant. Unknown names error lo
 ## Span hierarchy
 
 ```
+auth.verify                           [pre-request; parents provider HTTP calls]
+└── http.client (× JWKS/STS/IAP/Graph)
+
 a2a.<method>                          [SpanKindServer; dispatcher]
 └── agent.execute                     [outer loop; root for the task]
     ├── llm.completion (× N turns)    [per LLM provider call]
     │   └── http.client (× outbound)  [auto via otelhttp on egress transport]
     └── tool.<tool_name> (× M calls)  [per tool invocation]
         └── http.client (if HTTP)
+
+channel.<adapter>.deliver             [inbound Slack/Telegram/Teams]
+└── a2a.tasks/send (via internal POST + injected traceparent)
+    └── (full a2a.<method> subtree above)
+
+schedule.fire                         [file-backend tick; opens per fire]
+└── (a2a.<method> / agent.execute subtree, depending on dispatcher)
 ```
+
+`auth.verify`, `channel.<adapter>.deliver`, and `schedule.fire` were added in issue #187 to cover three latency / causality surfaces operators previously couldn't see in traces. Each one:
+
+- Is opened once per operation (auth: per inbound request; channel: per inbound message; schedule: per file-backend tick).
+- Uses the global `Tracer()` — no new tracer install — so the off-by-default tracing posture extends to them automatically (no-op when tracing is disabled, zero allocation).
+- Sets `codes.Error` Status on the failure path so the error-rate dashboards work uniformly across span types.
+
+### `auth.verify`
+
+Wraps the `Provider.Chain.Verify` call in `forge-core/auth/middleware.go`. Without this span the provider's outbound HTTP calls (JWKS fetch, AWS STS verify, IAP token introspect, AAD Graph) showed up as **orphan root spans** with no "why was this called" context, and total auth latency was invisible.
+
+| Attribute | Source |
+|---|---|
+| `forge.auth.provider` | `Identity.Source` (e.g. `oidc`, `gcp_iap`, `aws_sigv4`) — only on success |
+| `forge.auth.token_kind` | `jwt` / `opaque` / `sigv4` / `iap_jwt` / `empty` — mirrors the audit `token_kind` field |
+| `forge.auth.decision` | `verify` on success, `fail` on any rejection |
+| `forge.auth.user_id` / `org_id` | from `Identity` on success |
+| `forge.auth.fail_reason` | `missing_token` / `rejected` / `invalid` / `not_for_me` / `provider_unavailable` / `infrastructure` — only on failure; matches the `auth.FailReason` vocabulary used by the audit `auth_fail` event |
+
+Span closes BEFORE `installSequenceCounterMiddleware` runs, so it sits outside the per-invocation sequence counter scope — the right scope, since the question is "did the caller authenticate?", not "what did the agent do?"
+
+### `channel.<adapter>.deliver`
+
+Wraps the per-message handler in each channel adapter (Slack / Telegram / Teams) around the parse + thread-context fetch + internal A2A POST. The router's internal POST injects the W3C `traceparent` from the calling ctx, so the agent server's `a2a.tasks/send` span nests under `channel.<adapter>.deliver` and you can finally answer "how long does Slack→agent take?" from the flame graph alone.
+
+| Attribute | Source |
+|---|---|
+| `forge.channel.adapter` | `slack` / `telegram` / `msteams` |
+| `forge.channel.target` | conversational destination — Slack channel ID, Telegram chat ID, Teams chat ID |
+| `forge.channel.message_id` | upstream message identifier (pivot back to the source system) |
+| `forge.channel.user_id` | upstream sender identity |
+
+### `schedule.fire`
+
+Wraps `Scheduler.fire` in `forge-core/scheduler/scheduler.go`. Before this span the dispatched executor work looked unsourced — no current span at fire time, so any downstream `agent.execute` was an orphan root. **File-backend only for v1.** The K8s backend's trigger Pod is a separate curl-based Pod and would need `traceparent` injected into the rendered CronJob YAML at `forge package` time — tracked as a follow-up.
+
+| Attribute | Source |
+|---|---|
+| `forge.schedule.id` | `Schedule.ID` |
+| `forge.schedule.cron` | `Schedule.Cron` |
+| `forge.schedule.source` | `yaml` (from `forge.yaml schedules[]`) or `llm` (added at runtime via `schedule_create`) |
 
 ### Attribute conventions
 

--- a/docs/core-concepts/scheduling.md
+++ b/docs/core-concepts/scheduling.md
@@ -80,3 +80,17 @@ When `forge package` runs with `schedules[]` populated, it emits one `cronjob-<i
 - **Persistence (Kubernetes mode)**: CronJob resources in etcd — durable across pod restarts without a PVC.
 - **History**: File backend keeps the last 50 executions per schedule. Kubernetes backend defers to the audit stream's `schedule_complete` events.
 - **Audit events**: `schedule_fire`, `schedule_complete`, `schedule_skip`, `schedule_modify`.
+
+## Tracing
+
+When tracing is enabled, the **file backend** opens a `schedule.fire` span around each dispatch. The dispatcher's downstream `agent.execute` (and the LLM / tool subtree below it) nest under this span, so an operator filtering on `forge.schedule.id` in their trace browser sees every span the scheduled job produced as one tree instead of an orphaned `agent.execute` root.
+
+| Attribute | Source |
+|---|---|
+| `forge.schedule.id` | `Schedule.ID` |
+| `forge.schedule.cron` | `Schedule.Cron` — e.g. `@hourly`, `*/5 * * * *` |
+| `forge.schedule.source` | `yaml` (from `forge.yaml schedules[]`) or `llm` (added at runtime via `schedule_create`) |
+
+Span Status is set to `Error` when the dispatch callback returns an error so error-rate dashboards work uniformly across the Forge span families. See [Observability — Tracing › `schedule.fire`](../core-concepts/observability-tracing.md#schedulefire) for the full hierarchy.
+
+**Kubernetes backend** is **out of scope for v1** — the trigger Pod is a separate curl-based Pod, so plumbing `traceparent` into the dispatch requires injecting it into the rendered CronJob YAML at `forge package` time. Tracked as a follow-up.

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -411,11 +411,26 @@ audit events to map the actual call graph.
 
 ---
 
+## Tracing
+
+When tracing is enabled (`observability.tracing.enabled: true`), the auth middleware emits an `auth.verify` span around every `Provider.Chain.Verify` call. The span parents any outbound HTTP calls the provider issues (JWKS fetch, AWS STS verify, IAP token introspect, AAD Graph) so they nest under it instead of appearing as orphan root spans — making "why was this called" obvious in a trace browser.
+
+| Attribute | Source |
+|---|---|
+| `forge.auth.provider` | `Identity.Source` on success (`oidc`, `aws_sigv4`, `gcp_iap`, …) |
+| `forge.auth.token_kind` | `jwt` / `opaque` / `sigv4` / `iap_jwt` / `empty` — mirrors the audit field |
+| `forge.auth.decision` | `verify` (success) or `fail` (any rejection) |
+| `forge.auth.user_id` / `forge.auth.org_id` | from `Identity` on success |
+| `forge.auth.fail_reason` | `missing_token` / `rejected` / `invalid` / `not_for_me` / `provider_unavailable` / `infrastructure` — only on failure |
+
+Span Status is set to `Error` on the failure path so the error-rate dashboards count auth rejections consistently across the rest of the Forge span families. See [Observability — Tracing](../core-concepts/observability-tracing.md#authverify) for the full hierarchy.
+
 ## Related Documentation
 
 | Document | Description |
 |----------|-------------|
 | [Audit Logging](audit-logging.md) | `auth_verify` / `auth_fail` event shape, reason codes, `token_kind` values |
+| [Observability — Tracing](../core-concepts/observability-tracing.md) | `auth.verify` span attributes and parent semantics |
 | [Egress Security](egress-control.md) | Auth-host auto-allowlist and how it composes with operator-set domains |
 | [Trust Model](trust-model.md) | Caller → Forge trust boundary; what Forge does and doesn't trust |
 | [forge.yaml Schema](../reference/forge-yaml-schema.md) | Full YAML reference including `auth:` block |

--- a/forge-cli/channels/router.go
+++ b/forge-cli/channels/router.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+
 	"github.com/initializ/forge/forge-core/a2a"
 	"github.com/initializ/forge/forge-core/channels"
 )
@@ -87,6 +90,13 @@ func (r *Router) forwardToA2A(ctx context.Context, event *channels.ChannelEvent)
 	if r.bearerToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+r.bearerToken)
 	}
+	// Inject the W3C traceparent + baggage from the calling context onto
+	// the outbound HTTP request so the A2A server's a2a.tasks/send span
+	// nests under the calling channel.<adapter>.deliver span instead of
+	// starting as an orphan root. The composite propagator is installed
+	// globally in forge-core/runtime/tracing.go; when tracing is off
+	// it's a no-op and writes no headers. Issue #187.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(httpReq.Header))
 
 	resp, err := r.client.Do(httpReq)
 	if err != nil {

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -2638,22 +2638,11 @@ func makeAuthAuditCallback(auditLogger *coreruntime.AuditLogger) func(*http.Requ
 // distinguish "the token is bad" alerts from "the IdP is down" alerts
 // in their dashboards — the response and the runbook are different.
 func authFailReason(err error) string {
-	switch {
-	case err == nil:
-		return "unknown"
-	case errors.Is(err, auth.ErrMissingBearer):
-		return "missing_token"
-	case errors.Is(err, auth.ErrTokenRejected):
-		return "rejected"
-	case errors.Is(err, auth.ErrInvalidToken):
-		return "invalid"
-	case errors.Is(err, auth.ErrProviderUnavailable):
-		return "provider_unavailable"
-	case errors.Is(err, auth.ErrTokenNotForMe):
-		return "not_for_me"
-	default:
-		return "infrastructure"
-	}
+	// Delegate to forge-core/auth so the audit-event vocabulary and the
+	// auth.verify span-attribute vocabulary stay byte-identical (issue
+	// #187 — same reason codes appear in audit fail events and span
+	// forge.auth.fail_reason attributes; one source of truth).
+	return auth.FailReason(err)
 }
 
 // buildUserAuthChain returns the user-facing portion of the auth chain

--- a/forge-core/auth/auth_span_test.go
+++ b/forge-core/auth/auth_span_test.go
@@ -1,0 +1,281 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// installSpanRecorder swaps the global tracer provider for one that
+// records every emitted span into a SpanRecorder for the duration of
+// the test. Restores the prior provider on test cleanup so parallel /
+// later tests still see the no-op default.
+func installSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		coreruntime.SetTracerProvider(prev)
+	})
+	return rec
+}
+
+// staticOKProvider is a provider that accepts every token and returns
+// a fixed Identity. Used by the success-path span test.
+type staticOKProvider struct {
+	identity Identity
+}
+
+func (p *staticOKProvider) Name() string { return "static_ok" }
+func (p *staticOKProvider) Verify(_ context.Context, token string, _ Headers) (*Identity, error) {
+	id := p.identity
+	return &id, nil
+}
+
+// authSpanRejectingProvider returns a fixed sentinel error so the failure-path
+// tests can confirm the matching FailReason classification surfaces on
+// the span.
+type authSpanRejectingProvider struct{ err error }
+
+func (p *authSpanRejectingProvider) Name() string { return "rejecting" }
+func (p *authSpanRejectingProvider) Verify(_ context.Context, token string, _ Headers) (*Identity, error) {
+	return nil, p.err
+}
+
+func newAuthedRequest(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/tasks/send", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+// findSpanByName locates the first recorded span whose Name matches
+// `want` and returns it. Helper so each test stays focused on the
+// assertion that matters.
+func findSpanByName(t *testing.T, rec *tracetest.SpanRecorder, want string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range rec.Ended() {
+		if s.Name() == want {
+			return s
+		}
+	}
+	t.Fatalf("no span named %q recorded; got %d spans", want, len(rec.Ended()))
+	return nil
+}
+
+func attrValue(s sdktrace.ReadOnlySpan, key string) string {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// TestAuthVerifySpan_SuccessRecordsProviderTokenKindDecision is the
+// core issue #187 invariant on the success path. A request with a
+// valid token must produce an `auth.verify` span whose attributes
+// mirror the audit `auth_verify` event fields — same `provider` and
+// `token_kind`, plus `decision="verify"`. The audit row and the trace
+// span then cross-link cleanly by trace_id.
+func TestAuthVerifySpan_SuccessRecordsProviderTokenKindDecision(t *testing.T) {
+	rec := installSpanRecorder(t)
+
+	mw := Middleware(MiddlewareOptions{
+		Chain: &staticOKProvider{identity: Identity{
+			Source: "static_ok",
+			UserID: "u-42",
+			OrgID:  "o-7",
+		}},
+	})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAuthedRequest("eyJ.fake.jwt"))
+
+	span := findSpanByName(t, rec, "auth.verify")
+	if got := attrValue(span, observability.AttrForgeAuthProvider); got != "static_ok" {
+		t.Errorf("forge.auth.provider = %q, want static_ok", got)
+	}
+	if got := attrValue(span, observability.AttrForgeAuthDecision); got != "verify" {
+		t.Errorf("forge.auth.decision = %q, want verify", got)
+	}
+	if got := attrValue(span, observability.AttrForgeAuthTokenKind); got == "" {
+		t.Errorf("forge.auth.token_kind missing; got %v", span.Attributes())
+	}
+	if got := attrValue(span, observability.AttrForgeAuthUserID); got != "u-42" {
+		t.Errorf("forge.auth.user_id = %q, want u-42", got)
+	}
+	if got := attrValue(span, observability.AttrForgeAuthOrgID); got != "o-7" {
+		t.Errorf("forge.auth.org_id = %q, want o-7", got)
+	}
+}
+
+// TestAuthVerifySpan_FailureSetsErrorStatusAndFailReason pins the
+// failure-path contract. Each chain-error sentinel maps to a
+// distinct fail_reason code (matches the audit auth_fail vocabulary)
+// AND sets the span status to Error so the error-rate dashboards work
+// across span types uniformly.
+func TestAuthVerifySpan_FailureSetsErrorStatusAndFailReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantReason string
+	}{
+		{"rejected", ErrTokenRejected, "rejected"},
+		{"invalid", ErrInvalidToken, "invalid"},
+		{"provider_unavailable", ErrProviderUnavailable, "provider_unavailable"},
+		{"not_for_me", ErrTokenNotForMe, "not_for_me"},
+		{"infrastructure_fallback", errors.New("unexpected"), "infrastructure"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := installSpanRecorder(t)
+			mw := Middleware(MiddlewareOptions{Chain: &authSpanRejectingProvider{err: c.err}})
+			h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("downstream handler must not run on failure path")
+			}))
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newAuthedRequest("eyJ.fake.jwt"))
+
+			span := findSpanByName(t, rec, "auth.verify")
+			if got := attrValue(span, observability.AttrForgeAuthDecision); got != "fail" {
+				t.Errorf("decision = %q, want fail", got)
+			}
+			if got := attrValue(span, observability.AttrForgeAuthFailReason); got != c.wantReason {
+				t.Errorf("fail_reason = %q, want %q", got, c.wantReason)
+			}
+			if status := span.Status().Code; status != codes.Error {
+				t.Errorf("status.code = %v, want %v", status, codes.Error)
+			}
+			// Provider attribute must NOT be set on failure — the
+			// chain ran but no provider claimed the token.
+			if got := attrValue(span, observability.AttrForgeAuthProvider); got != "" {
+				t.Errorf("provider should be unset on failure; got %q", got)
+			}
+		})
+	}
+}
+
+// TestAuthVerifySpan_MissingBearerOpensZeroDurationSpan confirms the
+// path where the auth header is entirely absent still produces an
+// auth.verify span (Status=Error, fail_reason=missing_token). Without
+// this span the audit auth_fail event has no trace parent and SIEM
+// trace↔audit pivots silently break for the most common failure mode.
+func TestAuthVerifySpan_MissingBearerOpensZeroDurationSpan(t *testing.T) {
+	rec := installSpanRecorder(t)
+	mw := Middleware(MiddlewareOptions{Chain: &authSpanRejectingProvider{err: errors.New("should not be called")}})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("downstream handler must not run when bearer is missing")
+	}))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/tasks/send", nil))
+
+	span := findSpanByName(t, rec, "auth.verify")
+	if got := attrValue(span, observability.AttrForgeAuthFailReason); got != "missing_token" {
+		t.Errorf("fail_reason = %q, want missing_token", got)
+	}
+	if status := span.Status().Code; status != codes.Error {
+		t.Errorf("status.code = %v, want Error", status)
+	}
+}
+
+// TestAuthVerifySpan_ParentsProviderHTTPClientSpans pins the issue's
+// motivating use case: JWKS / STS / IAP / Graph outbound HTTP calls
+// the provider issues during Verify must nest UNDER auth.verify. We
+// stand up a real http.Client+Transport that opens a child span on
+// every round-trip and confirm its parent SpanContext is the
+// auth.verify span we just opened.
+func TestAuthVerifySpan_ParentsProviderHTTPClientSpans(t *testing.T) {
+	rec := installSpanRecorder(t)
+
+	providerHTTPCallParent := trace.SpanContext{}
+	roundTripper := childSpanRoundTripper{onParent: func(sc trace.SpanContext) {
+		providerHTTPCallParent = sc
+	}}
+	httpCallingProvider := &httpCallingProvider{client: &http.Client{Transport: roundTripper}}
+	mw := Middleware(MiddlewareOptions{Chain: httpCallingProvider})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAuthedRequest("eyJ.fake.jwt"))
+
+	authSpan := findSpanByName(t, rec, "auth.verify")
+	if !providerHTTPCallParent.IsValid() {
+		t.Fatalf("provider's outbound call captured no parent; auth.verify did not parent it")
+	}
+	if providerHTTPCallParent.TraceID() != authSpan.SpanContext().TraceID() {
+		t.Errorf("provider call trace_id = %s, want %s",
+			providerHTTPCallParent.TraceID(), authSpan.SpanContext().TraceID())
+	}
+	if providerHTTPCallParent.SpanID() != authSpan.SpanContext().SpanID() {
+		t.Errorf("provider call parent span_id = %s, want %s (auth.verify span)",
+			providerHTTPCallParent.SpanID(), authSpan.SpanContext().SpanID())
+	}
+}
+
+// httpCallingProvider mimics oidc/aws_sigv4/gcp_iap/http_verifier:
+// each Verify call issues at least one outbound HTTP request. The
+// test asserts the round-trip's ctx still carries the auth.verify
+// span so it parents whatever http.client span gets opened
+// downstream by an otelhttp-wrapped transport.
+type httpCallingProvider struct{ client *http.Client }
+
+func (p *httpCallingProvider) Name() string { return "http_caller" }
+func (p *httpCallingProvider) Verify(ctx context.Context, token string, _ Headers) (*Identity, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://jwks.invalid", nil)
+	// We don't actually do the network call — the round tripper is a
+	// stub that captures the ctx's active span and returns 200.
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return &Identity{Source: "http_caller", UserID: "u-1"}, nil
+}
+
+type childSpanRoundTripper struct {
+	onParent func(trace.SpanContext)
+}
+
+func (r childSpanRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// In real production this is `otelhttp.Transport` which opens an
+	// http.client span using the parent from req.Context(). We
+	// emulate that by capturing the current span's SpanContext from
+	// the request's ctx — which is the parent the wrapped transport
+	// would record.
+	parent := trace.SpanContextFromContext(req.Context())
+	r.onParent(parent)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     http.Header{},
+		Request:    req,
+	}, nil
+}
+
+// keep strings used so test imports stay tidy across edits.
+var _ = strings.TrimSpace

--- a/forge-core/auth/middleware.go
+++ b/forge-core/auth/middleware.go
@@ -5,6 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
 )
 
 // errorResponse is the JSON body returned for auth failures.
@@ -128,13 +134,45 @@ func Middleware(opts MiddlewareOptions) func(http.Handler) http.Handler {
 			hasNonBearerAuth := token == "" && iapHeader != ""
 
 			if token == "" && !hasNonBearerAuth {
+				// Open + immediately end an auth.verify span so the
+				// missing-token failure shows up in the flame graph
+				// (zero-duration span, Status=Error) instead of
+				// silently disappearing. Without the span the
+				// auth-fail audit event has no trace parent and
+				// SIEM trace ↔ audit pivots break for this path.
+				// Issue #187.
+				_, span := coreruntime.Tracer().Start(r.Context(), "auth.verify")
+				span.SetAttributes(
+					attribute.String(observability.AttrForgeAuthTokenKind, kind),
+					attribute.String(observability.AttrForgeAuthDecision, "fail"),
+					attribute.String(observability.AttrForgeAuthFailReason, "missing_token"),
+				)
+				span.SetStatus(codes.Error, "missing bearer token")
+				span.End()
 				notifyAuth(opts.OnAuth, r, nil, ErrMissingBearer, kind)
 				writeAuthError(w, "valid bearer token required")
 				return
 			}
 
-			identity, err := opts.Chain.Verify(r.Context(), token, HeadersFromRequest(r))
+			// Open auth.verify around the Provider.Verify call so any
+			// outbound http.client spans the provider opens (JWKS
+			// fetch, AWS STS verify, IAP token introspect, AAD Graph)
+			// nest under it instead of appearing as orphan roots.
+			// Total auth latency = span duration. The span ends before
+			// the per-invocation sequence counter is installed, which
+			// is the right scope: this span describes "did the caller
+			// authenticate?", not "what did the agent do during the
+			// invocation?". Issue #187.
+			verifyCtx, span := coreruntime.Tracer().Start(r.Context(), "auth.verify")
+			identity, err := opts.Chain.Verify(verifyCtx, token, HeadersFromRequest(r))
 			if err != nil || identity == nil {
+				span.SetAttributes(
+					attribute.String(observability.AttrForgeAuthTokenKind, kind),
+					attribute.String(observability.AttrForgeAuthDecision, "fail"),
+					attribute.String(observability.AttrForgeAuthFailReason, authFailReason(err)),
+				)
+				span.SetStatus(codes.Error, classifyAuthFailure(err))
+				span.End()
 				notifyAuth(opts.OnAuth, r, nil, err, kind)
 				writeAuthError(w, classifyAuthFailure(err))
 				return
@@ -149,6 +187,19 @@ func Middleware(opts MiddlewareOptions) func(http.Handler) http.Handler {
 			// was the verifier — that mis-attributes IAP-fronted traffic
 			// in audit dashboards.
 			kind = refineTokenKind(kind, identity.Source)
+
+			span.SetAttributes(
+				attribute.String(observability.AttrForgeAuthProvider, identity.Source),
+				attribute.String(observability.AttrForgeAuthTokenKind, kind),
+				attribute.String(observability.AttrForgeAuthDecision, "verify"),
+			)
+			if identity.UserID != "" {
+				span.SetAttributes(attribute.String(observability.AttrForgeAuthUserID, identity.UserID))
+			}
+			if identity.OrgID != "" {
+				span.SetAttributes(attribute.String(observability.AttrForgeAuthOrgID, identity.OrgID))
+			}
+			span.End()
 
 			notifyAuth(opts.OnAuth, r, identity, nil, kind)
 
@@ -188,6 +239,56 @@ func notifyAuth(cb func(*http.Request, *Identity, error, string), r *http.Reques
 	}
 	cb(r, id, err, kind)
 }
+
+// FailReason maps a chain error to a stable, low-cardinality reason
+// code suitable for span attributes, audit fields, dashboards, and
+// alerting. Reason strings are part of the audit-event contract and
+// the auth.verify span-attribute contract — changing them is a
+// breaking change for downstream consumers.
+//
+// Reason codes:
+//
+//	missing_token        - no Authorization header (or the auth header
+//	                       the chain expected)
+//	rejected             - provider recognized + denied (revoked,
+//	                       expired, 401, 4xx)
+//	invalid              - token malformed or cryptographically invalid
+//	not_for_me           - chain exhausted, no provider claimed the
+//	                       token
+//	provider_unavailable - verifier/IdP unreachable (5xx, network,
+//	                       undecodable)
+//	infrastructure       - other unexpected error
+//
+// provider_unavailable lets operators distinguish "the token is bad"
+// alerts from "the IdP is down" alerts in their dashboards — the
+// response and the runbook are different.
+//
+// Lives in forge-core/auth so both the middleware's auth.verify span
+// (issue #187) AND the audit-emit site in forge-cli/runtime use the
+// same vocabulary. Single source of truth.
+func FailReason(err error) string {
+	switch {
+	case err == nil:
+		return "unknown"
+	case errors.Is(err, ErrMissingBearer):
+		return "missing_token"
+	case errors.Is(err, ErrTokenRejected):
+		return "rejected"
+	case errors.Is(err, ErrInvalidToken):
+		return "invalid"
+	case errors.Is(err, ErrProviderUnavailable):
+		return "provider_unavailable"
+	case errors.Is(err, ErrTokenNotForMe):
+		return "not_for_me"
+	default:
+		return "infrastructure"
+	}
+}
+
+// authFailReason is a package-internal alias for FailReason. Kept so
+// existing call sites within forge-core/auth/middleware.go read
+// naturally; external callers use the exported FailReason.
+func authFailReason(err error) string { return FailReason(err) }
 
 // classifyAuthFailure maps a chain error into a user-visible message.
 // Keep messages generic to avoid leaking information about which provider

--- a/forge-core/channels/spans.go
+++ b/forge-core/channels/spans.go
@@ -1,0 +1,72 @@
+package channels
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// StartDeliverSpan opens a `channel.<adapter>.deliver` span around an
+// inbound channel adapter's per-message handler and returns a finish
+// closure that records the error and ends the span. The span attributes
+// mirror the upstream-system metadata an operator needs to pivot from
+// the trace back to the Slack thread / Telegram chat / Teams message
+// that produced this invocation. Issue #187.
+//
+// The span PARENTS the internal A2A POST that
+// `forge-cli/channels/router.go` issues, because that router injects
+// the W3C traceparent from the calling ctx onto the outbound HTTP
+// request — the A2A server's `a2a.tasks/send` span then nests under
+// this delivery span instead of starting as an orphan root.
+//
+// Usage shape (defer captures the named return so finish sees the
+// final err value):
+//
+//	go func() {
+//	    ctx, _, finish := channels.StartDeliverSpan(ctx, "slack", event)
+//	    var err error
+//	    defer finish(&err)
+//	    // ... handler work mutates err ...
+//	}()
+//
+// When tracing is disabled the global tracer is a no-op and Start
+// returns an empty span with zero allocations — safe to call on
+// every inbound message regardless of tracing posture.
+func StartDeliverSpan(ctx context.Context, adapter string, event *ChannelEvent) (context.Context, trace.Span, func(*error)) {
+	ctx, span := coreruntime.Tracer().Start(ctx, "channel."+adapter+".deliver")
+	attrs := []attribute.KeyValue{
+		attribute.String(observability.AttrForgeChannelAdapter, adapter),
+	}
+	if event != nil {
+		if event.WorkspaceID != "" {
+			// WorkspaceID is the per-adapter "conversational location"
+			// identifier — Slack channel ID, Telegram chat ID, Teams
+			// chat ID. Stamped as channel.target so SIEM filters pivot
+			// to the upstream system without translating per adapter.
+			attrs = append(attrs, attribute.String(
+				observability.AttrForgeChannelTarget, event.WorkspaceID))
+		}
+		if event.MessageID != "" {
+			attrs = append(attrs, attribute.String(
+				observability.AttrForgeChannelMessageID, event.MessageID))
+		}
+		if event.UserID != "" {
+			attrs = append(attrs, attribute.String(
+				observability.AttrForgeChannelUserID, event.UserID))
+		}
+	}
+	span.SetAttributes(attrs...)
+
+	finish := func(errPtr *error) {
+		if errPtr != nil && *errPtr != nil {
+			span.SetStatus(codes.Error, (*errPtr).Error())
+		}
+		span.End()
+	}
+	return ctx, span, finish
+}

--- a/forge-core/channels/spans_test.go
+++ b/forge-core/channels/spans_test.go
@@ -1,0 +1,149 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// installSpanRecorder swaps the global tracer provider for one that
+// records every emitted span and restores the prior provider on
+// cleanup. Mirrors the helper in forge-core/auth/auth_span_test.go.
+func installSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() { coreruntime.SetTracerProvider(prev) })
+	return rec
+}
+
+func findSpanByName(t *testing.T, rec *tracetest.SpanRecorder, want string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range rec.Ended() {
+		if s.Name() == want {
+			return s
+		}
+	}
+	t.Fatalf("no span named %q recorded; got %d spans", want, len(rec.Ended()))
+	return nil
+}
+
+func attrValue(s sdktrace.ReadOnlySpan, key string) string {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// TestStartDeliverSpan_StampsAdapterAndEventAttributes pins the issue
+// #187 channel-attribute contract. The span's adapter / target /
+// message_id / user_id attributes are sourced from the ChannelEvent
+// and the adapter name passed by the caller. Operators pivoting from
+// a customer support ticket ("find the trace for message X in
+// channel Y") rely on these being stamped consistently across all
+// three adapters.
+func TestStartDeliverSpan_StampsAdapterAndEventAttributes(t *testing.T) {
+	rec := installSpanRecorder(t)
+	event := &ChannelEvent{
+		Channel:     "slack",
+		WorkspaceID: "C0123",
+		ThreadID:    "1700000000.000001",
+		UserID:      "U987",
+		MessageID:   "1700000000.000200",
+	}
+	_, _, finish := StartDeliverSpan(context.Background(), "slack", event)
+	var err error
+	finish(&err)
+
+	s := findSpanByName(t, rec, "channel.slack.deliver")
+	if got := attrValue(s, observability.AttrForgeChannelAdapter); got != "slack" {
+		t.Errorf("adapter = %q, want slack", got)
+	}
+	if got := attrValue(s, observability.AttrForgeChannelTarget); got != "C0123" {
+		t.Errorf("target = %q, want C0123", got)
+	}
+	if got := attrValue(s, observability.AttrForgeChannelMessageID); got != "1700000000.000200" {
+		t.Errorf("message_id = %q", got)
+	}
+	if got := attrValue(s, observability.AttrForgeChannelUserID); got != "U987" {
+		t.Errorf("user_id = %q, want U987", got)
+	}
+}
+
+// TestStartDeliverSpan_ErrorSetsStatus is the failure-path contract.
+// Adapter handlers that return an error set Status=Error so the
+// error-rate dashboards work uniformly across the auth.verify /
+// channel.<adapter>.deliver / schedule.fire span families.
+func TestStartDeliverSpan_ErrorSetsStatus(t *testing.T) {
+	rec := installSpanRecorder(t)
+	_, _, finish := StartDeliverSpan(context.Background(), "telegram", &ChannelEvent{WorkspaceID: "chat-1"})
+	err := errors.New("simulated handler failure")
+	finish(&err)
+
+	s := findSpanByName(t, rec, "channel.telegram.deliver")
+	if code := s.Status().Code; code != codes.Error {
+		t.Errorf("status code = %v, want Error", code)
+	}
+	if desc := s.Status().Description; desc != "simulated handler failure" {
+		t.Errorf("status desc = %q", desc)
+	}
+}
+
+// TestStartDeliverSpan_AdapterNameDrivesSpanName pins the
+// `channel.<adapter>.deliver` naming convention. Switching adapter
+// changes the span name. Three runtimes' worth of trace dashboards
+// pre-filter on the literal span name to build "Slack→agent
+// latency" tiles; renaming the convention breaks them.
+func TestStartDeliverSpan_AdapterNameDrivesSpanName(t *testing.T) {
+	rec := installSpanRecorder(t)
+	for _, adapter := range []string{"slack", "telegram", "msteams"} {
+		_, _, finish := StartDeliverSpan(context.Background(), adapter, &ChannelEvent{WorkspaceID: "x"})
+		var err error
+		finish(&err)
+		findSpanByName(t, rec, "channel."+adapter+".deliver")
+	}
+}
+
+// TestStartDeliverSpan_ChildContextCarriesActiveSpan is the parent-
+// child contract that drives `traceparent` injection in the router.
+// The downstream A2A POST runs under the returned ctx; when its
+// outbound request gets the W3C traceparent header injected, the
+// downstream a2a.tasks/send span nests under
+// channel.<adapter>.deliver. If the returned ctx didn't carry the
+// span, the injection writes a no-op header and the nesting silently
+// breaks.
+func TestStartDeliverSpan_ChildContextCarriesActiveSpan(t *testing.T) {
+	installSpanRecorder(t)
+	ctx, span, finish := StartDeliverSpan(context.Background(), "slack", &ChannelEvent{WorkspaceID: "x"})
+	var err error
+	defer finish(&err)
+
+	got := trace.SpanFromContext(ctx)
+	if got.SpanContext().SpanID() != span.SpanContext().SpanID() {
+		t.Errorf("ctx-derived span %s != returned span %s",
+			got.SpanContext().SpanID(), span.SpanContext().SpanID())
+	}
+}
+
+// TestStartDeliverSpan_NilEventDoesNotCrash confirms the guard works
+// for the empty-event path that occurs in tests / on the
+// unconfigured-channels code path.
+func TestStartDeliverSpan_NilEventDoesNotCrash(t *testing.T) {
+	installSpanRecorder(t)
+	_, _, finish := StartDeliverSpan(context.Background(), "slack", nil)
+	var err error
+	finish(&err) // must not panic
+}

--- a/forge-core/observability/attrs.go
+++ b/forge-core/observability/attrs.go
@@ -175,6 +175,94 @@ const (
 	// stream.
 	AttrForgeGuardrailViolationCount = "forge.guardrail.violation_count"
 
+	// ─── Auth verification span attributes (issue #187) ──────────────
+	//
+	// Stamped on auth.verify spans the auth middleware opens around
+	// every Provider.Verify call. Symmetric to the auth_verify /
+	// auth_fail audit-event fields so a SIEM looking at a trace sees
+	// the same provider / token_kind / decision metadata it sees in
+	// the audit stream — pivot between the two by trace_id without a
+	// translation table.
+
+	// AttrForgeAuthProvider names the chain entry that verified the
+	// token — "oidc", "http_verifier", "gcp_iap", "aws_sigv4",
+	// "static_token". Sourced from Identity.Source on success; empty
+	// on the failure path (no provider claimed the token).
+	AttrForgeAuthProvider = "forge.auth.provider"
+
+	// AttrForgeAuthTokenKind is the post-verify structural classification
+	// of the credential — "jwt", "opaque", "sigv4", "iap_jwt", "empty".
+	// Matches the audit token_kind field exactly.
+	AttrForgeAuthTokenKind = "forge.auth.token_kind"
+
+	// AttrForgeAuthDecision is "verify" on success or "fail" on any
+	// rejection path. The span Status carries the codes.Error marker on
+	// fail; this attribute exists separately so SIEM consumers can
+	// group on decision without parsing span status strings.
+	AttrForgeAuthDecision = "forge.auth.decision"
+
+	// AttrForgeAuthUserID / OrgID stamp the verified identity. Omitted
+	// on the failure path. Useful for "auth latency per org" queries.
+	AttrForgeAuthUserID = "forge.auth.user_id"
+	AttrForgeAuthOrgID  = "forge.auth.org_id"
+
+	// AttrForgeAuthFailReason is the classified failure reason for the
+	// fail path — same vocabulary as the audit auth_fail.reason field
+	// (e.g. "missing_token", "token_not_for_me", "token_rejected").
+	// Omitted on the success path.
+	AttrForgeAuthFailReason = "forge.auth.fail_reason"
+
+	// ─── Channel adapter delivery span attributes (issue #187) ────────
+	//
+	// Stamped on channel.<adapter>.deliver spans the per-message handler
+	// opens around the inbound-channel → internal-A2A-POST hop. Pairs
+	// with traceparent injection on the internal POST so downstream
+	// a2a.tasks/send spans nest under channel.<adapter>.deliver in the
+	// flame graph.
+
+	// AttrForgeChannelAdapter names the channel plugin that received
+	// the message — "slack", "telegram", "msteams".
+	AttrForgeChannelAdapter = "forge.channel.adapter"
+
+	// AttrForgeChannelTarget identifies the conversational destination
+	// — Slack channel ID / thread TS, Telegram chat ID, Teams chat
+	// ID. Format is adapter-specific; a consumer pivots back to the
+	// upstream system by joining on (channel.adapter, channel.target).
+	AttrForgeChannelTarget = "forge.channel.target"
+
+	// AttrForgeChannelMessageID is the upstream message identifier the
+	// adapter received. Useful for the "find the trace for THIS Slack
+	// message" pivot from a customer support ticket.
+	AttrForgeChannelMessageID = "forge.channel.message_id"
+
+	// AttrForgeChannelUserID is the upstream sender identity — Slack
+	// U…, Telegram numeric ID, Teams AAD object ID. Useful for "auth
+	// latency by user" queries.
+	AttrForgeChannelUserID = "forge.channel.user_id"
+
+	// ─── Scheduler fire span attributes (issue #187) ──────────────────
+	//
+	// Stamped on schedule.fire spans the file-backend scheduler opens
+	// around every dispatch. Spans pair with the schedule_fire /
+	// schedule_complete audit events so a SIEM joins them by trace_id.
+	// K8s-backend dispatch is out of scope for v1 — the trigger Pod is
+	// a separate curl-based Pod and needs traceparent injected into the
+	// rendered CronJob YAML at `forge package` time.
+
+	// AttrForgeScheduleID is the schedule identifier — Schedule.ID from
+	// the registered Schedule struct.
+	AttrForgeScheduleID = "forge.schedule.id"
+
+	// AttrForgeScheduleCron is the cron expression that fired. Matches
+	// the schedule_fire audit event's identifier and lets operators
+	// build "fires per cron expression" rollups.
+	AttrForgeScheduleCron = "forge.schedule.cron"
+
+	// AttrForgeScheduleSource is either "yaml" (schedule from forge.yaml
+	// at startup) or "llm" (schedule added at runtime by the agent's
+	// LLM through the schedule_create tool). Sourced from Schedule.Source.
+	AttrForgeScheduleSource = "forge.schedule.source"
+
 	// AttrForgeGuardrailEvidence is the triggering content. Set only
 	// when TracingConfig.CaptureContent is true. Passes through
 	// PrepareSpanContent (redact-then-truncate) just like the other

--- a/forge-core/scheduler/schedule_fire_span_test.go
+++ b/forge-core/scheduler/schedule_fire_span_test.go
@@ -1,0 +1,211 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+func installSpanRecorderScheduler(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	coreruntime.SetTracerProvider(tp)
+	t.Cleanup(func() { coreruntime.SetTracerProvider(prev) })
+	return rec
+}
+
+func findSpanByNameScheduler(t *testing.T, rec *tracetest.SpanRecorder, want string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range rec.Ended() {
+		if s.Name() == want {
+			return s
+		}
+	}
+	t.Fatalf("no span named %q recorded; got %d spans", want, len(rec.Ended()))
+	return nil
+}
+
+func attrValueScheduler(s sdktrace.ReadOnlySpan, key string) string {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// TestScheduleFireSpan_StampsAttributesAndParentsDispatch is the
+// core issue #187 invariant on the scheduler. fire() opens a span
+// named "schedule.fire" whose attributes carry the schedule's id /
+// cron / source — exactly the keys an operator filters on when
+// asking "show me everything this scheduled job did over the past
+// hour." The dispatch callback's ctx MUST carry that span so any
+// downstream agent.execute / llm.completion / tool.<name> spans
+// nest under it.
+func TestScheduleFireSpan_StampsAttributesAndParentsDispatch(t *testing.T) {
+	rec := installSpanRecorderScheduler(t)
+
+	var dispatchParentTrace trace.TraceID
+	var dispatchParentSpan trace.SpanID
+	dispatch := func(ctx context.Context, sched Schedule) error {
+		sc := trace.SpanContextFromContext(ctx)
+		dispatchParentTrace = sc.TraceID()
+		dispatchParentSpan = sc.SpanID()
+		return nil
+	}
+
+	store := newMockStore()
+	store.schedules["job-7"] = Schedule{
+		ID:      "job-7",
+		Cron:    "@hourly",
+		Task:    "summarize-feed",
+		Source:  "yaml",
+		Enabled: true,
+		Created: time.Now().UTC().Add(-time.Hour),
+		LastRun: time.Now().UTC().Add(-time.Hour),
+	}
+
+	ctx := context.Background()
+	sched := New(store, dispatch, &mockLogger{}, nil)
+	sched.Reload(ctx)
+	sched.tick(ctx)
+
+	// Wait for the goroutine-backed fire() to finish — same pattern
+	// as the existing scheduler_test.go tests.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.Ended()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	span := findSpanByNameScheduler(t, rec, "schedule.fire")
+	if got := attrValueScheduler(span, observability.AttrForgeScheduleID); got != "job-7" {
+		t.Errorf("schedule.id = %q, want job-7", got)
+	}
+	if got := attrValueScheduler(span, observability.AttrForgeScheduleCron); got != "@hourly" {
+		t.Errorf("schedule.cron = %q, want @hourly", got)
+	}
+	if got := attrValueScheduler(span, observability.AttrForgeScheduleSource); got != "yaml" {
+		t.Errorf("schedule.source = %q, want yaml", got)
+	}
+	// Dispatch ctx MUST be a child of schedule.fire.
+	if dispatchParentTrace != span.SpanContext().TraceID() {
+		t.Errorf("dispatch parent trace %s != schedule.fire trace %s",
+			dispatchParentTrace, span.SpanContext().TraceID())
+	}
+	if dispatchParentSpan != span.SpanContext().SpanID() {
+		t.Errorf("dispatch parent span %s != schedule.fire span %s",
+			dispatchParentSpan, span.SpanContext().SpanID())
+	}
+}
+
+// TestScheduleFireSpan_ErrorSetsStatusError pins the failure-path:
+// the dispatch callback returning an error must surface as a span
+// Status=Error so the error-rate dashboards reflect "fraction of
+// fires that errored" without joining audit + trace streams.
+func TestScheduleFireSpan_ErrorSetsStatusError(t *testing.T) {
+	rec := installSpanRecorderScheduler(t)
+	dispatch := func(_ context.Context, _ Schedule) error {
+		return errors.New("simulated dispatch failure")
+	}
+
+	store := newMockStore()
+	store.schedules["job-fail"] = Schedule{
+		ID:      "job-fail",
+		Cron:    "@hourly",
+		Task:    "fail-me",
+		Source:  "llm",
+		Enabled: true,
+		Created: time.Now().UTC().Add(-time.Hour),
+		LastRun: time.Now().UTC().Add(-time.Hour),
+	}
+	ctx := context.Background()
+	sched := New(store, dispatch, &mockLogger{}, nil)
+	sched.Reload(ctx)
+	sched.tick(ctx)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.Ended()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	span := findSpanByNameScheduler(t, rec, "schedule.fire")
+	if code := span.Status().Code; code != codes.Error {
+		t.Errorf("status code = %v, want Error", code)
+	}
+}
+
+// TestScheduleFireSpan_SourceSurfacesLLMOriginatedSchedules is the
+// observability question the issue calls out as the
+// `schedule.source` attribute's reason for existing: operators want
+// to distinguish "this fire came from forge.yaml" from "the agent's
+// LLM created this schedule at runtime via schedule_create". Both
+// are valid; lumping them together hides bugs.
+func TestScheduleFireSpan_SourceSurfacesLLMOriginatedSchedules(t *testing.T) {
+	rec := installSpanRecorderScheduler(t)
+	var fired sync.Map
+	dispatch := func(_ context.Context, sched Schedule) error {
+		fired.Store(sched.ID, true)
+		return nil
+	}
+
+	store := newMockStore()
+	store.schedules["yaml-job"] = Schedule{
+		ID: "yaml-job", Cron: "@hourly", Task: "y", Source: "yaml",
+		Enabled: true,
+		Created: time.Now().UTC().Add(-time.Hour),
+		LastRun: time.Now().UTC().Add(-time.Hour),
+	}
+	store.schedules["llm-job"] = Schedule{
+		ID: "llm-job", Cron: "@hourly", Task: "l", Source: "llm",
+		Enabled: true,
+		Created: time.Now().UTC().Add(-time.Hour),
+		LastRun: time.Now().UTC().Add(-time.Hour),
+	}
+	ctx := context.Background()
+	sched := New(store, dispatch, &mockLogger{}, nil)
+	sched.Reload(ctx)
+	sched.tick(ctx)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.Ended()) >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	sources := map[string]string{}
+	for _, s := range rec.Ended() {
+		if s.Name() != "schedule.fire" {
+			continue
+		}
+		id := attrValueScheduler(s, observability.AttrForgeScheduleID)
+		source := attrValueScheduler(s, observability.AttrForgeScheduleSource)
+		sources[id] = source
+	}
+	if sources["yaml-job"] != "yaml" {
+		t.Errorf("yaml-job source = %q, want yaml", sources["yaml-job"])
+	}
+	if sources["llm-job"] != "llm" {
+		t.Errorf("llm-job source = %q, want llm", sources["llm-job"])
+	}
+}

--- a/forge-core/scheduler/scheduler.go
+++ b/forge-core/scheduler/scheduler.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/initializ/forge/forge-core/observability"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
 )
 
 // Logger is the minimal logging interface used by the scheduler.
@@ -178,6 +184,23 @@ func (s *Scheduler) tick(ctx context.Context) {
 func (s *Scheduler) fire(ctx context.Context, sched Schedule, fireTime time.Time) {
 	start := time.Now()
 
+	// Open schedule.fire around the dispatch so the runner's
+	// downstream agent.execute + llm.completion + tool.<name> spans
+	// nest under it, and the SIEM can answer "show me everything
+	// this scheduled job did" by joining on this span's trace_id.
+	// File-backend only — K8s-backend dispatch fires from a
+	// separate trigger Pod and would need traceparent injected into
+	// the rendered CronJob YAML at `forge package` time (deferred,
+	// see issue #187 out-of-scope). When tracing is off the global
+	// tracer is no-op and Start is zero-allocation.
+	ctx, span := coreruntime.Tracer().Start(ctx, "schedule.fire")
+	span.SetAttributes(
+		attribute.String(observability.AttrForgeScheduleID, sched.ID),
+		attribute.String(observability.AttrForgeScheduleCron, sched.Cron),
+		attribute.String(observability.AttrForgeScheduleSource, sched.Source),
+	)
+	defer span.End()
+
 	if s.audit != nil {
 		s.audit(AuditScheduleFire, sched.ID, map[string]any{"task": sched.Task})
 	}
@@ -189,6 +212,9 @@ func (s *Scheduler) fire(ctx context.Context, sched Schedule, fireTime time.Time
 
 	err := s.dispatch(ctx, sched)
 	duration := time.Since(start)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	}
 
 	status := "completed"
 	errStr := ""

--- a/forge-plugins/channels/msteams/msteams.go
+++ b/forge-plugins/channels/msteams/msteams.go
@@ -619,12 +619,22 @@ func (p *Plugin) dispatch(ctx context.Context, msg *ChatMessage, chatTypeHint st
 	go func() {
 		taskCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
-		resp, herr := handler(taskCtx, event)
+
+		// Open channel.msteams.deliver around the dispatch so the
+		// internal A2A POST (carrying the traceparent injected by the
+		// router) nests under it. Issue #187.
+		spanCtx, _, finish := channels.StartDeliverSpan(taskCtx, "msteams", event)
+		var handlerErr error
+		defer finish(&handlerErr)
+
+		resp, herr := handler(spanCtx, event)
 		if herr != nil {
+			handlerErr = herr
 			log.Printf("[msteams] handler error: %v", herr)
 			return
 		}
 		if serr := p.SendResponse(event, resp); serr != nil {
+			handlerErr = serr
 			log.Printf("[msteams] send response error: %v", serr)
 		}
 	}()

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -421,6 +421,16 @@ func (p *Plugin) readLoop(ctx context.Context, conn *websocket.Conn, handler cha
 		}
 
 		go func() {
+			// Open channel.slack.deliver around the full per-message
+			// pipeline (parse + thread context fetch + internal A2A
+			// POST) so operators can see "how long did Slack→agent
+			// take?" from the flame graph. The router injects the
+			// traceparent on the internal POST so the agent's
+			// a2a.tasks/send span nests under this one. Issue #187.
+			spanCtx, _, finish := channels.StartDeliverSpan(ctx, "slack", event)
+			var handlerErr error
+			defer finish(&handlerErr)
+
 			// Add :eyes: reaction to indicate we received the message.
 			_ = p.addReaction(event.WorkspaceID, event.MessageID, "eyes")
 
@@ -446,18 +456,20 @@ func (p *Plugin) readLoop(ctx context.Context, conn *websocket.Conn, handler cha
 				}
 			}()
 
-			resp, err := handler(ctx, event)
+			resp, err := handler(spanCtx, event)
 			close(done)
 
 			// Remove the :eyes: reaction.
 			_ = p.removeReaction(event.WorkspaceID, event.MessageID, "eyes")
 
 			if err != nil {
+				handlerErr = err
 				fmt.Printf("slack: handler error: %v\n", err)
 				return
 			}
-			if err := p.SendResponse(event, resp); err != nil {
-				fmt.Printf("slack: send response error: %v\n", err)
+			if sendErr := p.SendResponse(event, resp); sendErr != nil {
+				handlerErr = sendErr
+				fmt.Printf("slack: send response error: %v\n", sendErr)
 			}
 		}()
 	}

--- a/forge-plugins/channels/telegram/telegram.go
+++ b/forge-plugins/channels/telegram/telegram.go
@@ -224,7 +224,14 @@ func (p *Plugin) handleEvent(event *channels.ChannelEvent, handler channels.Even
 		taskCtx, taskCancel := context.WithTimeout(context.Background(), handlerTimeout)
 		defer taskCancel()
 
-		stopTyping := p.startTypingIndicator(taskCtx, event.WorkspaceID)
+		// Open channel.telegram.deliver around the full per-message
+		// pipeline so the internal A2A POST (which carries the
+		// traceparent injected by the router) nests under it. Issue #187.
+		spanCtx, _, finish := channels.StartDeliverSpan(taskCtx, "telegram", event)
+		var handlerErr error
+		defer finish(&handlerErr)
+
+		stopTyping := p.startTypingIndicator(spanCtx, event.WorkspaceID)
 
 		// Send an interim message if the task takes longer than the threshold.
 		done := make(chan struct{})
@@ -240,16 +247,18 @@ func (p *Plugin) handleEvent(event *channels.ChannelEvent, handler channels.Even
 			}
 		}()
 
-		resp, err := handler(taskCtx, event)
+		resp, err := handler(spanCtx, event)
 		close(done)
 		stopTyping()
 
 		if err != nil {
+			handlerErr = err
 			fmt.Printf("telegram: handler error: %v\n", err)
 			return
 		}
-		if err := p.SendResponse(event, resp); err != nil {
-			fmt.Printf("telegram: send response error: %v\n", err)
+		if sendErr := p.SendResponse(event, resp); sendErr != nil {
+			handlerErr = sendErr
+			fmt.Printf("telegram: send response error: %v\n", sendErr)
 		}
 	}()
 }


### PR DESCRIPTION
## Summary

Three runtime surfaces that own user-perceived latency or causality but didn't show up in traces before. All three landed under one PR per the issue.

| Span | What it covers | Headline payoff |
|---|---|---|
| `auth.verify` | wraps `Provider.Chain.Verify` in `forge-core/auth/middleware.go` | provider HTTP calls (JWKS / STS / IAP / Graph) stop showing as orphan roots; total auth latency is visible |
| `channel.<adapter>.deliver` | wraps the per-message handler in Slack / Telegram / Teams; the router's internal A2A POST now injects W3C `traceparent` | "Slack→agent latency" is answerable from one trace |
| `schedule.fire` | wraps `Scheduler.fire` (file backend) | scheduled-job downstream work has a parent instead of orphan `agent.execute` |

All three use the existing global `Tracer()` — no new tracer install. When tracing is off the no-op tracer makes them zero-allocation. Status=Error on the failure path keeps error-rate dashboards uniform.

## Attributes

```
auth.verify             forge.auth.provider, .token_kind, .decision,
                        .user_id, .org_id, .fail_reason
channel.X.deliver       forge.channel.adapter, .target, .message_id, .user_id
schedule.fire           forge.schedule.id, .cron, .source (yaml|llm)
```

## Cross-cutting

- Lifted `authFailReason` from `forge-cli/runtime` into the exported `auth.FailReason(err)` helper so the span's `forge.auth.fail_reason` attribute and the audit `auth_fail.reason` field share one vocabulary. Single source of truth.
- New `channels.StartDeliverSpan(ctx, adapter, event) (ctx, span, finish func(*error))` helper consumed identically by the three adapters so the span shape stays consistent.
- Span tests use the upstream `tracetest.SpanRecorder` swap-the-global-provider pattern; cleanup restores the no-op default.

## Out of scope (deferred follow-ups)

- **K8s-backend `schedule.fire`** — the trigger Pod is a separate curl-based Pod, so propagation needs `traceparent` injected into the rendered CronJob YAML at `forge package` time. Tracked as a follow-up.
- **Egress allow/block span** — decision lives inside the existing `http.client` span already; a child span would duplicate. If the decision needs visibility, a `forge.egress.decision` attribute on `http.client` is the right move.
- **MCP server startup span** — one-shot at startup; the `mcp_server_started` audit suffices.
- **Memory read/write spans** — in-process, microseconds; not worth the span-count multiplication without a specific perf question.

## Test plan

- [x] `golangci-lint run` across all four modules — 0 issues
- [x] `gofmt -w` across all modules
- [x] `go test ./...` in `forge-core/`, `forge-cli/`, `forge-plugins/` — all green
- [x] New unit tests pin:
  - **Auth**: success records provider / token_kind / decision / user_id / org_id; failure sets decision=fail + fail_reason from the FailReason() vocabulary + Status=Error (5 sub-cases: rejected / invalid / provider_unavailable / not_for_me / infrastructure); missing-bearer path opens a span with missing_token; provider's outbound HTTP calls inherit auth.verify as parent (the issue's motivating use case).
  - **Channel**: adapter / target / message_id / user_id attributes stamped; error path sets Status=Error; span name is `channel.<adapter>.deliver` for each of slack / telegram / msteams; returned ctx carries the active span (drives traceparent injection).
  - **Schedule**: id / cron / source attributes stamped; dispatch ctx is a child of schedule.fire; error path sets Status=Error; `yaml` vs `llm` source surfaces correctly.
- [ ] Manual smoke: enable tracing, hit an authenticated `tasks/send` and confirm the auth.verify span parents the provider's outbound HTTP call.