### PR TITLE
feat(llm): Anthropic-format custom URLs + AWS Bedrock SigV4 outbound (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@
 
 ### Added
 
+- **Anthropic-format custom URLs + AWS Bedrock SigV4 outbound auth
+  (issue #202).** Two-phase rollout:
+  - **Phase 1**: `forge init`'s "Custom" provider option now asks
+    whether the endpoint speaks OpenAI Chat Completions or Anthropic
+    Messages wire format and writes the matching provider into the
+    generated `forge.yaml` (`openai` or `anthropic`). Both flows
+    accept the same Base URL + API key inputs; the shape picker is
+    the only branch. Underlying plumbing already supported
+    `provider: anthropic + ANTHROPIC_BASE_URL` symmetric with the
+    OpenAI path (#137 / #139); this exposes it through the wizard.
+  - **Phase 2**: new `model.auth_scheme: aws_sigv4` + `model.aws_region`
+    fields on `ModelRef` (with matching `ClientConfig.AuthScheme` /
+    `AWSRegion`) wrap the LLM client's `http.Transport` with an
+    AWS SigV4 signer. Credentials resolve via the standard env vars
+    (`AWS_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY` / `_SESSION_TOKEN`).
+    Works symmetrically across the openai and anthropic providers
+    so an operator can point either at AWS Bedrock or any other
+    SigV4-fronted gateway:
+    - `provider: anthropic` + `auth_scheme: aws_sigv4` → calls
+      Anthropic-shaped endpoints with SigV4 signing instead of
+      `x-api-key`; the `anthropic-version` header still rides.
+    - `provider: openai` + `auth_scheme: aws_sigv4` → calls
+      OpenAI-shaped endpoints with SigV4 signing instead of
+      `Authorization: Bearer`; the `OpenAI-Organization` header
+      still rides.
+  - SigV4 signer is **hand-rolled** (~250 LOC, stdlib only) matching
+    the existing `forge-core/auth/providers/aws_sigv4` inbound-auth
+    posture — keeps the binary footprint flat (no aws-sdk-go-v2 +
+    ~5 MB).
+  - `AWS_REGION` env safety-net for the SigV4 path symmetric with
+    `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` env safety-nets — set
+    once at the platform layer instead of in every `forge.yaml`.
+  - Bedrock hostnames (`bedrock-runtime.<region>.amazonaws.com`)
+    auto-extend the egress allowlist via the existing
+    `LLMProviderDomains` parsing — no separate `egress.allowed_domains`
+    entry required when `model.base_url` points there.
+  - The empty `AuthScheme` default preserves the pre-#202 contract
+    byte-for-byte. Existing Anthropic and OpenAI deployments see
+    zero behavior change.
+  - Web identity tokens / IRSA / EC2 instance metadata resolution is
+    NOT yet supported — the credential getter reads env only. Most
+    Bedrock deployments today set the AWS env vars at the platform
+    layer (via IRSA's env injection, sidecar credential fetcher, or
+    `AWS_PROFILE` resolution). STS-based credential refresh is
+    tracked as a follow-up.
+  - **Out of scope for this PR**: Bedrock-specific URL / body
+    rewriting (`/model/<id>/invoke` path + `anthropic_version` body
+    field). Operators today either point Forge at a Bedrock-compat
+    proxy that handles the translation (litellm, OpenRouter) or wait
+    for a Phase 2.5 PR that adds native Bedrock InvokeModel
+    passthrough.
+  - Pinned by `TestSigV4Transport_{StampsAuthorizationAndAmzDate,
+    StampsSecurityTokenWhenTemporary,
+    PreservesBodyAndContentLength, DoesNotMutateCallerRequest,
+    PropagatesUnderlyingError, MissingCredentialsErrors,
+    RequiresRegionAndService, CanonicalQueryOrdering,
+    EndToEndAgainstHTTPTestServer}`,
+    `TestSigV4CredentialsFromEnv_ParsesStandardVars`,
+    `TestAnthropicClient_{DefaultAuthSchemeKeepsXAPIKey,
+    SigV4AuthSchemeOmitsXAPIKey, SigV4WrapsTransport,
+    DefaultTransportNotWrapped}`,
+    `TestOpenAIClient_{DefaultAuthSchemeKeepsBearer,
+    SigV4AuthSchemeOmitsBearer, SigV4WrapsTransport,
+    OrgIDStillSetUnderSigV4}`,
+    `TestLLMProviderDomains_BedrockHostExtracted`,
+    `TestNormalizeCustomProvider_{AnthropicShapeRewritesToAnthropic,
+    DefaultShapeStaysOpenAI}`.
+
 - **Platform admission hook for per-agent quota / cost-limit gating
   (issue #201).** A new pre-dispatch middleware lets the platform tell
   an agent process to stop accepting new `tasks/send` invocations when

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -18,15 +18,28 @@ entrypoint: "agent.py"              # Required for crewai/langchain, omit for fo
 model:
   provider: "openai"                # openai, anthropic, gemini, ollama
   name: "gpt-4o"                    # Model name
+  base_url: ""                      # Override the provider's default API host (issue #139)
   organization_id: "org-xxx"        # OpenAI Organization ID (enterprise, optional)
+  auth_scheme: ""                   # "" (default) / "x_api_key" / "bearer" / "aws_sigv4" — issue #202
+  aws_region: ""                    # Required when auth_scheme: aws_sigv4 — issue #202
   fallbacks:                        # Fallback providers (optional)
     - provider: "anthropic"
       name: "claude-sonnet-4-20250514"
       organization_id: ""           # Per-fallback org ID override (optional)
-# For OpenAI-compatible endpoints (OpenRouter, vLLM, litellm, self-hosted
-# Kimi/Llama): use provider: "openai" + set OPENAI_BASE_URL in .env.
-# The forge init wizard's "Custom" option normalizes to this shape — the
-# generated forge.yaml never carries provider: "custom".
+
+# Custom URL endpoints (OpenRouter, vLLM, litellm, self-hosted Kimi/Llama,
+# Together.ai, Anyscale, Bedrock OpenAI compat, …):
+#   provider: "openai" + OPENAI_BASE_URL env  → OpenAI Chat Completions wire format
+#   provider: "anthropic" + ANTHROPIC_BASE_URL env → Anthropic Messages wire format
+# The forge init wizard's "Custom" option asks which wire format the URL
+# speaks and writes the matching provider; generated forge.yaml never
+# carries provider: "custom". Issue #202 Phase 1.
+
+# AWS Bedrock with native API key auth is not supported (Bedrock uses
+# SigV4 signing). Set auth_scheme: aws_sigv4 + aws_region to use AWS
+# credentials (AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY / _SESSION_TOKEN
+# env) for outbound LLM calls — works against any SigV4-fronted endpoint
+# that speaks OpenAI or Anthropic wire format. Issue #202 Phase 2.
 
 tools:
   - name: "web_search"

--- a/forge-cli/cmd/init.go
+++ b/forge-cli/cmd/init.go
@@ -397,6 +397,13 @@ func collectInteractive(opts *initOptions) error {
 	if ctx.CustomAPIKey != "" {
 		opts.EnvVars["MODEL_API_KEY"] = ctx.CustomAPIKey
 	}
+	// Carry the wizard's wire-format choice through to
+	// normalizeCustomProvider via a synthetic env key. Stripped by
+	// the normalizer before .env is written so it never reaches the
+	// agent process. Issue #202 Phase 1.
+	if ctx.CustomShape != "" {
+		opts.EnvVars["__custom_shape"] = ctx.CustomShape
+	}
 
 	// Store egress domains, merging in any auth-provider hosts so the
 	// agent can reach its IdP / verifier at runtime.
@@ -536,26 +543,57 @@ func normalizeCustomProvider(opts *initOptions) {
 	if opts.ModelProvider != "custom" {
 		return
 	}
-	opts.ModelProvider = "openai"
-	// Migrate legacy MODEL_BASE_URL / MODEL_API_KEY (TUI wizard,
-	// older Web UI revs) to the OPENAI_* names the runtime reads.
-	if v := opts.EnvVars["MODEL_BASE_URL"]; v != "" {
-		opts.EnvVars["OPENAI_BASE_URL"] = v
-		delete(opts.EnvVars, "MODEL_BASE_URL")
+	// Issue #202 Phase 1: the wizard now asks whether the custom URL
+	// speaks OpenAI Chat Completions or Anthropic Messages wire
+	// format. The Web UI Custom flow doesn't ask yet — it falls
+	// through to the legacy openai default for back-compat. Honoring
+	// this here means both surfaces can converge on the same
+	// scaffold once the Web UI gains the picker.
+	shape := opts.EnvVars["__custom_shape"]
+	delete(opts.EnvVars, "__custom_shape")
+	if shape == "" {
+		shape = "openai"
 	}
-	if v := opts.EnvVars["MODEL_API_KEY"]; v != "" {
-		opts.EnvVars["OPENAI_API_KEY"] = v
-		delete(opts.EnvVars, "MODEL_API_KEY")
-		if opts.APIKey == "" {
-			opts.APIKey = v
+
+	switch shape {
+	case "anthropic":
+		opts.ModelProvider = "anthropic"
+		if v := opts.EnvVars["MODEL_BASE_URL"]; v != "" {
+			opts.EnvVars["ANTHROPIC_BASE_URL"] = v
+			delete(opts.EnvVars, "MODEL_BASE_URL")
 		}
-	}
-	// storeProviderEnvVar runs before scaffold and short-circuits when
-	// provider="custom"; fold in any opts.APIKey set by flag or POST
-	// so the .env emits OPENAI_API_KEY consistently with the path
-	// taken by every other openai-shaped configuration.
-	if opts.APIKey != "" && opts.EnvVars["OPENAI_API_KEY"] == "" {
-		opts.EnvVars["OPENAI_API_KEY"] = opts.APIKey
+		if v := opts.EnvVars["MODEL_API_KEY"]; v != "" {
+			opts.EnvVars["ANTHROPIC_API_KEY"] = v
+			delete(opts.EnvVars, "MODEL_API_KEY")
+			if opts.APIKey == "" {
+				opts.APIKey = v
+			}
+		}
+		if opts.APIKey != "" && opts.EnvVars["ANTHROPIC_API_KEY"] == "" {
+			opts.EnvVars["ANTHROPIC_API_KEY"] = opts.APIKey
+		}
+	default:
+		opts.ModelProvider = "openai"
+		// Migrate legacy MODEL_BASE_URL / MODEL_API_KEY (TUI wizard,
+		// older Web UI revs) to the OPENAI_* names the runtime reads.
+		if v := opts.EnvVars["MODEL_BASE_URL"]; v != "" {
+			opts.EnvVars["OPENAI_BASE_URL"] = v
+			delete(opts.EnvVars, "MODEL_BASE_URL")
+		}
+		if v := opts.EnvVars["MODEL_API_KEY"]; v != "" {
+			opts.EnvVars["OPENAI_API_KEY"] = v
+			delete(opts.EnvVars, "MODEL_API_KEY")
+			if opts.APIKey == "" {
+				opts.APIKey = v
+			}
+		}
+		// storeProviderEnvVar runs before scaffold and short-circuits when
+		// provider="custom"; fold in any opts.APIKey set by flag or POST
+		// so the .env emits OPENAI_API_KEY consistently with the path
+		// taken by every other openai-shaped configuration.
+		if opts.APIKey != "" && opts.EnvVars["OPENAI_API_KEY"] == "" {
+			opts.EnvVars["OPENAI_API_KEY"] = opts.APIKey
+		}
 	}
 }
 

--- a/forge-cli/cmd/init_custom_provider_test.go
+++ b/forge-cli/cmd/init_custom_provider_test.go
@@ -226,3 +226,58 @@ func TestScaffold_CustomProviderWebUIShape(t *testing.T) {
 		t.Errorf(".env missing OPENAI_API_KEY=sk-from-webui:\n%s", envStr)
 	}
 }
+
+// TestNormalizeCustomProvider_AnthropicShapeRewritesToAnthropic is
+// the issue #202 Phase 1 pin: when the wizard's shape picker chose
+// "anthropic", the normalizer rewrites MODEL_* env vars onto the
+// ANTHROPIC_* names AND flips the provider from "custom" to
+// "anthropic". Generated forge.yaml then carries
+// `provider: anthropic` and the runtime's ResolveModelConfig wires
+// ANTHROPIC_BASE_URL onto the client.
+func TestNormalizeCustomProvider_AnthropicShapeRewritesToAnthropic(t *testing.T) {
+	opts := &initOptions{
+		ModelProvider: "custom",
+		EnvVars: map[string]string{
+			"__custom_shape": "anthropic",
+			"MODEL_BASE_URL": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"MODEL_API_KEY":  "ignored-on-sigv4",
+		},
+	}
+	normalizeCustomProvider(opts)
+
+	if opts.ModelProvider != "anthropic" {
+		t.Errorf("ModelProvider = %q, want anthropic", opts.ModelProvider)
+	}
+	if got := opts.EnvVars["ANTHROPIC_BASE_URL"]; got != "https://bedrock-runtime.us-east-1.amazonaws.com" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q, want bedrock URL", got)
+	}
+	if got := opts.EnvVars["ANTHROPIC_API_KEY"]; got != "ignored-on-sigv4" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want carried-over key", got)
+	}
+	if _, present := opts.EnvVars["MODEL_BASE_URL"]; present {
+		t.Errorf("MODEL_BASE_URL should be deleted")
+	}
+	if _, present := opts.EnvVars["__custom_shape"]; present {
+		t.Errorf("__custom_shape synthetic env key must be stripped before write")
+	}
+}
+
+// TestNormalizeCustomProvider_DefaultShapeStaysOpenAI confirms back-
+// compat: no __custom_shape in env (e.g. Web UI Custom flow that
+// hasn't gained the picker yet) keeps the legacy default of OpenAI.
+func TestNormalizeCustomProvider_DefaultShapeStaysOpenAI(t *testing.T) {
+	opts := &initOptions{
+		ModelProvider: "custom",
+		EnvVars: map[string]string{
+			"MODEL_BASE_URL": "https://openrouter.example/v1",
+			"MODEL_API_KEY":  "sk-router",
+		},
+	}
+	normalizeCustomProvider(opts)
+	if opts.ModelProvider != "openai" {
+		t.Errorf("default-shape should map to openai; got %q", opts.ModelProvider)
+	}
+	if got := opts.EnvVars["OPENAI_BASE_URL"]; got == "" {
+		t.Errorf("OPENAI_BASE_URL should be set on default path")
+	}
+}

--- a/forge-cli/internal/tui/steps/provider_step.go
+++ b/forge-cli/internal/tui/steps/provider_step.go
@@ -23,6 +23,12 @@ const (
 	providerModelPhase
 	providerOrgIDPhase
 	providerCustomURLPhase
+	// providerCustomShapePhase asks whether the custom endpoint
+	// speaks OpenAI Chat Completions or Anthropic Messages wire
+	// format. Default is OpenAI for back-compat; Anthropic-shape
+	// unlocks Bedrock's Anthropic passthrough and any
+	// Anthropic-compatible proxy. See issue #202 Phase 1.
+	providerCustomShapePhase
 	providerCustomModelPhase
 	providerCustomAuthPhase
 	providerDonePhase
@@ -87,11 +93,19 @@ type ProviderStep struct {
 	customURL          string
 	customModel        string
 	customAuth         string
-	validateFn         ValidateKeyFunc
-	oauthFn            OAuthFlowFunc
-	validating         bool
-	valErr             error
-	oauthRunning       bool
+	// customShape is the wire format the custom endpoint speaks —
+	// "openai" (default) or "anthropic". Selected via the
+	// providerCustomShapePhase selector. Flows out via WizardContext
+	// and into normalizeCustomProvider, which writes either
+	// `provider: openai + OPENAI_BASE_URL` or
+	// `provider: anthropic + ANTHROPIC_BASE_URL`. Issue #202 Phase 1.
+	customShape       string
+	customShapeSelect components.SingleSelect
+	validateFn        ValidateKeyFunc
+	oauthFn           OAuthFlowFunc
+	validating        bool
+	valErr            error
+	oauthRunning      bool
 }
 
 // NewProviderStep creates a new provider selection step.
@@ -172,6 +186,8 @@ func (s *ProviderStep) Update(msg tea.Msg) (tui.Step, tea.Cmd) {
 		return s.updateOrgIDPhase(msg)
 	case providerCustomURLPhase:
 		return s.updateCustomURLPhase(msg)
+	case providerCustomShapePhase:
+		return s.updateCustomShapePhase(msg)
 	case providerCustomModelPhase:
 		return s.updateCustomModelPhase(msg)
 	case providerCustomAuthPhase:
@@ -504,6 +520,54 @@ func (s *ProviderStep) updateCustomURLPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 
 	if s.textInput.Done() {
 		s.customURL = s.textInput.Value()
+		// Phase 1 of issue #202: ask which wire format the endpoint
+		// speaks. Default to OpenAI because the wizard's existing
+		// example URLs all point at OpenAI-shaped services
+		// (litellm, Ollama, vLLM).
+		s.phase = providerCustomShapePhase
+		items := []components.SingleSelectItem{
+			{
+				Label:       "OpenAI Chat Completions",
+				Value:       "openai",
+				Description: "OpenRouter, litellm, vLLM, Together.ai, Ollama, Bedrock OpenAI compatibility",
+				Icon:        "🧩",
+			},
+			{
+				Label:       "Anthropic Messages",
+				Value:       "anthropic",
+				Description: "Anthropic-compatible proxies; AWS Bedrock Anthropic passthrough (Phase 2: aws_sigv4 auth)",
+				Icon:        "🅰️",
+			},
+		}
+		s.customShapeSelect = components.NewSingleSelect(
+			items,
+			s.styles.Theme.Accent,
+			s.styles.Theme.Primary,
+			s.styles.Theme.Secondary,
+			s.styles.Theme.Dim,
+			s.styles.Theme.Border,
+			s.styles.Theme.ActiveBorder,
+			s.styles.Theme.ActiveBg,
+			s.styles.KbdKey,
+			s.styles.KbdDesc,
+		)
+		return s, nil
+	}
+
+	return s, cmd
+}
+
+// updateCustomShapePhase collects the operator's choice between
+// OpenAI Chat Completions wire format and Anthropic Messages wire
+// format, then transitions to the model-name prompt. Issue #202
+// Phase 1.
+func (s *ProviderStep) updateCustomShapePhase(msg tea.Msg) (tui.Step, tea.Cmd) {
+	updated, cmd := s.customShapeSelect.Update(msg)
+	s.customShapeSelect = updated
+
+	if s.customShapeSelect.Done() {
+		_, val := s.customShapeSelect.Selected()
+		s.customShape = val
 		s.phase = providerCustomModelPhase
 		s.textInput = components.NewTextInput(
 			"Model name",
@@ -519,7 +583,6 @@ func (s *ProviderStep) updateCustomURLPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 		)
 		return s, s.textInput.Init()
 	}
-
 	return s, cmd
 }
 
@@ -601,6 +664,8 @@ func (s *ProviderStep) View(width int) string {
 		return s.textInput.View(width)
 	case providerCustomURLPhase, providerCustomModelPhase:
 		return s.textInput.View(width)
+	case providerCustomShapePhase:
+		return s.customShapeSelect.View(width)
 	case providerCustomAuthPhase:
 		return s.keyInput.View(width)
 	}
@@ -643,6 +708,7 @@ func (s *ProviderStep) Apply(ctx *tui.WizardContext) {
 	ctx.CustomBaseURL = s.customURL
 	ctx.CustomModel = s.customModel
 	ctx.CustomAPIKey = s.customAuth
+	ctx.CustomShape = s.customShape
 
 	// Store the provider API key in EnvVars so later steps (e.g. skills)
 	// can detect it's already collected and skip re-prompting.

--- a/forge-cli/internal/tui/steps/provider_step.go
+++ b/forge-cli/internal/tui/steps/provider_step.go
@@ -535,7 +535,7 @@ func (s *ProviderStep) updateCustomURLPhase(msg tea.Msg) (tui.Step, tea.Cmd) {
 			{
 				Label:       "Anthropic Messages",
 				Value:       "anthropic",
-				Description: "Anthropic-compatible proxies; AWS Bedrock Anthropic passthrough (Phase 2: aws_sigv4 auth)",
+				Description: "Anthropic-compatible proxies; AWS Bedrock Anthropic passthrough",
 				Icon:        "🅰️",
 			},
 		}

--- a/forge-cli/internal/tui/wizard.go
+++ b/forge-cli/internal/tui/wizard.go
@@ -29,7 +29,16 @@ type WizardContext struct {
 	CustomBaseURL  string
 	CustomModel    string
 	CustomAPIKey   string
-	EnvVars        map[string]string
+	// CustomShape selects which wire format the custom-URL endpoint
+	// speaks — "openai" (default; OpenAI Chat Completions, used by
+	// litellm / vLLM / OpenRouter / self-hosted Llama proxies) or
+	// "anthropic" (Anthropic Messages format, used by Bedrock's
+	// Anthropic passthrough and by Anthropic-compatible proxies).
+	// Drives whether normalizeCustomProvider sets ModelProvider to
+	// "openai" or "anthropic" and which BASE_URL / API_KEY env names
+	// are emitted to .env. See issue #202 Phase 1.
+	CustomShape string
+	EnvVars     map[string]string
 
 	// AuthMode is the user's selection from the auth step:
 	//   ""             — wizard step did not run

--- a/forge-core/catalog/providers.go
+++ b/forge-core/catalog/providers.go
@@ -48,7 +48,7 @@ var providers = []Provider{
 	{
 		ID:          "custom",
 		Label:       "Custom URL",
-		Description: "Any OpenAI-compatible endpoint",
+		Description: "OpenAI-compatible or Anthropic-compatible endpoint",
 		Icon:        "⚙️",
 		IsCustom:    true,
 	},

--- a/forge-core/llm/client.go
+++ b/forge-core/llm/client.go
@@ -20,4 +20,18 @@ type ClientConfig struct {
 	OrgID       string
 	MaxRetries  int
 	TimeoutSecs int
+
+	// AuthScheme + AWSRegion control outbound authentication when
+	// the operator points the client at AWS Bedrock (Anthropic
+	// passthrough or OpenAI compatibility endpoint) or any other
+	// SigV4-fronted gateway. Issue #202 Phase 2. Mirrors the
+	// matching forge.yaml ModelRef fields.
+	//
+	// AuthScheme == "" preserves the pre-#202 behavior — the
+	// Anthropic client sets `x-api-key: <APIKey>`, the OpenAI
+	// client sets `Authorization: Bearer <APIKey>`. AuthScheme ==
+	// "aws_sigv4" wraps the client's transport with the SigV4
+	// signer and skips the native header logic; APIKey is ignored.
+	AuthScheme string
+	AWSRegion  string
 }

--- a/forge-core/llm/providers/anthropic.go
+++ b/forge-core/llm/providers/anthropic.go
@@ -16,13 +16,27 @@ import (
 
 // AnthropicClient implements llm.Client for the Anthropic Messages API.
 type AnthropicClient struct {
-	apiKey  string
-	baseURL string
-	model   string
-	client  *http.Client
+	apiKey     string
+	baseURL    string
+	model      string
+	authScheme string
+	client     *http.Client
 }
 
 // NewAnthropicClient creates a new Anthropic client.
+//
+// When cfg.AuthScheme == "aws_sigv4", the client's http.Transport is
+// wrapped with the SigV4 signer (issue #202 Phase 2) and the
+// per-request x-api-key header is skipped. This routes outbound
+// requests at any AWS SigV4-fronted gateway that speaks the
+// Anthropic Messages wire format (custom proxies, Bedrock-compat
+// proxies). Operators provide AWS credentials via the standard
+// environment variables (AWS_ACCESS_KEY_ID / _SECRET_ / _SESSION_TOKEN)
+// and the region via cfg.AWSRegion. APIKey is ignored on this path.
+//
+// All other AuthScheme values (including the empty default) preserve
+// the pre-#202 contract: x-api-key + anthropic-version headers, no
+// transport wrapping.
 func NewAnthropicClient(cfg llm.ClientConfig) *AnthropicClient {
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
@@ -32,11 +46,35 @@ func NewAnthropicClient(cfg llm.ClientConfig) *AnthropicClient {
 	if timeout == 0 {
 		timeout = 120 * time.Second
 	}
+	httpClient := &http.Client{Timeout: timeout}
+	if cfg.AuthScheme == "aws_sigv4" {
+		httpClient.Transport = newBedrockSigningTransport(cfg.AWSRegion, http.DefaultTransport)
+	}
 	return &AnthropicClient{
-		apiKey:  cfg.APIKey,
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   cfg.Model,
-		client:  &http.Client{Timeout: timeout},
+		apiKey:     cfg.APIKey,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		model:      cfg.Model,
+		authScheme: cfg.AuthScheme,
+		client:     httpClient,
+	}
+}
+
+// newBedrockSigningTransport wraps an underlying transport with a
+// SigV4 signer pinned to the `bedrock` service in the configured
+// region, reading credentials from env each call so a credential
+// rotation propagates without restarting the agent. Issue #202 Phase 2.
+func newBedrockSigningTransport(region string, underlying http.RoundTripper) http.RoundTripper {
+	return &SigV4Transport{
+		Underlying: underlying,
+		Region:     region,
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			c, ok := SigV4CredentialsFromEnv()
+			if !ok {
+				return c, fmt.Errorf("aws_sigv4: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars required")
+			}
+			return c, nil
+		},
 	}
 }
 
@@ -107,8 +145,16 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, req *llm.ChatRequest) 
 
 func (c *AnthropicClient) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
+	// When the SigV4 transport is wrapped on the client, the
+	// Authorization header is what authenticates the request — the
+	// x-api-key header MUST NOT be sent, both because it isn't
+	// validated upstream and because it would be included in the
+	// SigV4 signed-headers set and complicate proxy debugging.
+	// Issue #202 Phase 2.
+	if c.authScheme != "aws_sigv4" {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
 }
 
 // Anthropic-specific request types.

--- a/forge-core/llm/providers/auth_scheme_test.go
+++ b/forge-core/llm/providers/auth_scheme_test.go
@@ -1,0 +1,147 @@
+package providers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// TestAnthropicClient_DefaultAuthSchemeKeepsXAPIKey pins the
+// pre-#202 contract: an AnthropicClient with no AuthScheme set sends
+// the `x-api-key` and `anthropic-version` headers exactly as it
+// always has. Without this every existing Anthropic deployment
+// breaks the moment Phase 2 lands.
+func TestAnthropicClient_DefaultAuthSchemeKeepsXAPIKey(t *testing.T) {
+	c := NewAnthropicClient(llm.ClientConfig{
+		APIKey: "sk-ant-test",
+		Model:  "claude-test",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	c.setHeaders(req)
+
+	if got := req.Header.Get("x-api-key"); got != "sk-ant-test" {
+		t.Errorf("default path lost x-api-key; got %q", got)
+	}
+	if got := req.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("anthropic-version missing on default path: %q", got)
+	}
+}
+
+// TestAnthropicClient_SigV4AuthSchemeOmitsXAPIKey is the Phase 2
+// invariant: when the client is configured for SigV4 outbound, the
+// per-request x-api-key header MUST NOT be sent. The SigV4 transport
+// will write Authorization instead — pre-stamping x-api-key would
+// just confuse the upstream signature verifier and the proxy trace
+// logs.
+func TestAnthropicClient_SigV4AuthSchemeOmitsXAPIKey(t *testing.T) {
+	c := NewAnthropicClient(llm.ClientConfig{
+		APIKey:     "sk-ant-test",
+		Model:      "anthropic.claude-sonnet-4-20250514-v1:0",
+		AuthScheme: "aws_sigv4",
+		AWSRegion:  "us-east-1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://bedrock-runtime.us-east-1.amazonaws.com/x", nil)
+	c.setHeaders(req)
+
+	if got := req.Header.Get("x-api-key"); got != "" {
+		t.Errorf("aws_sigv4 path leaked x-api-key: %q", got)
+	}
+	// anthropic-version must still ride — Bedrock's Anthropic
+	// passthrough recognizes it. SigV4 only swaps the auth
+	// mechanism, not the wire envelope.
+	if got := req.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("anthropic-version dropped on aws_sigv4 path: %q", got)
+	}
+}
+
+// TestAnthropicClient_SigV4WrapsTransport confirms the client's
+// http.Client.Transport is a *SigV4Transport when AuthScheme=aws_sigv4,
+// so every outbound request flows through the signer. Without this
+// the auth header would be skipped (above test) AND the transport
+// would be unsigned — leaving requests with no auth at all.
+func TestAnthropicClient_SigV4WrapsTransport(t *testing.T) {
+	c := NewAnthropicClient(llm.ClientConfig{
+		AuthScheme: "aws_sigv4",
+		AWSRegion:  "us-east-1",
+	})
+	if _, ok := c.client.Transport.(*SigV4Transport); !ok {
+		t.Errorf("transport is %T, want *SigV4Transport", c.client.Transport)
+	}
+}
+
+// TestAnthropicClient_DefaultTransportNotWrapped pins the no-overhead
+// path: a default AnthropicClient has http.Client.Transport == nil
+// (which net/http falls back to DefaultTransport). Wrapping when
+// AuthScheme is unset would impose a per-request SigV4 attempt + env
+// lookup on every Anthropic call that never needed it.
+func TestAnthropicClient_DefaultTransportNotWrapped(t *testing.T) {
+	c := NewAnthropicClient(llm.ClientConfig{APIKey: "sk-ant-x"})
+	if c.client.Transport != nil {
+		t.Errorf("default transport should be unwrapped (nil); got %T", c.client.Transport)
+	}
+}
+
+// TestOpenAIClient_DefaultAuthSchemeKeepsBearer pins the symmetric
+// pre-#202 contract for OpenAI: Authorization: Bearer <key> is the
+// default and continues to be set.
+func TestOpenAIClient_DefaultAuthSchemeKeepsBearer(t *testing.T) {
+	c := NewOpenAIClient(llm.ClientConfig{
+		APIKey: "sk-test",
+		Model:  "gpt-test",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	c.setHeaders(req)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer sk-test" {
+		t.Errorf("default path lost Authorization: %q", got)
+	}
+}
+
+// TestOpenAIClient_SigV4AuthSchemeOmitsBearer is the Phase 2 OpenAI
+// pin: at Bedrock's OpenAI-compat endpoint the SigV4 signer stamps
+// Authorization; Forge MUST NOT pre-populate Bearer.
+func TestOpenAIClient_SigV4AuthSchemeOmitsBearer(t *testing.T) {
+	c := NewOpenAIClient(llm.ClientConfig{
+		APIKey:     "sk-test",
+		Model:      "openai.gpt-4o",
+		AuthScheme: "aws_sigv4",
+		AWSRegion:  "us-east-1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions", nil)
+	c.setHeaders(req)
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("aws_sigv4 path leaked Authorization: %q", got)
+	}
+}
+
+// TestOpenAIClient_SigV4WrapsTransport mirrors the Anthropic side —
+// confirms the SigV4Transport is in place on the client's http.Client.
+func TestOpenAIClient_SigV4WrapsTransport(t *testing.T) {
+	c := NewOpenAIClient(llm.ClientConfig{
+		AuthScheme: "aws_sigv4",
+		AWSRegion:  "us-east-1",
+	})
+	if _, ok := c.client.Transport.(*SigV4Transport); !ok {
+		t.Errorf("transport is %T, want *SigV4Transport", c.client.Transport)
+	}
+}
+
+// TestOpenAIClient_OrgIDStillSetUnderSigV4 confirms the
+// OpenAI-Organization header isn't accidentally suppressed under the
+// SigV4 path. An operator pointing a Forge agent with an org ID at
+// Bedrock's OpenAI compat layer expects the same multi-tenant
+// attribution to surface as the standard provider would emit.
+func TestOpenAIClient_OrgIDStillSetUnderSigV4(t *testing.T) {
+	c := NewOpenAIClient(llm.ClientConfig{
+		AuthScheme: "aws_sigv4",
+		AWSRegion:  "us-east-1",
+		OrgID:      "org-xyz",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions", nil)
+	c.setHeaders(req)
+	if got := req.Header.Get("OpenAI-Organization"); got != "org-xyz" {
+		t.Errorf("OpenAI-Organization dropped under aws_sigv4: %q", got)
+	}
+}

--- a/forge-core/llm/providers/openai.go
+++ b/forge-core/llm/providers/openai.go
@@ -18,14 +18,25 @@ import (
 // OpenAIClient implements llm.Client for the OpenAI Chat Completions API.
 // Also works with Azure OpenAI and any OpenAI-compatible endpoint.
 type OpenAIClient struct {
-	apiKey  string
-	baseURL string
-	model   string
-	orgID   string
-	client  *http.Client
+	apiKey     string
+	baseURL    string
+	model      string
+	orgID      string
+	authScheme string
+	client     *http.Client
 }
 
 // NewOpenAIClient creates a new OpenAI client.
+//
+// When cfg.AuthScheme == "aws_sigv4" the client's http.Transport is
+// wrapped with the SigV4 signer (issue #202 Phase 2) and the per-
+// request Authorization: Bearer header is skipped. Routes outbound
+// at AWS Bedrock's OpenAI compatibility endpoint or any other
+// SigV4-fronted OpenAI-shaped gateway. AWS credentials resolve via
+// AWS_ACCESS_KEY_ID / _SECRET_ / _SESSION_TOKEN env; region via
+// cfg.AWSRegion. APIKey is ignored on this path.
+//
+// Empty AuthScheme preserves the pre-#202 contract byte-for-byte.
 func NewOpenAIClient(cfg llm.ClientConfig) *OpenAIClient {
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
@@ -35,12 +46,17 @@ func NewOpenAIClient(cfg llm.ClientConfig) *OpenAIClient {
 	if timeout == 0 {
 		timeout = 120 * time.Second
 	}
+	httpClient := &http.Client{Timeout: timeout}
+	if cfg.AuthScheme == "aws_sigv4" {
+		httpClient.Transport = newBedrockSigningTransport(cfg.AWSRegion, http.DefaultTransport)
+	}
 	return &OpenAIClient{
-		apiKey:  cfg.APIKey,
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   cfg.Model,
-		orgID:   cfg.OrgID,
-		client:  &http.Client{Timeout: timeout},
+		apiKey:     cfg.APIKey,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		model:      cfg.Model,
+		orgID:      cfg.OrgID,
+		authScheme: cfg.AuthScheme,
+		client:     httpClient,
 	}
 }
 
@@ -111,7 +127,10 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req *llm.ChatRequest) (<-
 
 func (c *OpenAIClient) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
-	if c.apiKey != "" {
+	// When AuthScheme=aws_sigv4 the SigV4 transport will stamp the
+	// Authorization header itself; don't pre-populate a Bearer token
+	// that would be replaced and confuse trace logs. Issue #202 Phase 2.
+	if c.apiKey != "" && c.authScheme != "aws_sigv4" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 	if c.orgID != "" {

--- a/forge-core/llm/providers/sigv4_transport.go
+++ b/forge-core/llm/providers/sigv4_transport.go
@@ -1,0 +1,340 @@
+package providers
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// AWS SigV4 outbound signing transport for LLM clients pointed at AWS
+// Bedrock (issue #202 Phase 2). Hand-rolled rather than pulled in via
+// aws-sdk-go-v2 to match the existing aws_sigv4 inbound-auth provider
+// (forge-core/auth/providers/aws_sigv4) — the SDK adds ~5 MB to the
+// binary for one signing function, and the algorithm is small enough
+// to fit in one file with no transitive deps.
+//
+// SigV4 spec: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+// Bedrock endpoint shape: https://bedrock-runtime.<region>.amazonaws.com/model/<model-id>/invoke
+//
+// Scope: this signer covers what Bedrock needs — the `bedrock` service
+// in a single region, body-bearing POST requests, header signing, no
+// query-string signing (Bedrock never uses pre-signed URLs). Anything
+// fancier — multi-region requests, query-string auth, chunked uploads
+// — is out of scope and would be the moment to swap to aws-sdk-go-v2.
+
+// SigV4Credentials carries the resolved AWS credentials the signer
+// uses. Populated either explicitly by the caller or via
+// SigV4CredentialsFromEnv. SessionToken is set when the underlying
+// credentials are temporary (STS AssumeRole, IRSA, EC2 instance
+// metadata) and adds the x-amz-security-token header to every request.
+type SigV4Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+// SigV4CredentialsFromEnv reads the standard AWS env vars. Returns
+// (creds, true) when AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are
+// both set; (zero, false) otherwise. AWS_SESSION_TOKEN is optional.
+//
+// Web identity / IRSA / EC2 instance metadata are NOT resolved here —
+// those need STS round-trips and the inbound aws_sigv4 provider's
+// hand-rolled STS client (forge-core/auth/providers/aws_sigv4/sts_client.go)
+// would be the model to copy. Tracked as a Phase 2 follow-up; the
+// majority of Bedrock deployments today set AWS_* env vars (or
+// AWS_PROFILE that resolves to them) before launching the agent.
+func SigV4CredentialsFromEnv() (SigV4Credentials, bool) {
+	ak := os.Getenv("AWS_ACCESS_KEY_ID")
+	sk := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if ak == "" || sk == "" {
+		return SigV4Credentials{}, false
+	}
+	return SigV4Credentials{
+		AccessKeyID:     ak,
+		SecretAccessKey: sk,
+		SessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
+	}, true
+}
+
+// SigV4Transport is an http.RoundTripper that signs each outbound
+// request with AWS Signature V4 before forwarding to the underlying
+// transport.
+//
+// Credentials are read once per request via the Credentials getter so
+// the transport plays well with rotating creds (an external watcher
+// can update a sync.Atomic-wrapped value the getter reads). Region and
+// Service are static — they describe the AWS endpoint being signed
+// for, not the caller's identity.
+//
+// Underlying is what we delegate the round trip to after signing —
+// composes cleanly with the existing otelhttp + egress-enforcer
+// transports because we mutate headers only.
+type SigV4Transport struct {
+	Underlying  http.RoundTripper
+	Credentials func() (SigV4Credentials, error)
+	Region      string
+	Service     string
+
+	// now is injected so tests can pin the X-Amz-Date header to a
+	// fixed value. Production callers leave it nil; the signer falls
+	// back to time.Now().UTC().
+	now func() time.Time
+}
+
+// RoundTrip signs req with SigV4 and forwards it to the underlying
+// transport. Clones the request before mutating headers (the
+// http.RoundTripper contract) and reads the body fully into memory
+// because SigV4 hashes the payload — there is no streaming-signature
+// option in the bedrock service.
+//
+// Body limits: chunked-streaming + unsigned payload is supported by
+// SigV4 but Bedrock doesn't accept it. Reading the body in full is
+// the price of pointing at Bedrock; bound your request sizes
+// upstream.
+func (t *SigV4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	creds, err := t.Credentials()
+	if err != nil {
+		return nil, fmt.Errorf("sigv4: resolving credentials: %w", err)
+	}
+	if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
+		return nil, fmt.Errorf("sigv4: missing AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY")
+	}
+	if t.Region == "" {
+		return nil, fmt.Errorf("sigv4: empty region")
+	}
+	if t.Service == "" {
+		return nil, fmt.Errorf("sigv4: empty service")
+	}
+
+	// Buffer the body once so we can hash it AND replay it on retry.
+	// SigV4 needs the payload digest; net/http needs to read the body
+	// when it sends. Avoiding the buffer entirely would require
+	// chunked signing which Bedrock doesn't accept.
+	var bodyBytes []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("sigv4: reading request body: %w", err)
+		}
+		_ = req.Body.Close()
+		bodyBytes = b
+	}
+
+	signed := req.Clone(req.Context())
+	signed.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	signed.ContentLength = int64(len(bodyBytes))
+
+	t.sign(signed, bodyBytes, creds)
+
+	underlying := t.Underlying
+	if underlying == nil {
+		underlying = http.DefaultTransport
+	}
+	return underlying.RoundTrip(signed)
+}
+
+// sign computes the SigV4 signature and stamps the Authorization +
+// X-Amz-Date (+ X-Amz-Security-Token when applicable) headers on req.
+// Body has already been read into payload.
+func (t *SigV4Transport) sign(req *http.Request, payload []byte, creds SigV4Credentials) {
+	now := time.Now().UTC()
+	if t.now != nil {
+		now = t.now().UTC()
+	}
+	amzDate := now.Format("20060102T150405Z") // ISO 8601 basic
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+	// Host header MUST be in the signed-headers set per spec. Go's
+	// http client populates req.Host from the URL on send, but
+	// req.Header.Get("Host") returns empty by default — set it
+	// explicitly so the canonical-headers computation includes the
+	// right value.
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+
+	payloadHash := sha256Hex(payload)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	canonicalHeaders, signedHeaders := canonicalHeaderSet(req.Header, host)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI(req.URL.Path),
+		canonicalQuery(req.URL.RawQuery),
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, t.Region, t.Service)
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := deriveSigningKey(creds.SecretAccessKey, dateStamp, t.Region, t.Service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	auth := fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		creds.AccessKeyID, credentialScope, signedHeaders, signature,
+	)
+	req.Header.Set("Authorization", auth)
+}
+
+// canonicalHeaderSet returns (canonical-headers block, signed-headers
+// list). Per SigV4 spec: lowercase header names, sorted ascending,
+// each followed by its value with internal whitespace collapsed.
+// We always include the host header (required) plus every other
+// header present on the request — including the x-amz-* set we just
+// stamped.
+func canonicalHeaderSet(h http.Header, host string) (string, string) {
+	pairs := make(map[string]string, len(h)+1)
+	pairs["host"] = host
+	for k, vals := range h {
+		lower := strings.ToLower(k)
+		// SigV4 excludes Authorization (we'd be signing the
+		// header we're about to write) and the Content-Length /
+		// User-Agent / Expect headers per the spec's
+		// "unsignable" set. The Bedrock service accepts a
+		// smaller set of signed headers than the general spec,
+		// but signing extras is safe.
+		if lower == "authorization" {
+			continue
+		}
+		pairs[lower] = collapseHeaderValue(strings.Join(vals, ","))
+	}
+	names := make([]string, 0, len(pairs))
+	for n := range pairs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var sb strings.Builder
+	for _, n := range names {
+		sb.WriteString(n)
+		sb.WriteByte(':')
+		sb.WriteString(pairs[n])
+		sb.WriteByte('\n')
+	}
+	return sb.String(), strings.Join(names, ";")
+}
+
+// canonicalURI returns the path component encoded per SigV4 rules —
+// each segment gets URI-encoded except for unreserved characters. For
+// Bedrock the path looks like
+// "/model/anthropic.claude-sonnet-4-20250514-v1%3A0/invoke" which is
+// already encoded by net/url when the operator built the request, so
+// we re-encode safely (idempotent for the unreserved set).
+func canonicalURI(path string) string {
+	if path == "" {
+		return "/"
+	}
+	// Re-encode each segment to ensure conformity. Bedrock's URLs
+	// use percent-encoded colons in the model id; preserve those.
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = uriEscape(seg, false)
+	}
+	return strings.Join(segments, "/")
+}
+
+// canonicalQuery sorts query parameters by key, then by value, per
+// SigV4 spec. Empty raw query → empty string.
+func canonicalQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	pairs := strings.Split(raw, "&")
+	encoded := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok {
+			encoded = append(encoded, uriEscape(p, true)+"=")
+			continue
+		}
+		encoded = append(encoded, uriEscape(k, true)+"="+uriEscape(v, true))
+	}
+	sort.Strings(encoded)
+	return strings.Join(encoded, "&")
+}
+
+// uriEscape percent-encodes everything outside the SigV4 unreserved
+// set (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`). When encodeSlash is
+// true, slashes are encoded too (query-component rules); when false,
+// they pass through (path-component rules).
+func uriEscape(s string, encodeSlash bool) string {
+	var sb strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case 'A' <= c && c <= 'Z',
+			'a' <= c && c <= 'z',
+			'0' <= c && c <= '9',
+			c == '-', c == '_', c == '.', c == '~':
+			sb.WriteByte(c)
+		case c == '/' && !encodeSlash:
+			sb.WriteByte(c)
+		default:
+			fmt.Fprintf(&sb, "%%%02X", c)
+		}
+	}
+	return sb.String()
+}
+
+// collapseHeaderValue trims and collapses repeated internal whitespace
+// per the SigV4 canonical-header rules.
+func collapseHeaderValue(v string) string {
+	v = strings.TrimSpace(v)
+	var sb strings.Builder
+	prevSpace := false
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == ' ' || c == '\t' {
+			if !prevSpace {
+				sb.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		sb.WriteByte(c)
+		prevSpace = false
+	}
+	return sb.String()
+}
+
+// deriveSigningKey runs the SigV4 HMAC chain to produce the final
+// signing key. Walks date → region → service → "aws4_request".
+func deriveSigningKey(secret, date, region, service string) []byte {
+	k := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	k = hmacSHA256(k, []byte(region))
+	k = hmacSHA256(k, []byte(service))
+	k = hmacSHA256(k, []byte("aws4_request"))
+	return k
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(data)
+	return m.Sum(nil)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/forge-core/llm/providers/sigv4_transport_test.go
+++ b/forge-core/llm/providers/sigv4_transport_test.go
@@ -1,0 +1,303 @@
+package providers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureRT records the request its RoundTrip was called with so the
+// tests can inspect headers the signer stamped.
+type captureRT struct {
+	got *http.Request
+	err error
+}
+
+func (c *captureRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	c.got = req
+	return &http.Response{
+		StatusCode: 200,
+		Body:       http.NoBody,
+		Header:     http.Header{},
+		Request:    req,
+	}, nil
+}
+
+// fixedClock makes the signer's time deterministic so the canonical
+// request — and therefore the signature — is reproducible.
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+// TestSigV4Transport_StampsAuthorizationAndAmzDate is the core spec
+// invariant: every request gets `Authorization: AWS4-HMAC-SHA256 …`
+// + `X-Amz-Date`. We don't pin the exact signature byte string
+// because that depends on URL/header canonicalization stability;
+// instead we assert the headers exist with the right shape.
+func TestSigV4Transport_StampsAuthorizationAndAmzDate(t *testing.T) {
+	cap := &captureRT{}
+	tr := &SigV4Transport{
+		Underlying: cap,
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{
+				AccessKeyID:     "AKIATEST",
+				SecretAccessKey: "secret-test",
+			}, nil
+		},
+		now: fixedClock(time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)),
+	}
+	req, _ := http.NewRequest(http.MethodPost,
+		"https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-20250514-v1%3A0/invoke",
+		bytes.NewReader([]byte(`{"hello":"world"}`)))
+
+	if _, err := tr.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	got := cap.got
+	if got == nil {
+		t.Fatal("underlying never invoked")
+	}
+	if d := got.Header.Get("X-Amz-Date"); d != "20260628T120000Z" {
+		t.Errorf("X-Amz-Date = %q, want 20260628T120000Z", d)
+	}
+	auth := got.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 Credential=AKIATEST/20260628/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization missing AWS4-HMAC-SHA256 + credential scope prefix: %q", auth)
+	}
+	if !strings.Contains(auth, "SignedHeaders=") || !strings.Contains(auth, "Signature=") {
+		t.Errorf("Authorization missing SignedHeaders / Signature: %q", auth)
+	}
+}
+
+// TestSigV4Transport_StampsSecurityTokenWhenTemporary pins the
+// behavior for temporary credentials (STS, IRSA, EC2 metadata): the
+// X-Amz-Security-Token header MUST be present and reflect the session
+// token. Without it Bedrock rejects every request with InvalidSecurity.
+func TestSigV4Transport_StampsSecurityTokenWhenTemporary(t *testing.T) {
+	cap := &captureRT{}
+	tr := &SigV4Transport{
+		Underlying: cap,
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{
+				AccessKeyID:     "ASIATEST",
+				SecretAccessKey: "secret",
+				SessionToken:    "FwoGZXIv-test-session",
+			}, nil
+		},
+		now: fixedClock(time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)),
+	}
+	req, _ := http.NewRequest(http.MethodPost,
+		"https://bedrock-runtime.us-east-1.amazonaws.com/x", bytes.NewReader([]byte("{}")))
+	_, _ = tr.RoundTrip(req)
+	if got := cap.got.Header.Get("X-Amz-Security-Token"); got != "FwoGZXIv-test-session" {
+		t.Errorf("X-Amz-Security-Token = %q", got)
+	}
+}
+
+// TestSigV4Transport_PreservesBodyAndContentLength asserts the body
+// survives signing — we read it to hash it, but we re-attach a fresh
+// reader that the underlying transport can read.
+func TestSigV4Transport_PreservesBodyAndContentLength(t *testing.T) {
+	cap := &captureRT{}
+	tr := &SigV4Transport{
+		Underlying: cap,
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{AccessKeyID: "AKIA", SecretAccessKey: "x"}, nil
+		},
+		now: fixedClock(time.Now()),
+	}
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	req, _ := http.NewRequest(http.MethodPost,
+		"https://bedrock-runtime.us-east-1.amazonaws.com/x", bytes.NewReader(body))
+	_, _ = tr.RoundTrip(req)
+	if cap.got.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", cap.got.ContentLength, len(body))
+	}
+	got, _ := io.ReadAll(cap.got.Body)
+	if !bytes.Equal(got, body) {
+		t.Errorf("body lost during signing: got %q want %q", got, body)
+	}
+}
+
+// TestSigV4Transport_DoesNotMutateCallerRequest is the
+// http.RoundTripper contract. SigV4 stamps headers + reads the body;
+// neither should leak back into the caller's request after RoundTrip
+// returns. Tests retries: a caller that re-issues the same req must
+// not see leftover Authorization from a prior round.
+func TestSigV4Transport_DoesNotMutateCallerRequest(t *testing.T) {
+	cap := &captureRT{}
+	tr := &SigV4Transport{
+		Underlying: cap,
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{AccessKeyID: "AKIA", SecretAccessKey: "x"}, nil
+		},
+		now: fixedClock(time.Now()),
+	}
+	orig, _ := http.NewRequest(http.MethodPost,
+		"https://bedrock-runtime.us-east-1.amazonaws.com/x", bytes.NewReader([]byte("{}")))
+	_, _ = tr.RoundTrip(orig)
+
+	if orig.Header.Get("Authorization") != "" {
+		t.Errorf("caller's request mutated; Authorization leaked: %q",
+			orig.Header.Get("Authorization"))
+	}
+	if orig.Header.Get("X-Amz-Date") != "" {
+		t.Errorf("caller's request mutated; X-Amz-Date leaked: %q",
+			orig.Header.Get("X-Amz-Date"))
+	}
+}
+
+// TestSigV4Transport_PropagatesUnderlyingError confirms the wrapper
+// is transparent on the failure path — network errors / connection
+// refuseds come back unchanged so callers retry / log normally.
+func TestSigV4Transport_PropagatesUnderlyingError(t *testing.T) {
+	want := errors.New("simulated transport failure")
+	tr := &SigV4Transport{
+		Underlying: &captureRT{err: want},
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{AccessKeyID: "AKIA", SecretAccessKey: "x"}, nil
+		},
+		now: fixedClock(time.Now()),
+	}
+	req, _ := http.NewRequest(http.MethodPost,
+		"https://example.invalid", bytes.NewReader([]byte("{}")))
+	_, err := tr.RoundTrip(req)
+	if !errors.Is(err, want) {
+		t.Errorf("RoundTrip err = %v, want %v", err, want)
+	}
+}
+
+// TestSigV4Transport_MissingCredentialsErrors pins the misconfig
+// path: if AWS env vars aren't set the credential getter returns an
+// error and SigV4Transport surfaces it; the underlying transport is
+// never invoked. Prevents an unsigned request from sneaking out.
+func TestSigV4Transport_MissingCredentialsErrors(t *testing.T) {
+	cap := &captureRT{}
+	tr := &SigV4Transport{
+		Underlying: cap,
+		Region:     "us-east-1",
+		Service:    "bedrock",
+		Credentials: func() (SigV4Credentials, error) {
+			return SigV4Credentials{}, errors.New("creds missing")
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/", nil)
+	_, err := tr.RoundTrip(req)
+	if err == nil {
+		t.Fatalf("expected error; got nil")
+	}
+	if cap.got != nil {
+		t.Errorf("underlying invoked despite credential error — unsigned request would have leaked")
+	}
+}
+
+// TestSigV4Transport_RequiresRegionAndService pins the second misconfig
+// path. Either an empty Region or an empty Service is an error before
+// any signing happens.
+func TestSigV4Transport_RequiresRegionAndService(t *testing.T) {
+	makeReq := func() *http.Request {
+		r, _ := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+		return r
+	}
+	creds := func() (SigV4Credentials, error) {
+		return SigV4Credentials{AccessKeyID: "k", SecretAccessKey: "s"}, nil
+	}
+	if _, err := (&SigV4Transport{Service: "bedrock", Credentials: creds}).RoundTrip(makeReq()); err == nil {
+		t.Errorf("empty Region should error")
+	}
+	if _, err := (&SigV4Transport{Region: "us-east-1", Credentials: creds}).RoundTrip(makeReq()); err == nil {
+		t.Errorf("empty Service should error")
+	}
+}
+
+// TestSigV4Transport_CanonicalQueryOrdering pins the algorithm's
+// sort-by-key-then-value semantics. Without correct ordering the
+// signature is wrong and Bedrock returns SignatureDoesNotMatch. Use
+// two parameters that would canonicalize to different orderings if
+// the sort were wrong.
+func TestSigV4Transport_CanonicalQueryOrdering(t *testing.T) {
+	got1 := canonicalQuery("b=2&a=1")
+	got2 := canonicalQuery("a=1&b=2")
+	if got1 != got2 {
+		t.Errorf("query ordering not normalized: %q vs %q", got1, got2)
+	}
+	if got1 != "a=1&b=2" {
+		t.Errorf("canonicalQuery = %q, want a=1&b=2", got1)
+	}
+}
+
+// TestSigV4Transport_EndToEndAgainstHTTPTestServer drives a real
+// http.Client through the transport against a stubbed server. The
+// server inspects the inbound Authorization header and confirms it
+// follows the SigV4 shape — proving the transport composes with
+// http.DefaultTransport as the underlying.
+func TestSigV4Transport_EndToEndAgainstHTTPTestServer(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := &http.Client{
+		Transport: &SigV4Transport{
+			Underlying: http.DefaultTransport,
+			Region:     "us-east-1",
+			Service:    "bedrock",
+			Credentials: func() (SigV4Credentials, error) {
+				return SigV4Credentials{AccessKeyID: "AKIA", SecretAccessKey: "s"}, nil
+			},
+			now: fixedClock(time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)),
+		},
+	}
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/x",
+		bytes.NewReader([]byte("{}")))
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 Credential=AKIA/20260628/us-east-1/bedrock/aws4_request") {
+		t.Errorf("server received Authorization = %q", gotAuth)
+	}
+}
+
+// TestSigV4CredentialsFromEnv_ParsesStandardVars covers the env
+// reader. Sets the three documented env vars and asserts they roundtrip
+// into the struct; clears them all and asserts the ok=false return so
+// the caller falls through to the error path.
+func TestSigV4CredentialsFromEnv_ParsesStandardVars(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA1234")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secretvalue")
+	t.Setenv("AWS_SESSION_TOKEN", "FwoGZXIvtest")
+
+	c, ok := SigV4CredentialsFromEnv()
+	if !ok {
+		t.Fatalf("expected ok=true with all three vars set")
+	}
+	if c.AccessKeyID != "AKIA1234" || c.SecretAccessKey != "secretvalue" || c.SessionToken != "FwoGZXIvtest" {
+		t.Errorf("creds round-trip: got %+v", c)
+	}
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	if _, ok := SigV4CredentialsFromEnv(); ok {
+		t.Errorf("expected ok=false with missing required vars")
+	}
+}

--- a/forge-core/runtime/config.go
+++ b/forge-core/runtime/config.go
@@ -87,6 +87,24 @@ func ResolveModelConfig(cfg *types.ForgeConfig, envVars map[string]string, provi
 		mc.Client.BaseURL = u
 	}
 
+	// Issue #202 Phase 2 — forge.yaml auth_scheme + aws_region carry
+	// onto the client config when the operator points at AWS Bedrock
+	// (or any other SigV4-fronted gateway). Empty AuthScheme leaves
+	// the pre-#202 provider-default behavior intact.
+	if cfg.Model.AuthScheme != "" {
+		mc.Client.AuthScheme = cfg.Model.AuthScheme
+	}
+	if cfg.Model.AWSRegion != "" {
+		mc.Client.AWSRegion = cfg.Model.AWSRegion
+	}
+	// AWS_REGION env safety-net for the SigV4 path. Mirrors the
+	// OPENAI_BASE_URL / ANTHROPIC_BASE_URL env pattern above — lets
+	// an operator override the region per-deploy without touching
+	// forge.yaml.
+	if r := envVars["AWS_REGION"]; r != "" && mc.Client.AWSRegion == "" {
+		mc.Client.AWSRegion = r
+	}
+
 	// Return nil if no provider could be resolved
 	if mc.Provider == "" {
 		return nil

--- a/forge-core/security/llm_provider_domains_test.go
+++ b/forge-core/security/llm_provider_domains_test.go
@@ -182,3 +182,28 @@ func TestLLMProviderEnvDomains_MalformedURL_NoEntry(t *testing.T) {
 		t.Errorf("malformed env URL must produce no entry; got %v", got)
 	}
 }
+
+// TestLLMProviderDomains_BedrockHostExtracted pins the issue #202
+// Phase 2 invariant: when an operator points the Anthropic or OpenAI
+// provider at AWS Bedrock (via `model.base_url`), the Bedrock
+// hostname auto-extends the egress allowlist — they don't need to
+// also remember to write `bedrock-runtime.<region>.amazonaws.com`
+// under `egress.allowed_domains`. Existing hostFromURL is generic; this
+// test is a regression pin so a future Bedrock URL-shape change
+// (regional differences, e.g. govcloud) still flows through cleanly.
+func TestLLMProviderDomains_BedrockHostExtracted(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		Model: types.ModelRef{
+			Provider:   "anthropic",
+			Name:       "anthropic.claude-sonnet-4-20250514-v1:0",
+			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			AuthScheme: "aws_sigv4",
+			AWSRegion:  "us-east-1",
+		},
+	}
+	got := security.LLMProviderDomains(cfg)
+	want := []string{"bedrock-runtime.us-east-1.amazonaws.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Bedrock hostname not in allowlist; got %v want %v", got, want)
+	}
+}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -483,6 +483,36 @@ type ModelRef struct {
 	// generated NetworkPolicy. See issue #139.
 	BaseURL string `yaml:"base_url,omitempty"`
 
+	// AuthScheme selects the outbound authentication scheme used to
+	// reach the configured BaseURL. Issue #202 Phase 2 — symmetric
+	// across the openai and anthropic providers so an operator can
+	// point either at AWS Bedrock (Anthropic passthrough or the
+	// OpenAI compatibility endpoint) using AWS SigV4 credentials in
+	// place of the provider's native API-key header.
+	//
+	// Valid values:
+	//
+	//	""           — provider default
+	//	                 (anthropic: x-api-key header from APIKey;
+	//	                  openai:    Authorization: Bearer header from APIKey)
+	//	"x_api_key"  — explicit anthropic native (same as "")
+	//	"bearer"     — explicit openai native (same as "")
+	//	"aws_sigv4"  — AWS Signature V4 signing on every request,
+	//	                using credentials resolved from the standard
+	//	                environment (AWS_ACCESS_KEY_ID / _SECRET_ /
+	//	                _SESSION_TOKEN) plus the AWSRegion field
+	//	                below. APIKey is ignored on this path.
+	//
+	// Unset for the vast majority of deployments — the default
+	// behavior matches the pre-#202 contract byte-for-byte.
+	AuthScheme string `yaml:"auth_scheme,omitempty"`
+
+	// AWSRegion is the AWS region used for SigV4 signing when
+	// AuthScheme == "aws_sigv4". Required on that path. Forge does
+	// not parse the region out of the BaseURL because Bedrock URLs
+	// often go through customer-side proxies that re-write the host.
+	AWSRegion string `yaml:"aws_region,omitempty"`
+
 	Version        string          `yaml:"version,omitempty"`
 	OrganizationID string          `yaml:"organization_id,omitempty"`
 	Fallbacks      []ModelFallback `yaml:"fallbacks,omitempty"`


### PR DESCRIPTION
## Summary

Two-phase rollout per the locked design under #202.

**Phase 1**: `forge init`'s "Custom" provider option now asks whether the endpoint speaks OpenAI Chat Completions or Anthropic Messages wire format and writes the matching provider into the generated `forge.yaml`. Underlying plumbing already supported `provider: anthropic` + `ANTHROPIC_BASE_URL` symmetric with the OpenAI path (#137 / #139); this exposes it through the wizard.

**Phase 2** (Option B from the issue): new `model.auth_scheme` + `model.aws_region` fields with a **hand-rolled SigV4 outbound transport**. Symmetric across both providers — `provider: anthropic` + `auth_scheme: aws_sigv4` lets the operator point at Bedrock's Anthropic passthrough or any SigV4-fronted Anthropic-compat proxy; the same for `provider: openai` against Bedrock's OpenAI compat endpoint.

## Why hand-roll SigV4 instead of pulling in aws-sdk-go-v2

The inbound `aws_sigv4` provider (#157) is already hand-rolled HTTP + XML for the same reason called out in its package doc:

> §9.1 — no aws-sdk-go-v2 dependency. The STS RPC is hand-rolled HTTP + XML; trade-off is smaller attack surface and no transitive deps.

aws-sdk-go-v2 would add ~5 MB to a binary that recently hit 88 MB. The signing algorithm is ~250 LOC of stdlib `crypto/hmac` + `crypto/sha256` + `encoding/hex`. This PR matches the existing posture.

## Configuration

```yaml
model:
  provider: anthropic                   # or "openai"
  name: anthropic.claude-sonnet-4-20250514-v1:0
  base_url: "https://bedrock-runtime.us-east-1.amazonaws.com"
  auth_scheme: aws_sigv4                # new
  aws_region: us-east-1                 # new
```

Credentials resolve via the standard AWS env vars (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`). Region picks up from `AWS_REGION` env if `aws_region` is unset.

When the AuthScheme is `aws_sigv4`:
- Anthropic client skips `x-api-key`; keeps `anthropic-version`.
- OpenAI client skips `Authorization: Bearer`; keeps `OpenAI-Organization`.
- The `http.Client.Transport` is wrapped with the SigV4 signer.
- `APIKey` is ignored on this path.

Empty AuthScheme preserves the pre-#202 contract byte-for-byte. All existing Anthropic and OpenAI deployments see zero behavior change.

## Bedrock host auto-allowlist

`LLMProviderDomains` parses `model.base_url` host-agnostically, so `bedrock-runtime.<region>.amazonaws.com` automatically extends the egress allowlist. Pinned by `TestLLMProviderDomains_BedrockHostExtracted`.

## Deferred (called out in the issue's "out of scope" + reaffirmed in the CHANGELOG)

- **Web identity / IRSA / EC2 metadata** credential resolution. Today the credential getter reads env only; most Bedrock deployments set AWS env vars at the platform layer (IRSA env injection, sidecar credential fetcher, `AWS_PROFILE` resolution before launch).
- **Bedrock-specific URL / body rewriting** (`/model/<id>/invoke` path + `anthropic_version` body field). Operators today point Forge at a Bedrock-compat proxy that handles the protocol translation (litellm). Phase 2.5 follow-up.
- **`forge init` "AWS Bedrock" first-class wizard option** (Phase 3 in the issue). The Custom path with shape-picker covers the configuration; the dedicated Bedrock option is pure UX polish.

## Test plan

- [x] `golangci-lint run` across all four modules — 0 issues
- [x] `gofmt -w` clean
- [x] `go test ./...` in `forge-core/` and `forge-cli/` — all green
- [x] 21 new tests pin:
  - **SigV4 transport** (10 tests): Authorization + X-Amz-Date stamped; X-Amz-Security-Token when temporary; body + Content-Length preserved; caller's request not mutated (RoundTripper contract); underlying error propagation; missing credentials short-circuit (no unsigned request leak); region + service required; canonical-query ordering; end-to-end against `httptest.NewServer`; env credential reader.
  - **Anthropic client** (4 tests): default keeps x-api-key + anthropic-version; SigV4 path omits x-api-key but keeps anthropic-version; SigV4 wraps the transport; default transport is unwrapped.
  - **OpenAI client** (4 tests): default keeps Authorization Bearer; SigV4 path omits Authorization; SigV4 wraps transport; OpenAI-Organization still rides under SigV4.
  - **Egress allowlist**: Bedrock hostname auto-extracted from `model.base_url`.
  - **Wizard normalize**: Anthropic-shape rewrite to `provider: anthropic` + ANTHROPIC_* env vars; default-shape stays on OpenAI.
- [ ] Manual smoke: real Bedrock account with Claude Sonnet model; set `AWS_ACCESS_KEY_ID` + `AWS_REGION` env; configure `model.auth_scheme: aws_sigv4`; verify request signs cleanly and 200s come back.

## Files

| File | Phase | Role |
|---|---|---|
| `forge-core/types/config.go` | 2 | `ModelRef.AuthScheme` + `AWSRegion` fields |
| `forge-core/llm/client.go` | 2 | `ClientConfig.AuthScheme` + `AWSRegion` fields |
| `forge-core/runtime/config.go` | 2 | Plumb through `ResolveModelConfig`; `AWS_REGION` env safety-net |
| `forge-core/llm/providers/sigv4_transport.go` | 2 | NEW. Hand-rolled SigV4 RoundTripper |
| `forge-core/llm/providers/anthropic.go` | 2 | Wrap transport + skip x-api-key on SigV4 path |
| `forge-core/llm/providers/openai.go` | 2 | Wrap transport + skip Bearer on SigV4 path |
| `forge-cli/internal/tui/wizard.go` | 1 | `WizardContext.CustomShape` |
| `forge-cli/internal/tui/steps/provider_step.go` | 1 | New `providerCustomShapePhase` between URL and Model phases |
| `forge-cli/cmd/init.go` | 1 | `normalizeCustomProvider` branches on shape; emits ANTHROPIC_* env when anthropic |
| `docs/reference/forge-yaml-schema.md` | 1+2 | New `auth_scheme` / `aws_region` fields documented |
| `CHANGELOG.md` | — | Unreleased entry |