### PR TITLE
feat(guardrails): generalize MODIFY policy decision beyond cli_execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Changed (potentially breaking)
+
+- **Guardrail MODIFY / DENY now apply to every tool, not just
+  `cli_execute` (#209 / governance R4a).** Pre-#209 the
+  `SkillGuardrailEngine` short-circuited on any tool whose name
+  wasn't `cli_execute`, so `deny_commands` / `deny_output` patterns
+  silently no-op'd for `web_search`, `http_request`, MCP calls, and
+  every custom tool. The short-circuit is removed.
+  - **Match-target asymmetry to be aware of**: for `cli_execute`
+    the match target is still the reconstructed shell command line
+    (`binary arg1 arg2 …`) so existing shell-style patterns keep
+    working. For every other tool the match target is the raw
+    tool-input JSON as the LLM produced it. See
+    `docs/security/policy-decisions.md` for migration guidance.
+  - **`GuardrailChecker.CheckInbound` / `CheckOutbound` signatures
+    change** to return `(PolicyResult, error)` — the new
+    `PolicyDecision` enum (`Allow` < `Modify` < `StepUp` < `Defer`
+    < `Deny`, ordered by restrictiveness) is the R4 taxonomy from
+    the governance framework. `StepUp`/`Defer` are reserved for R4b
+    (#210) / R4c (#211) and not yet emitted; callers today still
+    read only Allow / Modify / Deny.
+  - Every `guardrail_check` audit event already carried a
+    `fields.decision` string; nothing on the audit wire shape
+    changes.
+
 ### Added
 
 - **Anthropic-format custom URLs + AWS Bedrock SigV4 outbound auth

--- a/docs/security/policy-decisions.md
+++ b/docs/security/policy-decisions.md
@@ -1,0 +1,52 @@
+# Policy decisions
+
+Forge's guardrail engine can emit one of five decisions for any
+evaluated piece of content:
+
+| Decision  | Meaning                                                    | Where it fires today                                      |
+|-----------|------------------------------------------------------------|-----------------------------------------------------------|
+| `allow`   | Content passes through unmodified                          | Every gate, default                                       |
+| `deny`    | Content is rejected — the caller must not admit it         | InputGate, OutputGate, ToolCallGate, ToolOutputGate       |
+| `modify`  | Content is admissible but must be rewritten first          | InputGate (masking), OutputGate (masking), ToolOutputGate (redact) |
+| `step_up` | Reserved for R4b (#210) — additional user interaction     | not yet emitted                                           |
+| `defer`   | Reserved for R4c (#211) — out-of-band lookup required      | not yet emitted                                           |
+
+The `PolicyDecision` type and `PolicyResult` struct live in
+`forge-core/runtime/guardrails.go`. See the interface docstrings on
+`GuardrailChecker` for the exact contract.
+
+## MODIFY, generalized (#209)
+
+Before #209, `modify` was implemented for exactly one path —
+`cli_execute` output redaction. Skill-authored `deny_output` /
+`deny_commands` patterns silently no-op'd for every other tool. #209
+removes the `cli_execute` short-circuit so:
+
+- **User prompts** — the LibraryGuardrailEngine's InputGate mask
+  decision returns `DecisionModify` from `CheckInbound`.
+- **LLM responses** — same via OutputGate on `CheckOutbound`.
+- **Any tool output** — `SkillGuardrailEngine.CheckCommandOutput`
+  now applies the redact/block loop to output of ANY tool, not just
+  cli_execute. The loop is hoisted into a package-level
+  `applyOutputPolicy` so future call sites (MCP tool result hook,
+  RAG context ingestion) can reuse the same MODIFY semantics.
+
+## Audit event mapping
+
+Every `guardrail_check` event carries a `fields.decision` string:
+
+- `allowed` — Allow
+- `masked` — Modify
+- `blocked` — Deny (enforce mode)
+- `warned` — Deny (warn mode)
+
+These strings predate the `PolicyDecision` enum by several sprints —
+they stay for SIEM stability. Consumers building on the enum should
+map `allowed ↔ allow`, `masked ↔ modify`, `blocked ↔ deny`.
+
+## Test surface
+
+- `forge-core/runtime/policy_decision_test.go` — enum semantics +
+  `applyOutputPolicy` behavior across tools.
+- `forge-core/runtime/skill_guardrails_test.go` — `deny_commands`
+  and `deny_output` MODIFY paths fire for non-cli_execute tools.

--- a/docs/security/policy-decisions.md
+++ b/docs/security/policy-decisions.md
@@ -31,6 +31,51 @@ removes the `cli_execute` short-circuit so:
   `applyOutputPolicy` so future call sites (MCP tool result hook,
   RAG context ingestion) can reuse the same MODIFY semantics.
 
+### ⚠️ Behavior change: match target asymmetry
+
+`deny_commands` patterns match against **different target strings**
+depending on the tool:
+
+| Tool             | Match target                                            |
+|------------------|---------------------------------------------------------|
+| `cli_execute`    | Reconstructed shell command line: `binary arg1 arg2 …`  |
+| any other tool   | The raw tool-input JSON verbatim                        |
+
+For `cli_execute` this preserves the pre-#209 semantics — patterns
+authored as shell-style regexes (`\bget\s+secrets?\b`, `rm\s+-rf`)
+still fire the same way against the parsed `binary`+`args`.
+
+For every other tool, the match runs against the JSON payload as
+the LLM produced it. A pattern like `"query":"kubectl get secrets"`
+will match a `web_search` invocation whose LLM-provided arguments
+happen to contain that substring; a pattern like `rm\s+-rf` will
+NOT (there's no reconstructed command line for `web_search`).
+
+**Migration**: operators upgrading a pre-#209 skill should audit
+their `deny_commands` list. A permissive shell-style pattern that
+previously affected only `cli_execute` may now start denying
+`web_search` / `http_request` / MCP calls whose JSON body happens
+to contain that text. Split rules that were meant for one tool
+family into per-tool patterns anchored on JSON structure (e.g.
+`"binary":"kubectl"` for cli_execute-only matches) if the wider
+scope is undesirable.
+
+### Block/redact ordering
+
+`applyOutputPolicy` evaluates `deny_output` filters in two passes:
+
+1. **Block pass** — every `block` pattern is checked against the
+   **original** content. A single match short-circuits the whole
+   call to `Deny`.
+2. **Redact pass** — every `redact` pattern is applied cumulatively
+   to the (possibly already-partially-redacted) content, returning
+   `Modify` if any substitution happened.
+
+The two-pass design guarantees an earlier `redact` cannot suppress a
+later `block` match by rewriting the substring the block pattern
+would have caught — a `Deny`-worthy string is never silently
+downgraded to `Modify`.
+
 ## Audit event mapping
 
 Every `guardrail_check` event carries a `fields.decision` string:

--- a/forge-cli/runtime/guardrails_engine.go
+++ b/forge-cli/runtime/guardrails_engine.go
@@ -154,10 +154,13 @@ func (e *LibraryGuardrailEngine) structuredIfFileMode() *models.StructuredGuardr
 }
 
 // CheckInbound validates an inbound (user) message via InputGate.
-func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Message) error {
+// The returned PolicyResult carries the engine's Allow/Deny/Modify
+// decision (see #209). On Modify, msg.Parts is mutated in place so
+// downstream reads see the redacted text.
+func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Message) (coreruntime.PolicyResult, error) {
 	text := coreruntime.ExtractText(msg)
 	if text == "" {
-		return nil
+		return coreruntime.Allow(), nil
 	}
 
 	// Span lifecycle (issue #161): open before the library call so the
@@ -187,7 +190,7 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 	if err != nil {
 		e.logger.Warn("guardrail input gate error", map[string]any{"error": err.Error()})
 		result = nil
-		return nil
+		return coreruntime.Allow(), nil
 	}
 
 	switch result.Decision {
@@ -202,6 +205,7 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 			e.emitGuardrailEvent(ctx, "", result.MaskedContent, guardrailResultMasked, result)
 			evidenceContent = result.MaskedContent
 			decisionString = guardrailResultMasked
+			return coreruntime.Modify(result.MaskedContent, violationSummary(result)), nil
 		}
 	case guardrails.DecisionBlock:
 		desc := violationSummary(result)
@@ -209,40 +213,50 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 			e.emitGuardrailEvent(ctx, "", text, guardrailResultBlocked, result)
 			evidenceContent = text
 			decisionString = guardrailResultBlocked
-			return fmt.Errorf("input blocked: %s", desc)
+			return coreruntime.Deny(desc), fmt.Errorf("input blocked: %s", desc)
 		}
 		e.logger.Warn("guardrail input violation (warn mode)", map[string]any{"detail": desc})
 		e.emitGuardrailEvent(ctx, "", text, guardrailResultWarned, result)
 		evidenceContent = text
 		decisionString = guardrailResultWarned
 	}
-	return nil
+	return coreruntime.Allow(), nil
 }
 
 // CheckOutbound validates an outbound (agent) message via OutputGate.
 // Masked content is applied in-place; blocked content returns an error
 // only in enforce mode. One guardrail.output span per text part — the
 // trace tree mirrors the part-level iteration.
-func (e *LibraryGuardrailEngine) CheckOutbound(ctx context.Context, msg *a2a.Message) error {
+//
+// The aggregated PolicyResult follows the most-severe part's outcome:
+// any Deny → Deny; else any Modify → Modify (Modified reflects the
+// last modified part's content); else Allow.
+func (e *LibraryGuardrailEngine) CheckOutbound(ctx context.Context, msg *a2a.Message) (coreruntime.PolicyResult, error) {
+	aggregate := coreruntime.Allow()
 	for i, p := range msg.Parts {
 		if p.Kind != a2a.PartKindText || p.Text == "" {
 			continue
 		}
 
 		original := p.Text
-		blockErr := e.checkOneOutboundPart(ctx, msg, i, original)
+		partResult, blockErr := e.checkOneOutboundPart(ctx, msg, i, original)
 		if blockErr != nil {
-			return blockErr
+			return partResult, blockErr
+		}
+		// Escalate aggregate if this part is more severe than what
+		// we've seen so far. Allow < Modify < Deny.
+		if partResult.Decision > aggregate.Decision {
+			aggregate = partResult
 		}
 	}
-	return nil
+	return aggregate, nil
 }
 
 // checkOneOutboundPart runs OutputGate over a single text part. Split
 // from CheckOutbound so the per-part span has a clean lifetime (open
 // at function entry, deferred close at exit) without juggling state
 // across iterations.
-func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *a2a.Message, i int, original string) error {
+func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *a2a.Message, i int, original string) (coreruntime.PolicyResult, error) {
 	ctx, span := startGuardrailSpan(ctx, "output", "")
 	var (
 		evidenceContent string
@@ -264,7 +278,7 @@ func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *
 	if err != nil {
 		e.logger.Warn("guardrail output gate error", map[string]any{"error": err.Error()})
 		result = nil
-		return nil
+		return coreruntime.Allow(), nil
 	}
 
 	switch result.Decision {
@@ -275,6 +289,7 @@ func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *
 			e.emitGuardrailEvent(ctx, "", result.MaskedContent, guardrailResultMasked, result)
 			evidenceContent = result.MaskedContent
 			decisionString = guardrailResultMasked
+			return coreruntime.Modify(result.MaskedContent, violationSummary(result)), nil
 		}
 	case guardrails.DecisionBlock:
 		desc := violationSummary(result)
@@ -282,14 +297,14 @@ func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *
 			e.emitGuardrailEvent(ctx, "", original, guardrailResultBlocked, result)
 			evidenceContent = original
 			decisionString = guardrailResultBlocked
-			return fmt.Errorf("output blocked: %s", desc)
+			return coreruntime.Deny(desc), fmt.Errorf("output blocked: %s", desc)
 		}
 		e.logger.Warn("guardrail output violation (warn mode)", map[string]any{"detail": desc})
 		e.emitGuardrailEvent(ctx, "", original, guardrailResultWarned, result)
 		evidenceContent = original
 		decisionString = guardrailResultWarned
 	}
-	return nil
+	return coreruntime.Allow(), nil
 }
 
 // CheckToolCall validates the arguments the agent is about to pass to

--- a/forge-cli/runtime/guardrails_engine.go
+++ b/forge-cli/runtime/guardrails_engine.go
@@ -189,7 +189,6 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 	})
 	if err != nil {
 		e.logger.Warn("guardrail input gate error", map[string]any{"error": err.Error()})
-		result = nil
 		return coreruntime.Allow(), nil
 	}
 
@@ -228,9 +227,14 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 // only in enforce mode. One guardrail.output span per text part — the
 // trace tree mirrors the part-level iteration.
 //
-// The aggregated PolicyResult follows the most-severe part's outcome:
-// any Deny → Deny; else any Modify → Modify (Modified reflects the
-// last modified part's content); else Allow.
+// The aggregated PolicyResult follows the MOST-RESTRICTIVE part's
+// outcome per the PolicyDecision ordering (Allow < Modify < StepUp <
+// Defer < Deny). The strict `>` comparison keeps the FIRST part at
+// each severity level — subsequent equal-severity parts do not
+// overwrite Modified. In practice callers today only inspect the
+// mutated msg.Parts (each part carries its own redaction) — the
+// aggregate.Modified string is scaffolding for future R4b/R4c
+// callers that need a single-string projection.
 func (e *LibraryGuardrailEngine) CheckOutbound(ctx context.Context, msg *a2a.Message) (coreruntime.PolicyResult, error) {
 	aggregate := coreruntime.Allow()
 	for i, p := range msg.Parts {
@@ -243,8 +247,11 @@ func (e *LibraryGuardrailEngine) CheckOutbound(ctx context.Context, msg *a2a.Mes
 		if blockErr != nil {
 			return partResult, blockErr
 		}
-		// Escalate aggregate if this part is more severe than what
-		// we've seen so far. Allow < Modify < Deny.
+		// Escalate aggregate when this part is more restrictive. Uses
+		// the PolicyDecision ordinal-as-severity contract established
+		// in forge-core/runtime/guardrails.go: constants are ordered
+		// Allow < Modify < StepUp < Defer < Deny, so a numeric > is
+		// safe here even when StepUp/Defer flow through in future.
 		if partResult.Decision > aggregate.Decision {
 			aggregate = partResult
 		}
@@ -277,7 +284,6 @@ func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *
 	})
 	if err != nil {
 		e.logger.Warn("guardrail output gate error", map[string]any{"error": err.Error()})
-		result = nil
 		return coreruntime.Allow(), nil
 	}
 
@@ -339,7 +345,6 @@ func (e *LibraryGuardrailEngine) CheckToolCall(ctx context.Context, toolName, ar
 			"tool":  toolName,
 			"error": err.Error(),
 		})
-		result = nil
 		return args, nil
 	}
 
@@ -406,7 +411,6 @@ func (e *LibraryGuardrailEngine) CheckToolOutput(ctx context.Context, toolName, 
 			"tool":  toolName,
 			"error": err.Error(),
 		})
-		result = nil
 		return text, nil
 	}
 
@@ -468,7 +472,6 @@ func (e *LibraryGuardrailEngine) CheckContext(ctx context.Context, content strin
 	})
 	if err != nil {
 		e.logger.Warn("guardrail context gate error", map[string]any{"error": err.Error()})
-		result = nil
 		return content, nil
 	}
 
@@ -529,7 +532,6 @@ func (e *LibraryGuardrailEngine) CheckStream(ctx context.Context, chunk string) 
 	})
 	if err != nil {
 		e.logger.Warn("guardrail stream gate error", map[string]any{"error": err.Error()})
-		result = nil
 		return chunk, nil
 	}
 

--- a/forge-cli/runtime/guardrails_engine_test.go
+++ b/forge-cli/runtime/guardrails_engine_test.go
@@ -49,13 +49,13 @@ func TestFileGuardrailEngine_CheckInbound(t *testing.T) {
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "Hello, how are you?"}},
 	}
 	ctx := context.Background()
-	if err := engine.CheckInbound(ctx, msg); err != nil {
+	if _, err := engine.CheckInbound(ctx, msg); err != nil {
 		t.Errorf("normal message should pass inbound check: %v", err)
 	}
 
 	// Empty message should pass
 	emptyMsg := &a2a.Message{Role: "user"}
-	if err := engine.CheckInbound(ctx, emptyMsg); err != nil {
+	if _, err := engine.CheckInbound(ctx, emptyMsg); err != nil {
 		t.Errorf("empty message should pass inbound check: %v", err)
 	}
 }
@@ -73,7 +73,7 @@ func TestFileGuardrailEngine_CheckOutbound(t *testing.T) {
 		Role:  "agent",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "Here is the result."}},
 	}
-	if err := engine.CheckOutbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckOutbound(context.Background(), msg); err != nil {
 		t.Errorf("normal message should pass outbound check: %v", err)
 	}
 }
@@ -122,7 +122,7 @@ func TestBuildGuardrailChecker_FileMode(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "hello"}},
 	}
-	if err := checker.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := checker.CheckInbound(context.Background(), msg); err != nil {
 		t.Errorf("default checker should pass normal message: %v", err)
 	}
 }
@@ -148,7 +148,7 @@ func TestLibraryGuardrailEngine_EmitsAuditOnInboundMask(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "my email is foo@example.com please verify"}},
 	}
-	if err := engine.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckInbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckInbound: %v", err)
 	}
 
@@ -264,7 +264,7 @@ func TestLibraryGuardrailEngine_OmitsEvidenceByDefault(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "my email is foo@example.com"}},
 	}
-	if err := engine.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckInbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckInbound: %v", err)
 	}
 

--- a/forge-cli/runtime/guardrails_tracing_test.go
+++ b/forge-cli/runtime/guardrails_tracing_test.go
@@ -67,7 +67,7 @@ func TestCheckInbound_OpensInputSpanWithGateAttributes(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "my email is foo@example.com"}},
 	}
-	if err := engine.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckInbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckInbound: %v", err)
 	}
 
@@ -102,7 +102,7 @@ func TestCheckInbound_CaptureContent_StampsRedactedEvidence(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "my email is foo@example.com"}},
 	}
-	if err := engine.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckInbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckInbound: %v", err)
 	}
 
@@ -152,7 +152,7 @@ func TestCheckOutbound_OpensOutputSpan_NoToolAttribute(t *testing.T) {
 		Role:  "agent",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "Here is your answer."}},
 	}
-	if err := engine.CheckOutbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckOutbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckOutbound: %v", err)
 	}
 
@@ -212,7 +212,7 @@ func TestCheckInbound_NoTracing_NoSpansRecorded(t *testing.T) {
 		Role:  "user",
 		Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: "hello"}},
 	}
-	if err := engine.CheckInbound(context.Background(), msg); err != nil {
+	if _, err := engine.CheckInbound(context.Background(), msg); err != nil {
 		t.Fatalf("CheckInbound: %v", err)
 	}
 

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1270,7 +1270,7 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		server.WriteSSEEvent(w, flusher, "status", task) //nolint:errcheck
 
 		// Guardrail check inbound
-		if err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
+		if _, err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
 			task.Status = a2a.TaskStatus{
 				State: a2a.TaskStateFailed,
 				Message: &a2a.Message{
@@ -1340,7 +1340,7 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 		var finalState a2a.TaskState
 		for respMsg := range ch {
 			// Guardrail check outbound
-			if grErr := guardrails.CheckOutbound(ctx, respMsg); grErr != nil {
+			if _, grErr := guardrails.CheckOutbound(ctx, respMsg); grErr != nil {
 				task.Status = a2a.TaskStatus{
 					State: a2a.TaskStateFailed,
 					Message: &a2a.Message{
@@ -1511,7 +1511,7 @@ func (r *Runner) executeTask(
 		auditLogger.EmitInvocationComplete(ctx, snap.InvocationDuration, fields)
 	}
 
-	if err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
+	if _, err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
 		task.Status = a2a.TaskStatus{
 			State: a2a.TaskStateFailed,
 			Message: &a2a.Message{
@@ -1582,7 +1582,7 @@ func (r *Runner) executeTask(
 	}
 
 	if respMsg != nil {
-		if err := guardrails.CheckOutbound(ctx, respMsg); err != nil {
+		if _, err := guardrails.CheckOutbound(ctx, respMsg); err != nil {
 			task.Status = a2a.TaskStatus{
 				State: a2a.TaskStateFailed,
 				Message: &a2a.Message{
@@ -1781,7 +1781,7 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 		store.Put(task)
 		server.WriteSSEEvent(w, flusher, "status", task) //nolint:errcheck
 
-		if err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
+		if _, err := guardrails.CheckInbound(ctx, &params.Message); err != nil {
 			task.Status = a2a.TaskStatus{
 				State: a2a.TaskStateFailed,
 				Message: &a2a.Message{
@@ -1845,7 +1845,7 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 
 		var finalState a2a.TaskState
 		for respMsg := range ch {
-			if grErr := guardrails.CheckOutbound(ctx, respMsg); grErr != nil {
+			if _, grErr := guardrails.CheckOutbound(ctx, respMsg); grErr != nil {
 				task.Status = a2a.TaskStatus{
 					State: a2a.TaskStateFailed,
 					Message: &a2a.Message{

--- a/forge-core/runtime/guardrails.go
+++ b/forge-core/runtime/guardrails.go
@@ -12,15 +12,22 @@ import (
 // piece of content. Governance R4 requires the engine to be capable
 // of expressing each of these — even if a particular gate only
 // exercises a subset today. See docs/security/policy-decisions.md.
+//
+// Constants are ordered by RESTRICTIVENESS — the ordinal value maps
+// to severity so `partA.Decision > partB.Decision` selects the more
+// restrictive decision when aggregating across multiple parts:
+//
+//	Allow < Modify < StepUp < Defer < Deny
+//
+// Callers comparing severity SHOULD use the ordinal directly. Do NOT
+// reorder without updating every aggregate site (see
+// LibraryGuardrailEngine.CheckOutbound and its per-part escalation).
 type PolicyDecision int
 
 const (
 	// DecisionAllow — content passes through unmodified. Zero value.
+	// Least restrictive.
 	DecisionAllow PolicyDecision = iota
-
-	// DecisionDeny — content is rejected. Caller MUST propagate the
-	// error and MUST NOT let the content proceed.
-	DecisionDeny
 
 	// DecisionModify — content is admissible but must be rewritten
 	// (redacted, truncated, tagged) before it moves forward.
@@ -36,6 +43,10 @@ const (
 	// (platform API, human queue) before the caller can proceed.
 	// Reserved for R4c (#211).
 	DecisionDefer
+
+	// DecisionDeny — content is rejected. Caller MUST propagate the
+	// error and MUST NOT let the content proceed. Most restrictive.
+	DecisionDeny
 )
 
 // String returns the audit-safe decision token. Matches the strings

--- a/forge-core/runtime/guardrails.go
+++ b/forge-core/runtime/guardrails.go
@@ -7,6 +7,83 @@ import (
 	"github.com/initializ/forge/forge-core/a2a"
 )
 
+// PolicyDecision is the taxonomy of decisions a Forge policy engine
+// (guardrails, admission, skill rules) can produce for one evaluated
+// piece of content. Governance R4 requires the engine to be capable
+// of expressing each of these — even if a particular gate only
+// exercises a subset today. See docs/security/policy-decisions.md.
+type PolicyDecision int
+
+const (
+	// DecisionAllow — content passes through unmodified. Zero value.
+	DecisionAllow PolicyDecision = iota
+
+	// DecisionDeny — content is rejected. Caller MUST propagate the
+	// error and MUST NOT let the content proceed.
+	DecisionDeny
+
+	// DecisionModify — content is admissible but must be rewritten
+	// (redacted, truncated, tagged) before it moves forward.
+	// PolicyResult.Modified carries the replacement.
+	DecisionModify
+
+	// DecisionStepUp — content is conditionally admissible pending an
+	// additional user/operator interaction (re-auth, approval,
+	// verification). Reserved for R4b (#210).
+	DecisionStepUp
+
+	// DecisionDefer — decision requires an out-of-band lookup
+	// (platform API, human queue) before the caller can proceed.
+	// Reserved for R4c (#211).
+	DecisionDefer
+)
+
+// String returns the audit-safe decision token. Matches the strings
+// emitted on guardrail_check events so a SIEM index built from those
+// events can be queried by PolicyDecision value.
+func (d PolicyDecision) String() string {
+	switch d {
+	case DecisionAllow:
+		return "allow"
+	case DecisionDeny:
+		return "deny"
+	case DecisionModify:
+		return "modify"
+	case DecisionStepUp:
+		return "step_up"
+	case DecisionDefer:
+		return "defer"
+	default:
+		return "unknown"
+	}
+}
+
+// PolicyResult carries the outcome of one policy evaluation.
+//
+// For DecisionAllow / DecisionDeny / DecisionStepUp / DecisionDefer,
+// Modified is empty. For DecisionModify, Modified holds the
+// rewritten content; callers substitute it into the value stream.
+// Reason is a short human-readable string surfaced on audit events
+// and (for Deny) returned to the caller as an error message.
+type PolicyResult struct {
+	Decision PolicyDecision
+	Modified string
+	Reason   string
+}
+
+// Allow constructs a passthrough result.
+func Allow() PolicyResult { return PolicyResult{Decision: DecisionAllow} }
+
+// Deny constructs a rejection result carrying `reason`.
+func Deny(reason string) PolicyResult {
+	return PolicyResult{Decision: DecisionDeny, Reason: reason}
+}
+
+// Modify constructs a redact-and-continue result.
+func Modify(newContent, reason string) PolicyResult {
+	return PolicyResult{Decision: DecisionModify, Modified: newContent, Reason: reason}
+}
+
 // GuardrailChecker validates messages, tool calls, retrieved context,
 // and tool / LLM output against guardrail policies. Implementations
 // may use file-based config, database-backed config, or no-op
@@ -22,12 +99,17 @@ import (
 // tags from the request scope.
 type GuardrailChecker interface {
 	// CheckInbound validates an inbound (user) message — InputGate.
-	CheckInbound(ctx context.Context, msg *a2a.Message) error
+	// Returns a PolicyResult carrying the engine's decision. On
+	// DecisionModify the implementation SHOULD have already mutated
+	// msg in place so the caller's downstream reads see the redacted
+	// content; PolicyResult.Modified is provided for audit-trail use.
+	// On DecisionDeny the caller MUST NOT admit the message.
+	CheckInbound(ctx context.Context, msg *a2a.Message) (PolicyResult, error)
 
 	// CheckOutbound validates an outbound (agent) message —
-	// OutputGate. Implementations should prefer redacting sensitive
-	// content over blocking.
-	CheckOutbound(ctx context.Context, msg *a2a.Message) error
+	// OutputGate. Same semantics as CheckInbound: MODIFY mutates
+	// msg in place, DENY blocks.
+	CheckOutbound(ctx context.Context, msg *a2a.Message) (PolicyResult, error)
 
 	// CheckToolCall validates the arguments the agent is about to
 	// pass to a tool — ToolCallGate. Called from the BeforeToolExec
@@ -66,8 +148,12 @@ type GuardrailChecker interface {
 // Used as a fallback when no guardrail configuration is available.
 type NoopGuardrailChecker struct{}
 
-func (n *NoopGuardrailChecker) CheckInbound(_ context.Context, _ *a2a.Message) error  { return nil }
-func (n *NoopGuardrailChecker) CheckOutbound(_ context.Context, _ *a2a.Message) error { return nil }
+func (n *NoopGuardrailChecker) CheckInbound(_ context.Context, _ *a2a.Message) (PolicyResult, error) {
+	return Allow(), nil
+}
+func (n *NoopGuardrailChecker) CheckOutbound(_ context.Context, _ *a2a.Message) (PolicyResult, error) {
+	return Allow(), nil
+}
 func (n *NoopGuardrailChecker) CheckToolCall(_ context.Context, _, args string) (string, error) {
 	return args, nil
 }

--- a/forge-core/runtime/guardrails_test.go
+++ b/forge-core/runtime/guardrails_test.go
@@ -32,11 +32,11 @@ func TestNoopGuardrailChecker_ImplementsInterface(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := checker.CheckInbound(ctx, msg); err != nil {
+	if _, err := checker.CheckInbound(ctx, msg); err != nil {
 		t.Errorf("NoopGuardrailChecker.CheckInbound() unexpected error: %v", err)
 	}
 
-	if err := checker.CheckOutbound(ctx, msg); err != nil {
+	if _, err := checker.CheckOutbound(ctx, msg); err != nil {
 		t.Errorf("NoopGuardrailChecker.CheckOutbound() unexpected error: %v", err)
 	}
 

--- a/forge-core/runtime/policy_decision_test.go
+++ b/forge-core/runtime/policy_decision_test.go
@@ -1,0 +1,77 @@
+package runtime
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestPolicyDecision_StringMapping(t *testing.T) {
+	cases := []struct {
+		d    PolicyDecision
+		want string
+	}{
+		{DecisionAllow, "allow"},
+		{DecisionDeny, "deny"},
+		{DecisionModify, "modify"},
+		{DecisionStepUp, "step_up"},
+		{DecisionDefer, "defer"},
+		{PolicyDecision(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.d.String(); got != c.want {
+			t.Errorf("%d.String(): got %q want %q", int(c.d), got, c.want)
+		}
+	}
+}
+
+func TestPolicyResult_Constructors(t *testing.T) {
+	if r := Allow(); r.Decision != DecisionAllow || r.Modified != "" || r.Reason != "" {
+		t.Errorf("Allow(): unexpected %+v", r)
+	}
+	if r := Deny("nope"); r.Decision != DecisionDeny || r.Reason != "nope" {
+		t.Errorf("Deny(): unexpected %+v", r)
+	}
+	if r := Modify("redacted", "matched"); r.Decision != DecisionModify || r.Modified != "redacted" || r.Reason != "matched" {
+		t.Errorf("Modify(): unexpected %+v", r)
+	}
+}
+
+// TestApplyOutputPolicy_ModifyForAnyTool proves the R4a acceptance
+// criterion: "MODIFY case emitted for a non-cli_execute tool output".
+// The helper is content-agnostic — it doesn't know which tool the
+// caller was operating on, which is the whole point of R4a.
+func TestApplyOutputPolicy_ModifyForAnyTool(t *testing.T) {
+	filters := []compiledOutputFilter{{
+		re:     regexp.MustCompile(`secret-[a-z]+`),
+		action: "redact",
+	}}
+	res := applyOutputPolicy("prod-db uses secret-abc", filters, &testLogger{}, "http_request")
+	if res.Decision != DecisionModify {
+		t.Fatalf("expected DecisionModify, got %s", res.Decision)
+	}
+	if res.Modified != "prod-db uses [BLOCKED BY POLICY]" {
+		t.Errorf("unexpected modified content: %q", res.Modified)
+	}
+}
+
+func TestApplyOutputPolicy_BlockShortCircuits(t *testing.T) {
+	filters := []compiledOutputFilter{
+		{re: regexp.MustCompile(`redact-me`), action: "redact"},
+		{re: regexp.MustCompile(`BEGIN CERTIFICATE`), action: "block"},
+	}
+	res := applyOutputPolicy("data: BEGIN CERTIFICATE ... redact-me", filters, &testLogger{}, "web_search")
+	if res.Decision != DecisionDeny {
+		t.Errorf("expected DecisionDeny on block match, got %s", res.Decision)
+	}
+}
+
+func TestApplyOutputPolicy_AllowWhenNoMatch(t *testing.T) {
+	filters := []compiledOutputFilter{{
+		re:     regexp.MustCompile(`nope`),
+		action: "redact",
+	}}
+	res := applyOutputPolicy("nothing to see", filters, &testLogger{}, "")
+	if res.Decision != DecisionAllow {
+		t.Errorf("expected DecisionAllow, got %s (mod=%q)", res.Decision, res.Modified)
+	}
+}

--- a/forge-core/runtime/policy_decision_test.go
+++ b/forge-core/runtime/policy_decision_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+// TestPolicyDecision_SeverityOrdering pins the ordinal-as-severity
+// contract callers rely on (LibraryGuardrailEngine.CheckOutbound
+// uses `>` to escalate the aggregate result). Reordering these
+// constants without updating aggregate sites is exactly the class
+// of silent breakage this test guards against.
+func TestPolicyDecision_SeverityOrdering(t *testing.T) {
+	order := []PolicyDecision{
+		DecisionAllow,
+		DecisionModify,
+		DecisionStepUp,
+		DecisionDefer,
+		DecisionDeny,
+	}
+	for i := 1; i < len(order); i++ {
+		if order[i-1] >= order[i] {
+			t.Errorf("severity broken: %s(%d) should be < %s(%d)",
+				order[i-1], order[i-1], order[i], order[i])
+		}
+	}
+	// Also pin the zero-value expectation — deployments that
+	// return `PolicyResult{}` implicitly mean Allow.
+	if DecisionAllow != 0 {
+		t.Errorf("DecisionAllow must remain the zero value; got %d", DecisionAllow)
+	}
+}
+
 func TestPolicyDecision_StringMapping(t *testing.T) {
 	cases := []struct {
 		d    PolicyDecision
@@ -62,6 +88,31 @@ func TestApplyOutputPolicy_BlockShortCircuits(t *testing.T) {
 	res := applyOutputPolicy("data: BEGIN CERTIFICATE ... redact-me", filters, &testLogger{}, "web_search")
 	if res.Decision != DecisionDeny {
 		t.Errorf("expected DecisionDeny on block match, got %s", res.Decision)
+	}
+}
+
+// TestApplyOutputPolicy_RedactDoesNotHideEarlierBlock is a regression
+// test for reviewer initializ-mk's #221 point: a "redact" pattern
+// listed before a "block" pattern MUST NOT rewrite text in a way
+// that suppresses the block match. Pre-fix, the loop matched
+// blocks against the progressively-redacted string, so a
+// well-crafted redact-then-block config silently downgraded Deny
+// to Modify. Post-fix, block checks run against the ORIGINAL
+// content first (two-pass evaluation).
+func TestApplyOutputPolicy_RedactDoesNotHideEarlierBlock(t *testing.T) {
+	// The redact rule matches "secret " and rewrites it away.
+	// The block rule wants to match "secret key" — with the pre-fix
+	// single-pass loop it never fires because "secret " was already
+	// redacted to "[BLOCKED BY POLICY]". Post-fix, block runs first
+	// against original content and returns Deny.
+	filters := []compiledOutputFilter{
+		{re: regexp.MustCompile(`secret `), action: "redact"},
+		{re: regexp.MustCompile(`secret key`), action: "block"},
+	}
+	res := applyOutputPolicy("leaked secret key: abc", filters, &testLogger{}, "any_tool")
+	if res.Decision != DecisionDeny {
+		t.Errorf("block must beat earlier redact — got %s (modified=%q)",
+			res.Decision, res.Modified)
 	}
 }
 

--- a/forge-core/runtime/skill_guardrails.go
+++ b/forge-core/runtime/skill_guardrails.go
@@ -173,35 +173,40 @@ func (s *SkillGuardrailEngine) CheckCommandOutput(toolName, toolOutput string) (
 // scanning, RAG-context scanning, MCP tool-result scanning) can share
 // the same MODIFY semantics.
 //
-// Precedence: any "block" match short-circuits the loop and returns
-// DecisionDeny. Otherwise, every "redact" match is applied
-// cumulatively and the aggregated redacted string is returned as
-// DecisionModify (if any pattern matched) or DecisionAllow (no matches).
+// Two-pass evaluation (fixes the redact-hides-block downgrade
+// reviewer initializ-mk flagged): pass 1 checks every "block" pattern
+// against the ORIGINAL content and short-circuits to Deny on any
+// match. Only after all blocks pass does pass 2 apply "redact"
+// substitutions cumulatively. This guarantees a block-worthy string
+// isn't silently downgraded to Modify by an earlier redact that
+// rewrote the substring the block pattern would have caught.
 //
 // `logger` and `tool` are for the redaction log line — pass "" for
 // tool when the caller isn't tool-scoped.
 func applyOutputPolicy(content string, filters []compiledOutputFilter, logger Logger, tool string) PolicyResult {
+	// Pass 1: block checks against ORIGINAL content.
+	for _, f := range filters {
+		if f.action == "block" && f.re.MatchString(content) {
+			return Deny("output matched deny_output block pattern")
+		}
+	}
+	// Pass 2: cumulative redacts.
 	modified := content
 	changed := false
 	for _, f := range filters {
-		if !f.re.MatchString(modified) {
+		if f.action != "redact" || !f.re.MatchString(modified) {
 			continue
 		}
-		switch f.action {
-		case "block":
-			return Deny("output matched deny_output block pattern")
-		case "redact":
-			modified = f.re.ReplaceAllString(modified, "[BLOCKED BY POLICY]")
-			changed = true
-			fields := map[string]any{
-				"pattern": f.re.String(),
-				"action":  "redact",
-			}
-			if tool != "" {
-				fields["tool"] = tool
-			}
-			logger.Warn("skill guardrail output redaction", fields)
+		modified = f.re.ReplaceAllString(modified, "[BLOCKED BY POLICY]")
+		changed = true
+		fields := map[string]any{
+			"pattern": f.re.String(),
+			"action":  "redact",
 		}
+		if tool != "" {
+			fields["tool"] = tool
+		}
+		logger.Warn("skill guardrail output redaction", fields)
 	}
 	if changed {
 		return Modify(modified, "output matched deny_output redact pattern")

--- a/forge-core/runtime/skill_guardrails.go
+++ b/forge-core/runtime/skill_guardrails.go
@@ -103,23 +103,27 @@ func NewSkillGuardrailEngine(rules *agentspec.SkillGuardrailRules, enforce bool,
 	return engine
 }
 
-// CheckCommandInput validates a tool call before execution. It only fires for
-// cli_execute tool calls. Returns an error if the command matches a deny pattern.
+// CheckCommandInput validates a tool call before execution.
+//
+// For cli_execute, the JSON is parsed to build a "binary arg1 arg2..."
+// canonical string so operators can author shell-style patterns
+// (`git.*--force`). For any other tool, the raw tool-input JSON is
+// used as the match target — so `deny_commands` can match on payload
+// fragments of http_request / mcp / builtin tool calls too. This
+// generalizes MODIFY/DENY beyond the cli_execute-only path called
+// out in governance R4a (#209).
 func (s *SkillGuardrailEngine) CheckCommandInput(toolName, toolInput string) error {
-	if toolName != "cli_execute" {
-		return nil
-	}
 	if len(s.denyCommands) == 0 {
 		return nil
 	}
 
-	cmdLine := extractCommandLine(toolInput)
-	if cmdLine == "" {
+	matchTarget := canonicalizeToolInput(toolName, toolInput)
+	if matchTarget == "" {
 		return nil
 	}
 
 	for _, f := range s.denyCommands {
-		if f.re.MatchString(cmdLine) {
+		if f.re.MatchString(matchTarget) {
 			msg := f.message
 			if msg == "" {
 				msg = "command blocked by skill guardrail"
@@ -129,7 +133,8 @@ func (s *SkillGuardrailEngine) CheckCommandInput(toolName, toolInput string) err
 			}
 			s.logger.Warn("skill guardrail command match", map[string]any{
 				"pattern": f.re.String(),
-				"command": cmdLine,
+				"tool":    toolName,
+				"target":  matchTarget,
 				"message": msg,
 			})
 			return fmt.Errorf("skill guardrail: %s", msg)
@@ -139,35 +144,80 @@ func (s *SkillGuardrailEngine) CheckCommandInput(toolName, toolInput string) err
 	return nil
 }
 
-// CheckCommandOutput validates tool output after execution. It only fires for
-// cli_execute tool calls. Returns the (possibly redacted) output and an error
-// if the output matches a "block" pattern.
+// CheckCommandOutput validates tool output after execution.
+//
+// Applies deny_output patterns to the output of ANY tool — not just
+// cli_execute. Governance R4a (#209) requires MODIFY (redact) to be
+// available for all tool outputs, not a special-cased path. The
+// pattern-matching loop is delegated to applyOutputPolicy so other
+// call sites (LLM response scanning, future MCP tool result hook)
+// can reuse the same block/redact semantics.
 func (s *SkillGuardrailEngine) CheckCommandOutput(toolName, toolOutput string) (string, error) {
-	if toolName != "cli_execute" {
-		return toolOutput, nil
-	}
 	if len(s.denyOutput) == 0 || toolOutput == "" {
 		return toolOutput, nil
 	}
+	result := applyOutputPolicy(toolOutput, s.denyOutput, s.logger, toolName)
+	switch result.Decision {
+	case DecisionDeny:
+		return "", fmt.Errorf("tool output blocked by skill guardrail")
+	case DecisionModify:
+		return result.Modified, nil
+	default:
+		return toolOutput, nil
+	}
+}
 
-	for _, f := range s.denyOutput {
-		if !f.re.MatchString(toolOutput) {
+// applyOutputPolicy runs the block/redact pattern chain over content
+// and returns the resulting PolicyResult. Hoisted out of
+// CheckCommandOutput for R4a (#209) so future call sites (LLM output
+// scanning, RAG-context scanning, MCP tool-result scanning) can share
+// the same MODIFY semantics.
+//
+// Precedence: any "block" match short-circuits the loop and returns
+// DecisionDeny. Otherwise, every "redact" match is applied
+// cumulatively and the aggregated redacted string is returned as
+// DecisionModify (if any pattern matched) or DecisionAllow (no matches).
+//
+// `logger` and `tool` are for the redaction log line — pass "" for
+// tool when the caller isn't tool-scoped.
+func applyOutputPolicy(content string, filters []compiledOutputFilter, logger Logger, tool string) PolicyResult {
+	modified := content
+	changed := false
+	for _, f := range filters {
+		if !f.re.MatchString(modified) {
 			continue
 		}
-
 		switch f.action {
 		case "block":
-			return "", fmt.Errorf("tool output blocked by skill guardrail")
+			return Deny("output matched deny_output block pattern")
 		case "redact":
-			toolOutput = f.re.ReplaceAllString(toolOutput, "[BLOCKED BY POLICY]")
-			s.logger.Warn("skill guardrail output redaction", map[string]any{
+			modified = f.re.ReplaceAllString(modified, "[BLOCKED BY POLICY]")
+			changed = true
+			fields := map[string]any{
 				"pattern": f.re.String(),
 				"action":  "redact",
-			})
+			}
+			if tool != "" {
+				fields["tool"] = tool
+			}
+			logger.Warn("skill guardrail output redaction", fields)
 		}
 	}
+	if changed {
+		return Modify(modified, "output matched deny_output redact pattern")
+	}
+	return Allow()
+}
 
-	return toolOutput, nil
+// canonicalizeToolInput returns the string against which deny_commands
+// patterns are matched. For cli_execute this reconstructs the shell
+// command line ("binary args..."); for any other tool the raw JSON is
+// used so operators can author payload-shape patterns.
+func canonicalizeToolInput(toolName, toolInput string) string {
+	if toolName == "cli_execute" {
+		return extractCommandLine(toolInput)
+	}
+	return toolInput
 }
 
 // CheckUserInput validates a user message against deny_prompts patterns.

--- a/forge-core/runtime/skill_guardrails_test.go
+++ b/forge-core/runtime/skill_guardrails_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/initializ/forge/forge-core/agentspec"
@@ -46,10 +47,15 @@ func TestCheckCommandInput_DenyPatterns(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "non cli_execute passes through",
+			// Post-#209: deny_commands matches on the raw JSON of
+			// non-cli_execute tools too. A pattern matching "get
+			// secrets" now catches a web_search query for the same
+			// term. Pre-#209 this asserted wantErr:false — that
+			// behavior was the R4a gap.
+			name:      "non cli_execute matched on raw JSON",
 			toolName:  "web_search",
 			toolInput: `{"query":"kubectl get secrets"}`,
-			wantErr:   false,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -161,38 +167,64 @@ func TestNewSkillGuardrailEngine_InvalidRegex(t *testing.T) {
 	}
 }
 
-func TestCheckCommandInput_NonCLIExecute(t *testing.T) {
+// TestCheckCommandInput_AppliesToAllTools verifies R4a (#209): deny
+// patterns match on non-cli_execute tools' raw JSON payloads. Prior
+// to #209 this same test asserted the OPPOSITE (that deny was
+// silently skipped for non-cli tools) — a bug.
+func TestCheckCommandInput_AppliesToAllTools(t *testing.T) {
 	rules := &agentspec.SkillGuardrailRules{
 		DenyCommands: []agentspec.CommandFilter{
-			{Pattern: `.*`, Message: "blocks everything"},
+			{Pattern: `"query":"test"`, Message: "blocks test queries"},
 		},
 	}
 	sg := NewSkillGuardrailEngine(rules, true, &testLogger{})
 
-	// Non-cli_execute tools should pass through
 	for _, tool := range []string{"web_search", "http_request", "memory_search", "file_read"} {
 		err := sg.CheckCommandInput(tool, `{"query":"test"}`)
-		if err != nil {
-			t.Errorf("tool %q should not be blocked: %v", tool, err)
+		if err == nil {
+			t.Errorf("tool %q with matching payload should be blocked", tool)
 		}
 	}
 }
 
-func TestCheckCommandOutput_NonCLIExecute(t *testing.T) {
+// TestCheckCommandOutput_AppliesToAllTools verifies MODIFY (#209
+// R4a) fires for outputs of ANY tool, not just cli_execute.
+func TestCheckCommandOutput_AppliesToAllTools(t *testing.T) {
 	rules := &agentspec.SkillGuardrailRules{
 		DenyOutput: []agentspec.OutputFilter{
-			{Pattern: `.*`, Action: "block"},
+			{Pattern: `kind: Secret`, Action: "block"},
 		},
 	}
 	sg := NewSkillGuardrailEngine(rules, true, &testLogger{})
 
-	// Non-cli_execute tools should pass through
-	out, err := sg.CheckCommandOutput("web_search", "kind: Secret")
-	if err != nil {
-		t.Errorf("non-cli_execute should not be blocked: %v", err)
+	// A block pattern on a non-cli_execute tool's output must fire.
+	_, err := sg.CheckCommandOutput("web_search", "kind: Secret\ndata: ...")
+	if err == nil {
+		t.Fatal("expected block on matching output for non-cli_execute tool")
 	}
-	if out != "kind: Secret" {
-		t.Errorf("output should pass through unchanged for non-cli_execute")
+}
+
+// TestCheckCommandOutput_RedactAppliesToAllTools covers the MODIFY
+// leg of R4a: redact patterns rewrite output for ANY tool.
+func TestCheckCommandOutput_RedactAppliesToAllTools(t *testing.T) {
+	rules := &agentspec.SkillGuardrailRules{
+		DenyOutput: []agentspec.OutputFilter{
+			{Pattern: `sk-[A-Za-z0-9]{20,}`, Action: "redact"},
+		},
+	}
+	sg := NewSkillGuardrailEngine(rules, true, &testLogger{})
+
+	for _, tool := range []string{"http_request", "web_search", "mcp:acme.fetch"} {
+		out, err := sg.CheckCommandOutput(tool, "leaked key: sk-abcdefghij0123456789xyz end")
+		if err != nil {
+			t.Fatalf("tool %q: unexpected error: %v", tool, err)
+		}
+		if !strings.Contains(out, "[BLOCKED BY POLICY]") {
+			t.Errorf("tool %q: expected redaction, got %q", tool, out)
+		}
+		if strings.Contains(out, "sk-abcdefghij") {
+			t.Errorf("tool %q: raw secret leaked through: %q", tool, out)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #209. (Re-open of #219 which GitHub auto-closed after main was force-pushed; local branch rebased onto new main.)

## Summary
- Introduce `PolicyDecision` (Allow / Deny / Modify / StepUp / Defer) + `PolicyResult` in `forge-core/runtime` — the governance R4a taxonomy.
- Migrate `GuardrailChecker.CheckInbound` / `CheckOutbound` to return `(PolicyResult, error)`; noop + library engine + all 6 runner call sites updated.
- Drop the `cli_execute`-only short-circuit in `SkillGuardrailEngine.CheckCommandInput` / `CheckCommandOutput`. `deny_commands` now matches on the raw JSON of any tool; `deny_output` redact/block fires for output of ANY tool.
- Hoist the redact/block loop into a package-level `applyOutputPolicy` so future call sites (MCP tool result hook, RAG ingest) can reuse the same MODIFY semantics.

## Acceptance criteria (from #209)
- [x] `PolicyDecision` + `PolicyResult` types introduced
- [x] `CheckInbound` / `CheckOutbound` return `PolicyResult`
- [x] MODIFY applies to LLM responses AND user prompts AND all tool outputs (not just cli_execute)
- [x] Every guardrail audit event carries a `decision` field (unchanged — `guardrail_check` already emits `decision`)
- [x] Tests: MODIFY case emitted for a non-cli_execute tool output

## Test plan
- [x] `go test ./forge-core/... ./forge-cli/...` — full sweep green
- [x] `gofmt -w` + `golangci-lint run` all clean

Docs at `docs/security/policy-decisions.md`.