### PR TITLE
feat(credentials): JIT credential dispensing per tool call

### DIFF
--- a/docs/security/least-privilege-credentials.md
+++ b/docs/security/least-privilege-credentials.md
@@ -1,0 +1,123 @@
+# Just-in-time credentials (governance R9)
+
+Forge can mint short-lived, per-tool-call credentials at the moment
+of tool execution rather than passing a long-lived environment
+variable through the whole session. This narrows the blast radius of
+a leaked token: if the agent leaks a JIT AWS token, an attacker gets
+15 minutes of a scope-down role, not the deployment's full role.
+
+## Provider model
+
+Each credential comes from a **Provider** (a plugin), configured
+per-tool via a `CredentialSpec` in `forge.yaml`. At startup the
+runner resolves every spec against the plugin registry; on every
+matching tool call it calls the provider's `Materialize` to produce
+a fresh set of env vars, merges them into the tool's subprocess
+env, and (if the provider supports it) revokes the credential after
+the call completes.
+
+Built-in providers:
+
+| Name                | What it mints                                   | Config keys                                                           |
+|---------------------|-------------------------------------------------|-----------------------------------------------------------------------|
+| `static`            | Fixed env / headers from operator config        | `env`, `headers`, `ttl` (informational)                              |
+| `sts_assume_role`   | Short-lived AWS creds via STS AssumeRole        | `role_arn` (required), `session_name`, `external_id`, `duration`, `session_policy`, `region`, `endpoint` |
+
+`static` is passthrough — useful as a bootstrap or in tests. Real
+least-privilege posture comes from `sts_assume_role` (or a Vault
+dynamic-secrets provider, tracked as a follow-up).
+
+## Declaring specs in `forge.yaml`
+
+```yaml
+credentials:
+  # AWS CLI: 15-minute scoped read-only role, external-id tied to skill.
+  - tool: cli_execute
+    binary: aws
+    provider: sts_assume_role
+    spec:
+      role_arn: arn:aws:iam::123456789012:role/forge-skill-read
+      external_id: skill-alpha
+      session_name: forge-agent-jit
+      duration: 15m
+
+  # kubectl: static passthrough (until a Vault provider ships).
+  - tool: cli_execute
+    binary: kubectl
+    provider: static
+    spec:
+      env:
+        KUBECONFIG: /var/run/secrets/skill-alpha/kubeconfig
+      ttl: 1h
+```
+
+### Field reference
+
+- **tool** — the tool name (e.g. `cli_execute`, `http_request`).
+  Empty matches every tool.
+- **binary** — for `cli_execute` only, the binary being invoked.
+  Ignored on other tools.
+- **provider** — the plugin name.
+- **spec** — an object whose shape depends on the plugin.
+
+Only the FIRST matching spec fires — order specs from most to
+least specific.
+
+## `sts_assume_role` details
+
+The provider issues a single AWS STS AssumeRole POST signed with
+SigV4. The source credentials (the identity Forge itself runs
+under) come from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+`AWS_SESSION_TOKEN` env vars — the standard AWS chain. Override
+the source env-var names via `source_access_key` / `source_secret_key`
+/ `source_token` in the spec if the operator runs multiple identities
+side-by-side.
+
+The `duration` field must be between 15 minutes and 12 hours (AWS
+STS bounds). Below 15m gets rejected at startup, not silently
+truncated.
+
+`external_id` is threaded through to STS so operators can scope the
+target role's trust policy to a specific skill: only the STS call
+carrying the right external-id can assume it.
+
+The generated `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+`AWS_SESSION_TOKEN` are appended to the subprocess env — overriding
+any same-name values from the operator's static passthrough. Any
+AWS CLI (or SDK) the subprocess launches uses them automatically.
+
+## Audit events
+
+Two events fire per JIT credential lifecycle:
+
+- `credential_issued` — after materialize, before the tool runs.
+  Fields: `provider`, `tool`, `binary`, `ttl`, `env_keys`,
+  `header_keys`, `duration_ms`.
+- `credential_revoked` — after the tool completes (whether or not
+  the provider actually revokes). Fields: `provider`, `tool`,
+  `binary`. Carries `error` if revocation failed.
+- `credential_failed` — when materialize fails (STS 403, network
+  error). The tool call is then aborted.
+
+Payloads never contain the credential material itself — only the
+key names, so SIEMs can validate that expected credentials are being
+minted without exfiltrating secrets through the audit trail.
+
+## Threat model
+
+Solves:
+- Long-lived deployment credentials in reach of a compromised skill.
+- Cross-skill credential sharing (spec is per skill+tool+binary).
+- Post-hoc audit of "which role did this action run as" via
+  `credential_issued` events.
+
+Does not solve:
+- Live-token exfiltration during the tool call itself (the token IS
+  in the subprocess env for the duration of the call).
+- Provider-side compromise (a stolen STS AssumeRole call from the
+  Forge deployment role still works).
+- Revocation-under-attack when the underlying provider is offline.
+
+Combine JIT credentials (#215) with per-skill egress allow-lists
+(existing) + audit signing (#213) + hash chaining (#212) for full
+governance R9 posture.

--- a/docs/security/least-privilege-credentials.md
+++ b/docs/security/least-privilege-credentials.md
@@ -118,6 +118,37 @@ Does not solve:
   Forge deployment role still works).
 - Revocation-under-attack when the underlying provider is offline.
 
-Combine JIT credentials (#215) with per-skill egress allow-lists
-(existing) + audit signing (#213) + hash chaining (#212) for full
-governance R9 posture.
+### Preventing credential leakage into the LLM (⚠️ operator action)
+
+`cli_execute` merges the JIT env into the subprocess env — which
+means a subprocess like `env`, or a misbehaving CLI that dumps its
+own environment, will emit the credential material into stdout,
+which the LLM then reads. This is the shape the `TestCLIExecute_
+JITCredentialsInjectedIntoEnv` regression test uses to prove
+injection works, but in production it's a footgun.
+
+**Mitigation**: use the R4a `deny_output` skill guardrail (#209 /
+`docs/security/policy-decisions.md`) to redact the material before
+the LLM sees it. Example `SKILL.md` frontmatter:
+
+```yaml
+forge:
+  deny_output:
+    - pattern: 'AKIA[0-9A-Z]{16}'
+      action: redact
+    - pattern: 'aws_secret_access_key\s*=\s*\S+'
+      action: redact
+```
+
+Post-#209 the redact loop fires for output of any tool (not just
+`cli_execute`), so the same pattern list covers `http_request`
+response bodies that leak credentials in the headers echo of a
+misconfigured API.
+
+Combine JIT credentials (#215) with:
+- R4a `deny_output` (#209) — redact credentials before LLM ingest,
+- per-skill egress allow-lists (existing),
+- audit signing (#213) + hash chaining (#212) — for tamper-evident
+  `credential_issued` events,
+
+for full governance R9 posture.

--- a/forge-cli/runtime/credentials_audit.go
+++ b/forge-cli/runtime/credentials_audit.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/initializ/forge/forge-core/credentials"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// auditSinkAdapter is the credentials.AuditSink implementation that
+// routes to the AuditLogger. It's a small shim so the credentials
+// package doesn't depend on runtime (which would cycle: agentspec
+// -> credentials -> runtime -> agentspec).
+type auditSinkAdapter struct {
+	logger *coreruntime.AuditLogger
+}
+
+// Compile-time assertion.
+var _ credentials.AuditSink = (*auditSinkAdapter)(nil)
+
+// Emit forwards each event through EmitFromContext so per-invocation
+// correlation_id, task_id, sequence number, tenancy, and workflow
+// tags auto-attach when the caller's ctx carries them.
+func (a *auditSinkAdapter) Emit(ctx context.Context, event string, fields map[string]any) {
+	if a == nil || a.logger == nil {
+		return
+	}
+	a.logger.EmitFromContext(ctx, coreruntime.AuditEvent{
+		Event:  event,
+		Fields: fields,
+	})
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -681,7 +681,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		default:
 			// Forge framework — build tool registry and use built-in LLM executor
 			reg := tools.NewRegistry()
-			if err := builtins.RegisterAll(reg); err != nil {
+			// R9: wire the JIT credential injector into http_request
+			// alongside cli_execute (further down). Nil injector →
+			// no-op inside the tool, so unsigned-cred deployments
+			// see pre-R9 behavior.
+			if err := builtins.RegisterAll(reg, builtins.Options{
+				HTTPCredentialInjector: credInjector,
+			}); err != nil {
 				r.logger.Warn("failed to register builtin tools", map[string]any{"error": err.Error()})
 			}
 

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -30,6 +30,9 @@ import (
 	_ "github.com/initializ/forge/forge-core/auth/providers/oidc"
 	"github.com/initializ/forge/forge-core/auth/providers/statictoken"
 	"github.com/initializ/forge/forge-core/compress"
+	"github.com/initializ/forge/forge-core/credentials"
+	_ "github.com/initializ/forge/forge-core/credentials/static" //nolint:revive // registers static provider via init()
+	_ "github.com/initializ/forge/forge-core/credentials/sts"    //nolint:revive // registers sts_assume_role provider via init()
 	"github.com/initializ/forge/forge-core/llm"
 	"github.com/initializ/forge/forge-core/llm/oauth"
 	"github.com/initializ/forge/forge-core/llm/providers"
@@ -353,6 +356,24 @@ func (r *Runner) Run(ctx context.Context) error {
 		})
 	}
 	r.auditSigningKey = auditSigningKey
+
+	// R9 (#215) JIT credential injector. Resolves each declared
+	// CredentialSpec against the DefaultRegistry — imports of
+	// credentials/static and credentials/sts wire providers via init().
+	// Absent when the operator hasn't declared any specs (nil-safe:
+	// tools that hold this pointer treat nil as "no JIT").
+	var credInjector *credentials.Injector
+	if len(r.cfg.Config.Credentials) > 0 {
+		sink := &auditSinkAdapter{logger: auditLogger}
+		inj, err := credentials.NewInjector(ctx, credentials.DefaultRegistry, r.cfg.Config.Credentials, sink)
+		if err != nil {
+			return fmt.Errorf("resolving credentials: %w", err)
+		}
+		credInjector = inj
+		r.logger.Info("JIT credential injector wired", map[string]any{
+			"specs": len(r.cfg.Config.Credentials),
+		})
+	}
 
 	// Resolve TracingConfig early so we can thread it into the
 	// guardrail engine before the tracer provider itself is installed
@@ -700,7 +721,7 @@ func (r *Runner) Run(ctx context.Context) error {
 						cliCfg.TimeoutSeconds = r.derivedCLIConfig.TimeoutHint
 					}
 					if len(cliCfg.AllowedBinaries) > 0 {
-						r.cliExecTool = clitools.NewCLIExecuteTool(cliCfg)
+						r.cliExecTool = clitools.NewCLIExecuteTool(cliCfg).WithCredentialInjector(credInjector)
 						if regErr := reg.Register(r.cliExecTool); regErr != nil {
 							r.logger.Warn("failed to register cli_execute", map[string]any{"error": regErr.Error()})
 						} else {
@@ -721,7 +742,7 @@ func (r *Runner) Run(ctx context.Context) error {
 					TimeoutSeconds:  r.derivedCLIConfig.TimeoutHint,
 					WorkDir:         r.cfg.WorkDir,
 				}
-				r.cliExecTool = clitools.NewCLIExecuteTool(cliCfg)
+				r.cliExecTool = clitools.NewCLIExecuteTool(cliCfg).WithCredentialInjector(credInjector)
 				if regErr := reg.Register(r.cliExecTool); regErr != nil {
 					r.logger.Warn("failed to register auto-derived cli_execute", map[string]any{"error": regErr.Error()})
 				} else {

--- a/forge-cli/tools/cli_execute.go
+++ b/forge-cli/tools/cli_execute.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-core/credentials"
 	coretools "github.com/initializ/forge/forge-core/tools"
 )
 
@@ -35,6 +36,11 @@ type CLIExecuteTool struct {
 	proxyURL    string // egress proxy URL (e.g., "http://127.0.0.1:54321")
 	workDir     string // resolved absolute workDir for path confinement
 	homeDir     string // resolved $HOME for path confinement
+
+	// credInjector, when non-nil, mints JIT credentials per Execute
+	// call and merges them into the subprocess env. Governance R9.
+	// Nil injector → no-op, preserving pre-R9 behavior.
+	credInjector *credentials.Injector
 }
 
 // cliExecuteArgs is the JSON input schema for Execute.
@@ -101,6 +107,14 @@ func NewCLIExecuteTool(config CLIExecuteConfig) *CLIExecuteTool {
 		}
 	}
 
+	return t
+}
+
+// WithCredentialInjector attaches an R9 JIT-credential injector.
+// Called by the runner at startup after resolving AgentSpec.Credentials.
+// nil-safe: passing nil is equivalent to not calling this.
+func (t *CLIExecuteTool) WithCredentialInjector(inj *credentials.Injector) *CLIExecuteTool {
+	t.credInjector = inj
 	return t
 }
 
@@ -210,6 +224,24 @@ func (t *CLIExecuteTool) Execute(ctx context.Context, args json.RawMessage) (str
 
 	// Security check 6: Env isolation
 	cmd.Env = t.buildEnv(input.Binary)
+
+	// R9 JIT credentials: if the runner wired a credentials.Injector,
+	// mint fresh scoped-down creds now, merge them into the subprocess
+	// env, and defer revocation. Nil injector → no-op. Non-cli_execute
+	// spec matches are simply skipped by Injector.Materialize.
+	if t.credInjector != nil {
+		rawArgs, _ := json.Marshal(input)
+		handle, err := t.credInjector.Materialize(ctx, "cli_execute", input.Binary, rawArgs)
+		if err != nil {
+			return "", fmt.Errorf("cli_execute: minting JIT credentials: %w", err)
+		}
+		if handle != nil {
+			defer func() { _ = handle.Close(ctx) }()
+			for k, v := range handle.Env() {
+				cmd.Env = append(cmd.Env, k+"="+v)
+			}
+		}
+	}
 
 	// Stdin
 	if input.Stdin != "" {

--- a/forge-cli/tools/cli_execute.go
+++ b/forge-cli/tools/cli_execute.go
@@ -229,6 +229,15 @@ func (t *CLIExecuteTool) Execute(ctx context.Context, args json.RawMessage) (str
 	// mint fresh scoped-down creds now, merge them into the subprocess
 	// env, and defer revocation. Nil injector → no-op. Non-cli_execute
 	// spec matches are simply skipped by Injector.Materialize.
+	//
+	// Override semantics: if an operator lists a JIT key (e.g.
+	// AWS_ACCESS_KEY_ID) in env_passthrough AND has a JIT provider
+	// stamping the same name, the JIT value MUST win — otherwise the
+	// subprocess silently keeps the broader source creds (a privilege
+	// escalation). Go's os/exec dedups env keeping the last entry, but
+	// we don't want the security of the pipeline to depend on that: we
+	// explicitly strip conflicting keys BEFORE appending the JIT env.
+	// Regression test in cli_execute_creds_test.go.
 	if t.credInjector != nil {
 		rawArgs, _ := json.Marshal(input)
 		handle, err := t.credInjector.Materialize(ctx, "cli_execute", input.Binary, rawArgs)
@@ -237,8 +246,12 @@ func (t *CLIExecuteTool) Execute(ctx context.Context, args json.RawMessage) (str
 		}
 		if handle != nil {
 			defer func() { _ = handle.Close(ctx) }()
-			for k, v := range handle.Env() {
-				cmd.Env = append(cmd.Env, k+"="+v)
+			jitEnv := handle.Env()
+			if len(jitEnv) > 0 {
+				cmd.Env = stripEnvKeys(cmd.Env, jitEnv)
+				for k, v := range jitEnv {
+					cmd.Env = append(cmd.Env, k+"="+v)
+				}
 			}
 		}
 	}
@@ -292,6 +305,28 @@ func (t *CLIExecuteTool) Availability() (available, missing []string) {
 
 // SetProxyURL sets the egress proxy URL for subprocess env injection.
 func (t *CLIExecuteTool) SetProxyURL(url string) { t.proxyURL = url }
+
+// stripEnvKeys returns env minus any "KEY=…" entry whose KEY appears
+// in override. Used before appending JIT credentials so a same-named
+// env_passthrough entry can't shadow the scoped-down JIT value.
+// Comparison is exact (case-sensitive) — matches Go's own env
+// dedup behavior.
+func stripEnvKeys(env []string, override map[string]string) []string {
+	if len(override) == 0 || len(env) == 0 {
+		return env
+	}
+	out := env[:0:len(env)]
+	for _, kv := range env {
+		eq := strings.IndexByte(kv, '=')
+		if eq > 0 {
+			if _, drop := override[kv[:eq]]; drop {
+				continue
+			}
+		}
+		out = append(out, kv)
+	}
+	return out
+}
 
 // buildEnv constructs an isolated environment with only PATH, HOME, LANG
 // and explicitly configured passthrough variables. When workDir is set,

--- a/forge-cli/tools/cli_execute_creds_test.go
+++ b/forge-cli/tools/cli_execute_creds_test.go
@@ -1,0 +1,183 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/credentials"
+	_ "github.com/initializ/forge/forge-core/credentials/static" // register static
+)
+
+// captureSink records emitted audit events so the test can assert on
+// them without wiring the full AuditLogger machinery.
+type captureSink struct {
+	mu     sync.Mutex
+	events []struct {
+		name   string
+		fields map[string]any
+	}
+}
+
+func (c *captureSink) Emit(_ context.Context, name string, fields map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, struct {
+		name   string
+		fields map[string]any
+	}{name, fields})
+}
+
+func (c *captureSink) names() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.events))
+	for _, e := range c.events {
+		out = append(out, e.name)
+	}
+	return out
+}
+
+// TestCLIExecute_JITCredentialsInjectedIntoEnv is the acceptance test
+// for governance R9: a CredentialSpec routed to cli_execute results
+// in fresh env vars appearing on the subprocess.
+func TestCLIExecute_JITCredentialsInjectedIntoEnv(t *testing.T) {
+	sink := &captureSink{}
+	inj, err := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "cli_execute",
+			Binary:   "env",
+			Provider: "static",
+			Spec: json.RawMessage(`{
+				"env": {"AWS_ACCESS_KEY_ID": "AKIAJITCREDS", "AWS_SECRET_ACCESS_KEY": "s3cr3t"},
+				"ttl": "15m"
+			}`),
+		}},
+		sink,
+	)
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+
+	tool := NewCLIExecuteTool(CLIExecuteConfig{
+		AllowedBinaries: []string{"env"},
+		TimeoutSeconds:  10,
+	}).WithCredentialInjector(inj)
+
+	// Skip if `env` isn't in PATH — rare, but honour the guard so CI
+	// on minimal containers doesn't flake.
+	avail, _ := tool.Availability()
+	if !containsString(avail, "env") {
+		t.Skip("`env` binary not available in PATH")
+	}
+
+	args, _ := json.Marshal(cliExecuteArgs{Binary: "env", Args: nil})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result cliExecuteResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing tool output: %v", err)
+	}
+
+	if !strings.Contains(result.Stdout, "AWS_ACCESS_KEY_ID=AKIAJITCREDS") {
+		t.Errorf("subprocess env missing JIT access key.\nstdout: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "AWS_SECRET_ACCESS_KEY=s3cr3t") {
+		t.Errorf("subprocess env missing JIT secret.\nstdout: %s", result.Stdout)
+	}
+
+	// Verify audit events fired: credential_issued then credential_revoked.
+	names := sink.names()
+	if len(names) < 2 {
+		t.Fatalf("expected 2+ audit events, got %d: %v", len(names), names)
+	}
+	if names[0] != "credential_issued" {
+		t.Errorf("first event should be credential_issued, got %q", names[0])
+	}
+	if names[len(names)-1] != "credential_revoked" {
+		t.Errorf("last event should be credential_revoked, got %q", names[len(names)-1])
+	}
+}
+
+// TestCLIExecute_NoInjectorNoop guards backward compatibility:
+// without an injector wired, cli_execute behaves exactly as pre-R9.
+func TestCLIExecute_NoInjectorNoop(t *testing.T) {
+	tool := NewCLIExecuteTool(CLIExecuteConfig{
+		AllowedBinaries: []string{"env"},
+		TimeoutSeconds:  10,
+	})
+	avail, _ := tool.Availability()
+	if !containsString(avail, "env") {
+		t.Skip("`env` binary not available in PATH")
+	}
+	args, _ := json.Marshal(cliExecuteArgs{Binary: "env"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result cliExecuteResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	// A dangling JIT env var must NOT appear.
+	if strings.Contains(result.Stdout, "AWS_ACCESS_KEY_ID=AKIAJITCREDS") {
+		t.Errorf("subprocess saw JIT env despite no injector: %s", result.Stdout)
+	}
+}
+
+// TestCLIExecute_InjectorSkipsNonMatchingBinary verifies binary
+// scoping — a spec pinned to `aws` must not inject on `env` calls.
+func TestCLIExecute_InjectorSkipsNonMatchingBinary(t *testing.T) {
+	sink := &captureSink{}
+	inj, err := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "cli_execute",
+			Binary:   "aws", // pinned to aws, not env
+			Provider: "static",
+			Spec:     json.RawMessage(`{"env": {"SHOULD_NOT_APPEAR": "x"}}`),
+		}},
+		sink,
+	)
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+	tool := NewCLIExecuteTool(CLIExecuteConfig{
+		AllowedBinaries: []string{"env"},
+		TimeoutSeconds:  10,
+	}).WithCredentialInjector(inj)
+	avail, _ := tool.Availability()
+	if !containsString(avail, "env") {
+		t.Skip("`env` binary not available in PATH")
+	}
+	args, _ := json.Marshal(cliExecuteArgs{Binary: "env"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, "SHOULD_NOT_APPEAR") {
+		t.Errorf("binary-scoped credential leaked to non-matching binary: %s", out)
+	}
+	// No credential_issued should have fired since no spec matched.
+	for _, name := range sink.names() {
+		if name == "credential_issued" {
+			t.Errorf("unexpected credential_issued for non-matching binary")
+		}
+	}
+}
+
+func containsString(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/forge-cli/tools/cli_execute_creds_test.go
+++ b/forge-cli/tools/cli_execute_creds_test.go
@@ -173,6 +173,98 @@ func TestCLIExecute_InjectorSkipsNonMatchingBinary(t *testing.T) {
 	}
 }
 
+// TestCLIExecute_JITOverridesEnvPassthrough is the security-critical
+// regression test reviewer initializ-mk asked for on #236: when an
+// operator lists a JIT key (e.g. AWS_ACCESS_KEY_ID) in env_passthrough
+// AND has a JIT provider stamping the same name, the JIT value MUST
+// win. Otherwise the subprocess silently keeps the broader source
+// creds — a privilege escalation.
+//
+// The pre-fix implementation relied on os/exec's env dedup keeping
+// the last entry (which does work on current Go), but Forge must not
+// depend on that runtime behavior for security. The fix explicitly
+// strips conflicting keys from cmd.Env before appending the JIT env;
+// this test asserts the JIT value wins even when we can't rely on
+// exec dedup.
+func TestCLIExecute_JITOverridesEnvPassthrough(t *testing.T) {
+	// Seed the process env with a broad "source" value that
+	// env_passthrough will propagate.
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIASOURCEBROAD")
+
+	sink := &captureSink{}
+	inj, err := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "cli_execute",
+			Binary:   "env",
+			Provider: "static",
+			Spec: json.RawMessage(`{
+				"env": {"AWS_ACCESS_KEY_ID": "AKIAJITSCOPED"}
+			}`),
+		}},
+		sink,
+	)
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+
+	tool := NewCLIExecuteTool(CLIExecuteConfig{
+		AllowedBinaries: []string{"env"},
+		// EnvPassthrough conflicts intentionally with the JIT key.
+		EnvPassthrough: []string{"AWS_ACCESS_KEY_ID"},
+		TimeoutSeconds: 10,
+	}).WithCredentialInjector(inj)
+
+	avail, _ := tool.Availability()
+	if !containsString(avail, "env") {
+		t.Skip("`env` binary not available in PATH")
+	}
+	args, _ := json.Marshal(cliExecuteArgs{Binary: "env"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var result cliExecuteResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("parsing tool output: %v", err)
+	}
+
+	// The JIT value MUST be present.
+	if !strings.Contains(result.Stdout, "AWS_ACCESS_KEY_ID=AKIAJITSCOPED") {
+		t.Errorf("subprocess env missing JIT-scoped key.\nstdout: %s", result.Stdout)
+	}
+	// The source value MUST NOT be present — belt-and-suspenders
+	// stripping means only one AWS_ACCESS_KEY_ID line exists.
+	if strings.Contains(result.Stdout, "AWS_ACCESS_KEY_ID=AKIASOURCEBROAD") {
+		t.Errorf("source-broad key leaked past the JIT override.\nstdout: %s", result.Stdout)
+	}
+	// Also assert there's exactly ONE AWS_ACCESS_KEY_ID= line —
+	// duplicates would mean stripping didn't fire and we were
+	// relying on exec dedup. The test proves the strip pass ran.
+	if got := strings.Count(result.Stdout, "AWS_ACCESS_KEY_ID="); got != 1 {
+		t.Errorf("expected 1 AWS_ACCESS_KEY_ID line after strip, got %d.\nstdout: %s",
+			got, result.Stdout)
+	}
+}
+
+// TestStripEnvKeys unit-tests the pure helper independent of the
+// subprocess plumbing, so regressions land here first.
+func TestStripEnvKeys(t *testing.T) {
+	env := []string{"PATH=/usr/bin", "AWS_ACCESS_KEY_ID=source", "HOME=/tmp", "AWS_SECRET_ACCESS_KEY=also-source"}
+	override := map[string]string{"AWS_ACCESS_KEY_ID": "jit", "AWS_SECRET_ACCESS_KEY": "jit-sec"}
+	got := stripEnvKeys(env, override)
+	// PATH and HOME survive; both AWS_ keys are stripped.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 survivors, got %d: %v", len(got), got)
+	}
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "AWS_ACCESS_KEY_ID=") || strings.HasPrefix(kv, "AWS_SECRET_ACCESS_KEY=") {
+			t.Errorf("conflicting key survived: %s", kv)
+		}
+	}
+}
+
 func containsString(xs []string, want string) bool {
 	for _, x := range xs {
 		if x == want {

--- a/forge-core/credentials/credentials.go
+++ b/forge-core/credentials/credentials.go
@@ -1,0 +1,179 @@
+// Package credentials implements governance R9 — Just-In-Time
+// credential dispensing for per-action least privilege.
+//
+// The design is a two-tier plugin system: a Provider knows how to
+// mint short-lived Credentials for a particular backend (AWS STS,
+// HashiCorp Vault, RFC 8693 token exchange, etc.); a Credential
+// yields a concrete Materialization (env vars, headers) valid for
+// exactly one tool invocation.
+//
+// The runner calls Provider.NewCredential once per (skill, tool)
+// pair at startup, then calls Credential.Materialize on every
+// BeforeToolExec hook fire. This lets a provider batch expensive
+// setup (e.g. AWS credential resolution) once while still giving
+// each tool call a fresh scope-down.
+//
+// See docs/security/least-privilege-credentials.md for the operator
+// side.
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// CredentialSpec is the declarative shape a skill's config uses to
+// describe one JIT credential.
+//
+// Tool + Binary route the credential to a specific tool call:
+//   - Tool empty  → credential applies to every tool.
+//   - Tool set    → credential applies only to that tool.
+//   - Binary set  → additionally scoped to cli_execute invocations
+//     of that binary (ignored for non-cli_execute tools).
+//
+// Provider names the plugin (e.g. "sts_assume_role", "static").
+// Spec is opaque JSON the provider decodes into its own config struct.
+type CredentialSpec struct {
+	Tool     string          `json:"tool,omitempty" yaml:"tool,omitempty"`
+	Binary   string          `json:"binary,omitempty" yaml:"binary,omitempty"`
+	Provider string          `json:"provider" yaml:"provider"`
+	Spec     json.RawMessage `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// Materialization is what a Credential produces at tool-call time.
+//
+// Env holds environment variables to inject into a subprocess (for
+// cli_execute) or otherwise pass to the tool. Headers is for HTTP
+// tool calls that sign or authenticate outbound requests. TTL is the
+// operator-facing lifetime of the underlying secret — used for
+// audit and to schedule revocation. Revoke, when non-nil, is called
+// by the runner after the tool completes.
+type Materialization struct {
+	Env     map[string]string
+	Headers map[string]string
+	TTL     Duration
+	Revoke  func(context.Context) error
+}
+
+// Duration is a JSON-friendly time.Duration wrapper. Values marshal
+// as strings like "15m" / "1h" so config files stay readable and
+// audit events stay grep-friendly. We deliberately do not export a
+// full time.Duration to avoid tying the audit schema to Go's
+// nanosecond string form ("15m0s").
+type Duration string
+
+// Credential is what a provider hands back from NewCredential — a
+// reusable factory the runner calls once per tool invocation.
+//
+// Implementations MUST be safe for concurrent Materialize calls when
+// the same skill's tool is invoked from multiple goroutines. Each
+// Materialize call SHOULD produce a distinct credential; providers
+// that support caching (STS creds valid for 15m) MAY reuse a
+// materialization within its TTL but MUST NOT return one past
+// expiration.
+type Credential interface {
+	// Materialize mints one JIT credential for the given tool call.
+	// `args` is the raw JSON the LLM is about to pass to the tool —
+	// providers may inspect it to further scope down (e.g. read the
+	// S3 key path and constrain the STS session policy). Providers
+	// that don't care about args should ignore it.
+	Materialize(ctx context.Context, tool string, args json.RawMessage) (Materialization, error)
+
+	// Kind returns the provider name (e.g. "sts_assume_role"). Used
+	// on audit events so operators can filter by credential source.
+	Kind() string
+}
+
+// Provider is the plugin that mints Credentials. One provider
+// instance per registered plugin name — the runner looks it up once
+// at startup and reuses it for every skill.
+type Provider interface {
+	// Name returns the plugin name matched against CredentialSpec.Provider.
+	Name() string
+
+	// NewCredential decodes spec (the plugin-specific JSON payload)
+	// and returns a reusable Credential. Called once per matching
+	// CredentialSpec at runner startup.
+	NewCredential(ctx context.Context, spec CredentialSpec) (Credential, error)
+}
+
+// Registry holds Provider instances by name. A single Registry per
+// runtime; providers register themselves at init time by calling
+// Register() on the package-level default, or a fresh Registry can
+// be constructed for tests.
+type Registry struct {
+	mu        sync.RWMutex
+	providers map[string]Provider
+}
+
+// NewRegistry constructs an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{providers: make(map[string]Provider)}
+}
+
+// Register adds p to the registry. Panics on duplicate name — a
+// startup misconfiguration bug that should not survive to production.
+func (r *Registry) Register(p Provider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.providers[p.Name()]; exists {
+		panic(fmt.Sprintf("credentials: provider %q registered twice", p.Name()))
+	}
+	r.providers[p.Name()] = p
+}
+
+// Get returns the provider by name. Returns nil when the operator
+// referenced a provider that wasn't wired — the caller (runner
+// startup) reports this as a config error.
+func (r *Registry) Get(name string) Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.providers[name]
+}
+
+// Names returns the sorted set of registered provider names. Used
+// on startup logs so operators can confirm which plugins are wired.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.providers))
+	for n := range r.providers {
+		out = append(out, n)
+	}
+	return out
+}
+
+// DefaultRegistry is the package-level registry. Providers that live
+// in `credentials/*` subpackages register into this via init(), so
+// importing the subpackage is the only wiring an operator has to do.
+var DefaultRegistry = NewRegistry()
+
+// ErrUnknownProvider is returned when a CredentialSpec references a
+// plugin that wasn't in the Registry.
+var ErrUnknownProvider = errors.New("credentials: unknown provider")
+
+// ResolveSpec looks up spec.Provider in r and constructs the
+// Credential. Returns ErrUnknownProvider (wrapped) when not registered.
+func (r *Registry) ResolveSpec(ctx context.Context, spec CredentialSpec) (Credential, error) {
+	p := r.Get(spec.Provider)
+	if p == nil {
+		return nil, fmt.Errorf("%w: %q (known: %v)", ErrUnknownProvider, spec.Provider, r.Names())
+	}
+	return p.NewCredential(ctx, spec)
+}
+
+// MatchesTool reports whether spec applies to the given tool + binary
+// pair. Used by the runner to select the right CredentialSpec from a
+// skill's list on each BeforeToolExec fire.
+func (spec CredentialSpec) MatchesTool(tool, binary string) bool {
+	if spec.Tool != "" && spec.Tool != tool {
+		return false
+	}
+	if spec.Binary != "" && spec.Binary != binary {
+		return false
+	}
+	return true
+}

--- a/forge-core/credentials/credentials.go
+++ b/forge-core/credentials/credentials.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"gopkg.in/yaml.v3"
 )
 
 // CredentialSpec is the declarative shape a skill's config uses to
@@ -41,6 +43,56 @@ type CredentialSpec struct {
 	Binary   string          `json:"binary,omitempty" yaml:"binary,omitempty"`
 	Provider string          `json:"provider" yaml:"provider"`
 	Spec     json.RawMessage `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+// UnmarshalYAML lets `CredentialSpec` round-trip through
+// `gopkg.in/yaml.v3`. Without this, `Spec json.RawMessage` fails to
+// decode from any YAML shape (`cannot unmarshal !!map into
+// json.RawMessage`) — that broke `forge.yaml` config loading of the
+// `credentials:` block, flagged in @initializ-mk's #236 second review.
+//
+// Strategy: decode the wrapping fields via a type-alias to avoid
+// recursion; then decode the `spec` sub-node into a generic Go value
+// and re-encode as JSON so providers keep receiving canonical
+// `json.RawMessage` bytes. Pattern mirrors
+// `forge-skills/contract/types.go`'s `BinRequirement.UnmarshalYAML`.
+func (c *CredentialSpec) UnmarshalYAML(node *yaml.Node) error {
+	// Alias with `Spec` swapped out for a yaml.Node so we can hold
+	// on to the raw sub-document and marshal it ourselves. If we
+	// left Spec as json.RawMessage on the alias yaml.v3 would fail
+	// the same way it fails on the parent.
+	type alias struct {
+		Tool     string    `yaml:"tool,omitempty"`
+		Binary   string    `yaml:"binary,omitempty"`
+		Provider string    `yaml:"provider"`
+		Spec     yaml.Node `yaml:"spec,omitempty"`
+	}
+	var a alias
+	if err := node.Decode(&a); err != nil {
+		return fmt.Errorf("credential spec: %w", err)
+	}
+	c.Tool = a.Tool
+	c.Binary = a.Binary
+	c.Provider = a.Provider
+	// Empty spec is legal (some providers infer everything from
+	// env). Detect that as "Spec has zero kind" — the default for
+	// an unset yaml.Node.
+	if a.Spec.Kind == 0 {
+		c.Spec = nil
+		return nil
+	}
+	// Decode into a generic Go value, then round-trip through
+	// encoding/json so downstream providers see stable JSON bytes.
+	var raw any
+	if err := a.Spec.Decode(&raw); err != nil {
+		return fmt.Errorf("credential spec: decoding sub-node: %w", err)
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("credential spec: re-encoding as JSON: %w", err)
+	}
+	c.Spec = b
+	return nil
 }
 
 // Materialization is what a Credential produces at tool-call time.

--- a/forge-core/credentials/credentials_test.go
+++ b/forge-core/credentials/credentials_test.go
@@ -100,3 +100,85 @@ func TestCredentialSpec_MatchesTool(t *testing.T) {
 		})
 	}
 }
+
+// captureSink is a testing AuditSink that records every emit for later
+// inspection. Used by the revoked-semantics regression tests.
+type captureSink struct {
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	name   string
+	fields map[string]any
+}
+
+func (c *captureSink) Emit(_ context.Context, name string, fields map[string]any) {
+	c.events = append(c.events, capturedEvent{name, fields})
+}
+
+// TestHandleClose_SelfExpiringWhenNoRevoke pins the audit-honesty fix
+// reviewer @initializ-mk asked for on #236. Providers like STS and
+// static don't have a Revoke API — the credential remains live at
+// the source until its TTL expires. credential_revoked must be
+// emitted with revoked=false + self_expiring=true so operators can
+// distinguish "actually invalidated" from "tool finished, token
+// still live."
+func TestHandleClose_SelfExpiringWhenNoRevoke(t *testing.T) {
+	sink := &captureSink{}
+	h := &Handle{
+		mat:       Materialization{Env: map[string]string{"K": "v"}}, // Revoke == nil
+		kind:      "static",
+		tool:      "cli_execute",
+		binary:    "env",
+		audit:     sink,
+		revocable: false,
+	}
+	if err := h.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(sink.events))
+	}
+	e := sink.events[0]
+	if e.name != "credential_revoked" {
+		t.Errorf("event: got %q want credential_revoked", e.name)
+	}
+	if e.fields["revoked"] != false {
+		t.Errorf("revoked: got %v want false", e.fields["revoked"])
+	}
+	if e.fields["self_expiring"] != true {
+		t.Errorf("self_expiring: got %v want true", e.fields["self_expiring"])
+	}
+}
+
+// TestHandleClose_HardRevokeWhenProviderRevokes covers the other
+// half: providers with a Revoke callback report revoked=true +
+// self_expiring=false when Revoke succeeds.
+func TestHandleClose_HardRevokeWhenProviderRevokes(t *testing.T) {
+	sink := &captureSink{}
+	var revokeCalled bool
+	h := &Handle{
+		mat: Materialization{
+			Env: map[string]string{"K": "v"},
+			Revoke: func(context.Context) error {
+				revokeCalled = true
+				return nil
+			},
+		},
+		kind:      "vault_dynamic",
+		tool:      "cli_execute",
+		binary:    "psql",
+		audit:     sink,
+		revocable: true,
+	}
+	if err := h.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !revokeCalled {
+		t.Error("Revoke callback was not invoked")
+	}
+	e := sink.events[0]
+	if e.fields["revoked"] != true || e.fields["self_expiring"] != false {
+		t.Errorf("expected revoked=true self_expiring=false, got fields=%v", e.fields)
+	}
+}

--- a/forge-core/credentials/credentials_test.go
+++ b/forge-core/credentials/credentials_test.go
@@ -1,0 +1,102 @@
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type fakeProvider struct {
+	name string
+}
+
+func (f fakeProvider) Name() string { return f.name }
+func (f fakeProvider) NewCredential(_ context.Context, cs CredentialSpec) (Credential, error) {
+	return &fakeCred{kind: f.name, spec: cs}, nil
+}
+
+type fakeCred struct {
+	kind string
+	spec CredentialSpec
+}
+
+func (c *fakeCred) Kind() string { return c.kind }
+func (c *fakeCred) Materialize(_ context.Context, _ string, _ json.RawMessage) (Materialization, error) {
+	return Materialization{Env: map[string]string{"FROM": c.kind}}, nil
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	r.Register(fakeProvider{name: "foo"})
+	if p := r.Get("foo"); p == nil {
+		t.Fatal("Get returned nil for registered provider")
+	}
+	if p := r.Get("missing"); p != nil {
+		t.Errorf("Get returned non-nil for unregistered provider: %+v", p)
+	}
+}
+
+func TestRegistry_DuplicateRegistrationPanics(t *testing.T) {
+	r := NewRegistry()
+	r.Register(fakeProvider{name: "dup"})
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate provider name")
+		}
+	}()
+	r.Register(fakeProvider{name: "dup"})
+}
+
+func TestRegistry_ResolveSpec_UnknownProviderErrors(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.ResolveSpec(context.Background(), CredentialSpec{Provider: "nope"})
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !errors.Is(err, ErrUnknownProvider) {
+		t.Errorf("expected ErrUnknownProvider, got %v", err)
+	}
+}
+
+func TestRegistry_ResolveSpec_HappyPath(t *testing.T) {
+	r := NewRegistry()
+	r.Register(fakeProvider{name: "aws"})
+	cred, err := r.ResolveSpec(context.Background(), CredentialSpec{Provider: "aws"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cred.Kind() != "aws" {
+		t.Errorf("Kind: got %q want aws", cred.Kind())
+	}
+	mat, err := cred.Materialize(context.Background(), "cli_execute", nil)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if mat.Env["FROM"] != "aws" {
+		t.Errorf("Env: got %v", mat.Env)
+	}
+}
+
+func TestCredentialSpec_MatchesTool(t *testing.T) {
+	cases := []struct {
+		name         string
+		spec         CredentialSpec
+		tool, binary string
+		want         bool
+	}{
+		{"unscoped matches everything", CredentialSpec{}, "cli_execute", "aws", true},
+		{"tool match", CredentialSpec{Tool: "cli_execute"}, "cli_execute", "aws", true},
+		{"tool mismatch", CredentialSpec{Tool: "cli_execute"}, "http_request", "", false},
+		{"binary match", CredentialSpec{Tool: "cli_execute", Binary: "aws"}, "cli_execute", "aws", true},
+		{"binary mismatch", CredentialSpec{Tool: "cli_execute", Binary: "aws"}, "cli_execute", "gcloud", false},
+		{"binary ignored on non-cli tool", CredentialSpec{Tool: "http_request", Binary: "aws"}, "http_request", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.spec.MatchesTool(c.tool, c.binary); got != c.want {
+				t.Errorf("got %v want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/forge-core/credentials/injector.go
+++ b/forge-core/credentials/injector.go
@@ -1,0 +1,202 @@
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// AuditSink is the narrow interface Injector uses to emit
+// credential_issued / credential_revoked / credential_failed events.
+// Kept minimal (map-based fields) so the credentials package doesn't
+// depend on the runtime package (avoiding an import cycle —
+// forge-core/runtime/audit.go already imports agentspec which imports
+// this package).
+//
+// Runner startup wires a small adapter that implements this against
+// the real *runtime.AuditLogger.
+type AuditSink interface {
+	Emit(ctx context.Context, event string, fields map[string]any)
+}
+
+// Injector materializes JIT credentials at tool-exec time. Tools that
+// need credentials (currently cli_execute) call Materialize(...) and
+// merge the resulting env into their subprocess env; the returned
+// Handle is used to schedule revocation after the tool completes.
+//
+// Injector is a thin coordinator over a set of Credential instances
+// resolved at startup — the resolution → mint → audit path lives here
+// so individual tools don't each duplicate provider lookup + logging.
+type Injector struct {
+	specs []resolvedSpec
+	audit AuditSink
+}
+
+// resolvedSpec pairs a CredentialSpec (for matching) with the
+// Credential instance the provider handed back at startup.
+type resolvedSpec struct {
+	spec CredentialSpec
+	cred Credential
+}
+
+// NewInjector resolves each CredentialSpec against reg and returns
+// an Injector. Any spec that references an unregistered provider
+// fails startup — runners want a loud config error, not silent
+// omission that would leave a tool running without credentials.
+func NewInjector(ctx context.Context, reg *Registry, specs []CredentialSpec, audit AuditSink) (*Injector, error) {
+	if reg == nil {
+		reg = DefaultRegistry
+	}
+	if audit == nil {
+		audit = discardSink{}
+	}
+	out := make([]resolvedSpec, 0, len(specs))
+	for i, s := range specs {
+		cred, err := reg.ResolveSpec(ctx, s)
+		if err != nil {
+			return nil, fmt.Errorf("credentials[%d] (tool=%q binary=%q provider=%q): %w",
+				i, s.Tool, s.Binary, s.Provider, err)
+		}
+		out = append(out, resolvedSpec{spec: s, cred: cred})
+	}
+	return &Injector{specs: out, audit: audit}, nil
+}
+
+// Empty reports whether the injector has any resolved specs. Tools
+// can use this to short-circuit the materialize call in the common
+// no-JIT-configured case.
+func (i *Injector) Empty() bool { return i == nil || len(i.specs) == 0 }
+
+// Materialize looks up the first spec whose Tool+Binary matches, mints
+// a fresh Credential via Provider, and returns a Handle carrying the
+// Materialization plus a Close func to revoke it. Nil Handle when no
+// spec matched — the caller carries on without JIT env.
+//
+// `args` is the raw JSON the LLM passed the tool; providers can
+// inspect it to further scope down (e.g. read the S3 key path).
+func (i *Injector) Materialize(ctx context.Context, tool, binary string, args json.RawMessage) (*Handle, error) {
+	if i.Empty() {
+		return nil, nil
+	}
+	for _, rs := range i.specs {
+		if !rs.spec.MatchesTool(tool, binary) {
+			continue
+		}
+		start := time.Now()
+		mat, err := rs.cred.Materialize(ctx, tool, args)
+		if err != nil {
+			i.audit.Emit(ctx, "credential_failed", map[string]any{
+				"provider":    rs.cred.Kind(),
+				"tool":        tool,
+				"binary":      binary,
+				"error":       err.Error(),
+				"duration_ms": time.Since(start).Milliseconds(),
+			})
+			return nil, fmt.Errorf("credentials (%s → tool=%s): %w", rs.cred.Kind(), tool, err)
+		}
+		i.audit.Emit(ctx, "credential_issued", map[string]any{
+			"provider":    rs.cred.Kind(),
+			"tool":        tool,
+			"binary":      binary,
+			"ttl":         string(mat.TTL),
+			"env_keys":    sortedKeys(mat.Env),
+			"header_keys": sortedKeys(mat.Headers),
+			"duration_ms": time.Since(start).Milliseconds(),
+		})
+		return &Handle{
+			mat:       mat,
+			kind:      rs.cred.Kind(),
+			tool:      tool,
+			binary:    binary,
+			audit:     i.audit,
+			revocable: mat.Revoke != nil,
+		}, nil
+	}
+	return nil, nil
+}
+
+// Handle is the per-invocation grip on a materialized credential. The
+// caller invokes Close() when the tool has finished so the injector
+// can revoke (if applicable) and emit the credential_revoked audit
+// event.
+type Handle struct {
+	mat       Materialization
+	kind      string
+	tool      string
+	binary    string
+	audit     AuditSink
+	revocable bool
+	closed    bool
+}
+
+// Env returns the env vars to inject into a subprocess. Never returns
+// nil — an empty map is fine to append to a slice.
+func (h *Handle) Env() map[string]string {
+	if h == nil {
+		return nil
+	}
+	return h.mat.Env
+}
+
+// Headers returns the headers to inject on an outbound HTTP call.
+func (h *Handle) Headers() map[string]string {
+	if h == nil {
+		return nil
+	}
+	return h.mat.Headers
+}
+
+// Kind returns the provider name that minted this credential.
+func (h *Handle) Kind() string {
+	if h == nil {
+		return ""
+	}
+	return h.kind
+}
+
+// Close revokes the credential (if the provider supports it) and
+// emits credential_revoked. Idempotent — safe to defer.
+func (h *Handle) Close(ctx context.Context) error {
+	if h == nil || h.closed {
+		return nil
+	}
+	h.closed = true
+	fields := map[string]any{
+		"provider": h.kind,
+		"tool":     h.tool,
+		"binary":   h.binary,
+	}
+	if h.revocable {
+		if err := h.mat.Revoke(ctx); err != nil {
+			fields["error"] = err.Error()
+			h.audit.Emit(ctx, "credential_revoked", fields)
+			return err
+		}
+	}
+	h.audit.Emit(ctx, "credential_revoked", fields)
+	return nil
+}
+
+// sortedKeys returns m's keys sorted — used on audit events so
+// output is grep-friendly across runs (map iteration order is
+// non-deterministic).
+func sortedKeys(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// discardSink is the no-op AuditSink used when the caller doesn't
+// wire one. Useful in unit tests and for the standalone static
+// provider path.
+type discardSink struct{}
+
+func (discardSink) Emit(context.Context, string, map[string]any) {}

--- a/forge-core/credentials/injector.go
+++ b/forge-core/credentials/injector.go
@@ -158,18 +158,35 @@ func (h *Handle) Kind() string {
 
 // Close revokes the credential (if the provider supports it) and
 // emits credential_revoked. Idempotent — safe to defer.
+//
+// The emitted event carries a `revoked` bool distinguishing:
+//   - `revoked: true`  — the provider had a Revoke callback and it
+//     was invoked; the credential is invalidated at the source.
+//   - `revoked: false` — the provider has no Revoke path
+//     (`self_expiring: true`); the credential remains live until
+//     its TTL. Applies to STS + static providers today.
+//
+// Reviewer @initializ-mk asked for this on #236 — pre-fix,
+// credential_revoked was emitted even when nothing was invalidated,
+// so operators couldn't distinguish hard-revoke from tool-finished.
 func (h *Handle) Close(ctx context.Context) error {
 	if h == nil || h.closed {
 		return nil
 	}
 	h.closed = true
 	fields := map[string]any{
-		"provider": h.kind,
-		"tool":     h.tool,
-		"binary":   h.binary,
+		"provider":      h.kind,
+		"tool":          h.tool,
+		"binary":        h.binary,
+		"revoked":       h.revocable,
+		"self_expiring": !h.revocable,
 	}
 	if h.revocable {
 		if err := h.mat.Revoke(ctx); err != nil {
+			// Revoke failed — the credential is still live at the
+			// source. Correct the audit signal accordingly.
+			fields["revoked"] = false
+			fields["self_expiring"] = false
 			fields["error"] = err.Error()
 			h.audit.Emit(ctx, "credential_revoked", fields)
 			return err

--- a/forge-core/credentials/static/static.go
+++ b/forge-core/credentials/static/static.go
@@ -1,0 +1,89 @@
+// Package static is the reference no-op Credential provider for
+// governance R9.
+//
+// It maps a CredentialSpec straight to an env-var map — no expiration,
+// no revocation, no external calls. Two uses:
+//   - Default fallback so skills that don't declare a JIT provider
+//     still get an explicit CredentialSpec-shaped path (audit
+//     visibility, one consistent code path).
+//   - Test fixture — unit tests wire a static provider and inspect
+//     the injected env without pulling in AWS SDKs or mock servers.
+//
+// Not suitable for production least-privilege scoping — for that,
+// use sts_assume_role or a Vault provider.
+package static
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"github.com/initializ/forge/forge-core/credentials"
+)
+
+// ProviderName is the string used in CredentialSpec.Provider.
+const ProviderName = "static"
+
+// Spec is the plugin-specific config decoded from CredentialSpec.Spec.
+// A minimal shape — env vars, optional headers, and an operator-
+// declared TTL for audit purposes only (the values themselves never
+// expire).
+type Spec struct {
+	Env     map[string]string `json:"env,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	TTL     string            `json:"ttl,omitempty"`
+}
+
+// Provider implements credentials.Provider.
+type Provider struct{}
+
+// Name returns the plugin name.
+func (Provider) Name() string { return ProviderName }
+
+// NewCredential decodes spec.Spec into a Spec and returns a Credential
+// closed over it.
+func (Provider) NewCredential(_ context.Context, cs credentials.CredentialSpec) (credentials.Credential, error) {
+	var s Spec
+	if len(cs.Spec) > 0 {
+		if err := json.Unmarshal(cs.Spec, &s); err != nil {
+			return nil, fmt.Errorf("static provider: decoding spec: %w", err)
+		}
+	}
+	return &Credential{spec: s}, nil
+}
+
+// Credential is the materializer returned by Provider.NewCredential.
+type Credential struct {
+	spec Spec
+}
+
+// Kind returns the provider name for audit-event tagging.
+func (Credential) Kind() string { return ProviderName }
+
+// Materialize returns the operator-declared env/headers. No external
+// I/O, no error path.
+func (c *Credential) Materialize(_ context.Context, _ string, _ json.RawMessage) (credentials.Materialization, error) {
+	env := cloneMap(c.spec.Env)
+	headers := cloneMap(c.spec.Headers)
+	return credentials.Materialization{
+		Env:     env,
+		Headers: headers,
+		TTL:     credentials.Duration(c.spec.TTL),
+	}, nil
+}
+
+// cloneMap copies a map so callers can't mutate the provider's config
+// through the returned Materialization.
+func cloneMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	maps.Copy(out, m)
+	return out
+}
+
+func init() {
+	credentials.DefaultRegistry.Register(Provider{})
+}

--- a/forge-core/credentials/static/static_test.go
+++ b/forge-core/credentials/static/static_test.go
@@ -1,0 +1,80 @@
+package static
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/credentials"
+)
+
+func TestStaticProvider_RegisteredAtInit(t *testing.T) {
+	if p := credentials.DefaultRegistry.Get(ProviderName); p == nil {
+		t.Fatal("static provider not registered by init()")
+	}
+}
+
+func TestStaticProvider_MaterializeReturnsSpecEnv(t *testing.T) {
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: json.RawMessage(`{
+			"env": {"AWS_ACCESS_KEY_ID": "AKIAFAKE", "AWS_SECRET_ACCESS_KEY": "abc"},
+			"ttl": "1h"
+		}`),
+	}
+	cred, err := Provider{}.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	mat, err := cred.Materialize(context.Background(), "cli_execute", nil)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if mat.Env["AWS_ACCESS_KEY_ID"] != "AKIAFAKE" {
+		t.Errorf("env not injected: %v", mat.Env)
+	}
+	if mat.TTL != "1h" {
+		t.Errorf("ttl not surfaced: %q", mat.TTL)
+	}
+	if mat.Revoke != nil {
+		t.Errorf("static provider must not set Revoke")
+	}
+}
+
+func TestStaticProvider_ClonesEnvSoCallerCantMutateSpec(t *testing.T) {
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec:     json.RawMessage(`{"env": {"K": "v"}}`),
+	}
+	cred, _ := Provider{}.NewCredential(context.Background(), spec)
+	m1, _ := cred.Materialize(context.Background(), "", nil)
+	m1.Env["K"] = "mutated"
+	m2, _ := cred.Materialize(context.Background(), "", nil)
+	if m2.Env["K"] != "v" {
+		t.Errorf("provider leaked mutation across Materialize calls: got %q", m2.Env["K"])
+	}
+}
+
+func TestStaticProvider_EmptySpec_ReturnsEmptyMaterialization(t *testing.T) {
+	cred, err := Provider{}.NewCredential(context.Background(), credentials.CredentialSpec{Provider: ProviderName})
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	mat, err := cred.Materialize(context.Background(), "", nil)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if len(mat.Env) != 0 || len(mat.Headers) != 0 {
+		t.Errorf("expected empty materialization, got env=%v headers=%v", mat.Env, mat.Headers)
+	}
+}
+
+func TestStaticProvider_InvalidJSONSpecErrors(t *testing.T) {
+	_, err := Provider{}.NewCredential(context.Background(), credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec:     json.RawMessage(`{invalid`),
+	})
+	if err == nil {
+		t.Fatal("expected error on malformed spec")
+	}
+}

--- a/forge-core/credentials/sts/sts.go
+++ b/forge-core/credentials/sts/sts.go
@@ -25,12 +25,14 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/initializ/forge/forge-core/credentials"
@@ -116,10 +118,24 @@ type Credential struct {
 	duration   time.Duration
 	httpClient *http.Client
 	now        func() time.Time
+
+	// cacheMu guards the fields below. Materialize is called from
+	// multiple goroutines (one per tool invocation on a shared
+	// injector) so cache access must be serialized.
+	cacheMu     sync.Mutex
+	cached      credentials.Materialization
+	cachedUntil time.Time // wall-clock instant after which the cache is stale
 }
 
+// cacheSkew is the safety margin subtracted from the STS-issued
+// expiration when deciding whether the cached credential is still
+// safe to hand out. Reviewer @initializ-mk asked for caching
+// within TTL; giving up 60s at the tail keeps the tool call from
+// racing against expiration on a slow subprocess.
+const cacheSkew = 60 * time.Second
+
 // Kind returns the provider name for audit-event tagging.
-func (Credential) Kind() string { return ProviderName }
+func (*Credential) Kind() string { return ProviderName }
 
 // stsResponse is the subset of the AssumeRole XML response we care
 // about. STS returns:
@@ -155,10 +171,33 @@ type stsError struct {
 	} `xml:"Error"`
 }
 
-// Materialize issues one STS AssumeRole and returns the short-lived
-// credentials as AWS_* env vars. No revocation callback — STS creds
-// self-expire at the Duration; the runner records TTL for audit.
+// Materialize returns short-lived AWS credentials as env vars.
+//
+// Caches per-Credential: since Provider ignores per-call `args` (no
+// scope-down based on tool input), every call for a given spec yields
+// an equivalent credential, so serving the same materialization until
+// TTL-minus-skew expiration is safe and strictly better than re-issuing
+// on every tool call. Reviewer @initializ-mk asked for this — pre-fix,
+// an agent that ran `aws` N times made N AssumeRole calls, adding
+// latency per exec and risking account-level STS throttling.
+//
+// The cache is per-Credential (per-spec) and read under a mutex so
+// concurrent tool invocations from the same skill share.
+//
+// No revocation callback — STS creds expire on their own; the runner
+// records TTL for audit.
 func (c *Credential) Materialize(ctx context.Context, _ string, _ json.RawMessage) (credentials.Materialization, error) {
+	// Fast path: reuse a cached materialization when it's still safely
+	// within TTL.
+	c.cacheMu.Lock()
+	if !c.cachedUntil.IsZero() && c.nowFn().Before(c.cachedUntil) {
+		mat := c.cached
+		c.cacheMu.Unlock()
+		return cloneMaterialization(mat), nil
+	}
+	c.cacheMu.Unlock()
+
+	// Slow path: mint a fresh credential.
 	accessKey := os.Getenv(c.spec.SourceAccessKey)
 	secretKey := os.Getenv(c.spec.SourceSecretKey)
 	sessionToken := os.Getenv(c.spec.SourceToken) // optional (present when running under a role)
@@ -234,7 +273,7 @@ func (c *Credential) Materialize(ctx context.Context, _ string, _ json.RawMessag
 		return credentials.Materialization{}, fmt.Errorf("sts provider: empty credentials in response")
 	}
 
-	return credentials.Materialization{
+	mat := credentials.Materialization{
 		Env: map[string]string{
 			"AWS_ACCESS_KEY_ID":     creds.AccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": creds.SecretAccessKey,
@@ -244,15 +283,60 @@ func (c *Credential) Materialize(ctx context.Context, _ string, _ json.RawMessag
 		// Revoke is nil — STS credentials expire on their own; there
 		// is no API to invalidate them early. Operators wanting hard
 		// revoke should switch to a Vault dynamic-secret provider.
-	}, nil
+	}
+
+	// Populate the cache. Prefer the STS-issued Expiration when
+	// parseable; fall back to now + duration. Either way subtract
+	// cacheSkew so we hand out a stale credential.
+	expireAt := c.nowFn().Add(c.duration)
+	if creds.Expiration != "" {
+		if t, err := time.Parse(time.RFC3339, creds.Expiration); err == nil {
+			expireAt = t
+		}
+	}
+	c.cacheMu.Lock()
+	c.cached = mat
+	c.cachedUntil = expireAt.Add(-cacheSkew)
+	c.cacheMu.Unlock()
+
+	return cloneMaterialization(mat), nil
+}
+
+// nowFn returns the injected clock or time.Now, so tests can advance
+// the clock without touching the wall.
+func (c *Credential) nowFn() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// cloneMaterialization deep-copies the env map so a caller can't
+// mutate the cached entry via the returned Materialization.
+func cloneMaterialization(m credentials.Materialization) credentials.Materialization {
+	out := m
+	if len(m.Env) > 0 {
+		out.Env = make(map[string]string, len(m.Env))
+		maps.Copy(out.Env, m.Env)
+	}
+	if len(m.Headers) > 0 {
+		out.Headers = make(map[string]string, len(m.Headers))
+		maps.Copy(out.Headers, m.Headers)
+	}
+	return out
 }
 
 // truncate cuts s to at most n runes with an ellipsis suffix.
+// Slices on runes, not bytes — a byte slice at an arbitrary offset
+// can split a multi-byte UTF-8 sequence and produce invalid UTF-8,
+// which then goes into an error message. Reviewer @initializ-mk
+// flagged this on #236.
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	return s[:n] + "…"
+	return string(runes[:n]) + "…"
 }
 
 // ---- SigV4 signer (STS-only, stripped from providers/sigv4_transport.go) ----

--- a/forge-core/credentials/sts/sts.go
+++ b/forge-core/credentials/sts/sts.go
@@ -1,0 +1,388 @@
+// Package sts is the AWS STS AssumeRole reference provider for
+// governance R9 (JIT credential dispensing).
+//
+// One provider instance can serve many CredentialSpecs. Each spec
+// resolves to a Credential closed over the target role ARN, session
+// name, duration, and optional external-id / session policy. Every
+// Materialize call issues a fresh STS AssumeRole → returns
+// short-lived AWS_* env vars in the Materialization → the runner
+// injects them into the tool's subprocess env.
+//
+// SDK-free: STS AssumeRole is a single Query-API POST signed with
+// SigV4. The signer here is a stripped-down copy of the Bedrock
+// signer in forge-core/llm/providers/sigv4_transport.go — Forge's
+// intentional pattern is to hand-roll narrow AWS calls rather than
+// pull the full aws-sdk-go-v2 (~5 MB binary blow-up) for one
+// endpoint. See docs/security/least-privilege-credentials.md.
+package sts
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/initializ/forge/forge-core/credentials"
+)
+
+// ProviderName is the string used in CredentialSpec.Provider.
+const ProviderName = "sts_assume_role"
+
+// Spec is decoded from CredentialSpec.Spec.
+type Spec struct {
+	RoleARN         string `json:"role_arn"`
+	SessionName     string `json:"session_name,omitempty"`
+	ExternalID      string `json:"external_id,omitempty"`
+	Duration        string `json:"duration,omitempty"`          // e.g. "15m", "1h"; default 15m
+	SessionPolicy   string `json:"session_policy,omitempty"`    // inline JSON, sent as Policy=
+	Region          string `json:"region,omitempty"`            // default us-east-1
+	Endpoint        string `json:"endpoint,omitempty"`          // override for tests
+	SourceAccessKey string `json:"source_access_key,omitempty"` // env var name; default AWS_ACCESS_KEY_ID
+	SourceSecretKey string `json:"source_secret_key,omitempty"` // env var name; default AWS_SECRET_ACCESS_KEY
+	SourceToken     string `json:"source_token,omitempty"`      // env var name; default AWS_SESSION_TOKEN
+}
+
+// Provider implements credentials.Provider.
+type Provider struct {
+	// HTTPClient is exposed for tests to point at an httptest.Server.
+	// Zero value → http.DefaultClient.
+	HTTPClient *http.Client
+	// Now overrides the clock for deterministic signature tests.
+	Now func() time.Time
+}
+
+// Name returns the plugin name.
+func (Provider) Name() string { return ProviderName }
+
+// NewCredential validates spec and returns a Credential that will
+// mint fresh STS creds on every Materialize call.
+func (p Provider) NewCredential(_ context.Context, cs credentials.CredentialSpec) (credentials.Credential, error) {
+	var s Spec
+	if len(cs.Spec) > 0 {
+		if err := json.Unmarshal(cs.Spec, &s); err != nil {
+			return nil, fmt.Errorf("sts provider: decoding spec: %w", err)
+		}
+	}
+	if s.RoleARN == "" {
+		return nil, fmt.Errorf("sts provider: role_arn is required")
+	}
+	if s.Duration == "" {
+		s.Duration = "15m"
+	}
+	if s.Region == "" {
+		s.Region = "us-east-1"
+	}
+	if s.SessionName == "" {
+		s.SessionName = "forge-jit"
+	}
+	if s.SourceAccessKey == "" {
+		s.SourceAccessKey = "AWS_ACCESS_KEY_ID"
+	}
+	if s.SourceSecretKey == "" {
+		s.SourceSecretKey = "AWS_SECRET_ACCESS_KEY"
+	}
+	if s.SourceToken == "" {
+		s.SourceToken = "AWS_SESSION_TOKEN"
+	}
+	dur, err := time.ParseDuration(s.Duration)
+	if err != nil {
+		return nil, fmt.Errorf("sts provider: parsing duration %q: %w", s.Duration, err)
+	}
+	if dur < 900*time.Second || dur > 12*time.Hour {
+		return nil, fmt.Errorf("sts provider: duration %s outside AWS bounds [15m, 12h]", dur)
+	}
+	return &Credential{
+		spec:       s,
+		duration:   dur,
+		httpClient: p.HTTPClient,
+		now:        p.Now,
+	}, nil
+}
+
+// Credential is the materializer returned by Provider.NewCredential.
+type Credential struct {
+	spec       Spec
+	duration   time.Duration
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+// Kind returns the provider name for audit-event tagging.
+func (Credential) Kind() string { return ProviderName }
+
+// stsResponse is the subset of the AssumeRole XML response we care
+// about. STS returns:
+//
+//	<AssumeRoleResponse>
+//	  <AssumeRoleResult>
+//	    <Credentials>
+//	      <AccessKeyId>...</AccessKeyId>
+//	      <SecretAccessKey>...</SecretAccessKey>
+//	      <SessionToken>...</SessionToken>
+//	      <Expiration>2026-07-02T15:00:00Z</Expiration>
+//	    </Credentials>
+//	  </AssumeRoleResult>
+//	</AssumeRoleResponse>
+type stsResponse struct {
+	XMLName xml.Name `xml:"AssumeRoleResponse"`
+	Result  struct {
+		Credentials struct {
+			AccessKeyID     string `xml:"AccessKeyId"`
+			SecretAccessKey string `xml:"SecretAccessKey"`
+			SessionToken    string `xml:"SessionToken"`
+			Expiration      string `xml:"Expiration"`
+		} `xml:"Credentials"`
+	} `xml:"AssumeRoleResult"`
+}
+
+// stsError is STS's Query-API error shape.
+type stsError struct {
+	XMLName xml.Name `xml:"ErrorResponse"`
+	Error   struct {
+		Code    string `xml:"Code"`
+		Message string `xml:"Message"`
+	} `xml:"Error"`
+}
+
+// Materialize issues one STS AssumeRole and returns the short-lived
+// credentials as AWS_* env vars. No revocation callback — STS creds
+// self-expire at the Duration; the runner records TTL for audit.
+func (c *Credential) Materialize(ctx context.Context, _ string, _ json.RawMessage) (credentials.Materialization, error) {
+	accessKey := os.Getenv(c.spec.SourceAccessKey)
+	secretKey := os.Getenv(c.spec.SourceSecretKey)
+	sessionToken := os.Getenv(c.spec.SourceToken) // optional (present when running under a role)
+	if accessKey == "" || secretKey == "" {
+		return credentials.Materialization{}, fmt.Errorf(
+			"sts provider: source creds missing (%s / %s unset)",
+			c.spec.SourceAccessKey, c.spec.SourceSecretKey)
+	}
+
+	form := url.Values{}
+	form.Set("Action", "AssumeRole")
+	form.Set("Version", "2011-06-15")
+	form.Set("RoleArn", c.spec.RoleARN)
+	form.Set("RoleSessionName", c.spec.SessionName)
+	form.Set("DurationSeconds", strconv.Itoa(int(c.duration.Seconds())))
+	if c.spec.ExternalID != "" {
+		form.Set("ExternalId", c.spec.ExternalID)
+	}
+	if c.spec.SessionPolicy != "" {
+		form.Set("Policy", c.spec.SessionPolicy)
+	}
+	body := form.Encode()
+
+	endpoint := c.spec.Endpoint
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://sts.%s.amazonaws.com/", c.spec.Region)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return credentials.Materialization{}, fmt.Errorf("sts provider: building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	c.signSigV4(req, []byte(body), sigV4Creds{
+		AccessKeyID:     accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:    sessionToken,
+	})
+
+	client := c.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return credentials.Materialization{}, fmt.Errorf("sts provider: POST: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return credentials.Materialization{}, fmt.Errorf("sts provider: reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		var e stsError
+		_ = xml.Unmarshal(respBody, &e)
+		if e.Error.Code != "" {
+			return credentials.Materialization{}, fmt.Errorf(
+				"sts provider: AssumeRole failed (%d %s): %s",
+				resp.StatusCode, e.Error.Code, e.Error.Message)
+		}
+		return credentials.Materialization{}, fmt.Errorf(
+			"sts provider: AssumeRole failed (%d): %s",
+			resp.StatusCode, truncate(string(respBody), 200))
+	}
+
+	var out stsResponse
+	if err := xml.Unmarshal(respBody, &out); err != nil {
+		return credentials.Materialization{}, fmt.Errorf("sts provider: parsing response: %w", err)
+	}
+	creds := out.Result.Credentials
+	if creds.AccessKeyID == "" || creds.SecretAccessKey == "" || creds.SessionToken == "" {
+		return credentials.Materialization{}, fmt.Errorf("sts provider: empty credentials in response")
+	}
+
+	return credentials.Materialization{
+		Env: map[string]string{
+			"AWS_ACCESS_KEY_ID":     creds.AccessKeyID,
+			"AWS_SECRET_ACCESS_KEY": creds.SecretAccessKey,
+			"AWS_SESSION_TOKEN":     creds.SessionToken,
+		},
+		TTL: credentials.Duration(c.duration.String()),
+		// Revoke is nil — STS credentials expire on their own; there
+		// is no API to invalidate them early. Operators wanting hard
+		// revoke should switch to a Vault dynamic-secret provider.
+	}, nil
+}
+
+// truncate cuts s to at most n runes with an ellipsis suffix.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// ---- SigV4 signer (STS-only, stripped from providers/sigv4_transport.go) ----
+
+type sigV4Creds struct {
+	AccessKeyID, SecretAccessKey, SessionToken string
+}
+
+// signSigV4 stamps Authorization + X-Amz-Date (+ X-Amz-Security-Token)
+// headers on req. Body has already been read into payload. Service is
+// hardcoded to "sts" since that's the only endpoint this package hits.
+func (c *Credential) signSigV4(req *http.Request, payload []byte, creds sigV4Creds) {
+	now := time.Now().UTC()
+	if c.now != nil {
+		now = c.now().UTC()
+	}
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+
+	payloadHash := sha256Hex(payload)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	canonicalHeaders, signedHeaders := canonicalHeaderSet(req.Header, host)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI(req.URL.Path),
+		"", // STS AssumeRole uses form-encoded body; no query string
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/sts/aws4_request", dateStamp, c.spec.Region)
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := deriveSigningKey(creds.SecretAccessKey, dateStamp, c.spec.Region, "sts")
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	auth := fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		creds.AccessKeyID, credentialScope, signedHeaders, signature,
+	)
+	req.Header.Set("Authorization", auth)
+}
+
+func canonicalHeaderSet(h http.Header, host string) (string, string) {
+	pairs := make(map[string]string, len(h)+1)
+	pairs["host"] = host
+	for k, vals := range h {
+		lower := strings.ToLower(k)
+		if lower == "authorization" {
+			continue
+		}
+		pairs[lower] = collapseHeaderValue(strings.Join(vals, ","))
+	}
+	names := make([]string, 0, len(pairs))
+	for n := range pairs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var sb strings.Builder
+	for _, n := range names {
+		sb.WriteString(n)
+		sb.WriteByte(':')
+		sb.WriteString(pairs[n])
+		sb.WriteByte('\n')
+	}
+	return sb.String(), strings.Join(names, ";")
+}
+
+func canonicalURI(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func collapseHeaderValue(v string) string {
+	v = strings.TrimSpace(v)
+	var sb strings.Builder
+	prevSpace := false
+	for i := range len(v) {
+		ch := v[i]
+		if ch == ' ' || ch == '\t' {
+			if !prevSpace {
+				sb.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		sb.WriteByte(ch)
+		prevSpace = false
+	}
+	return sb.String()
+}
+
+func deriveSigningKey(secret, date, region, service string) []byte {
+	k := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	k = hmacSHA256(k, []byte(region))
+	k = hmacSHA256(k, []byte(service))
+	k = hmacSHA256(k, []byte("aws4_request"))
+	return k
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(data)
+	return m.Sum(nil)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func init() {
+	credentials.DefaultRegistry.Register(Provider{})
+}

--- a/forge-core/credentials/sts/sts_test.go
+++ b/forge-core/credentials/sts/sts_test.go
@@ -1,0 +1,264 @@
+package sts
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/credentials"
+)
+
+// mockSTS returns a test server that impersonates STS AssumeRole.
+// Captures the request headers + body for assertions.
+type mockSTS struct {
+	srv          *httptest.Server
+	lastAuth     string
+	lastDate     string
+	lastToken    string
+	lastBody     string
+	responseBody string
+	responseCode int
+}
+
+func newMockSTS() *mockSTS {
+	m := &mockSTS{
+		responseCode: 200,
+		responseBody: `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAMOCKEXAMPLE</AccessKeyId>
+      <SecretAccessKey>mockSecretAccessKeyMockSecretAccessKey0</SecretAccessKey>
+      <SessionToken>mockSessionTokenMockSessionToken==</SessionToken>
+      <Expiration>2026-07-02T15:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`,
+	}
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.lastAuth = r.Header.Get("Authorization")
+		m.lastDate = r.Header.Get("X-Amz-Date")
+		m.lastToken = r.Header.Get("X-Amz-Security-Token")
+		b, _ := io.ReadAll(r.Body)
+		m.lastBody = string(b)
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(m.responseCode)
+		_, _ = w.Write([]byte(m.responseBody))
+	}))
+	return m
+}
+
+// setSTSEnv sets AWS_* source-creds env for the test.
+func setSTSEnv(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIASOURCE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "sourceSecretKey")
+	t.Setenv("AWS_SESSION_TOKEN", "sourceSessionToken")
+}
+
+func TestSTSProvider_RegisteredAtInit(t *testing.T) {
+	if p := credentials.DefaultRegistry.Get(ProviderName); p == nil {
+		t.Fatal("sts_assume_role not registered")
+	}
+}
+
+func TestSTSProvider_MaterializeHappyPath(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	defer m.srv.Close()
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: mustJSON(t, Spec{
+			RoleARN:     "arn:aws:iam::123456789012:role/skill-read",
+			SessionName: "skill-alpha",
+			ExternalID:  "ext-42",
+			Duration:    "15m",
+			Endpoint:    m.srv.URL + "/",
+		}),
+	}
+	p := Provider{HTTPClient: m.srv.Client()}
+	cred, err := p.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	mat, err := cred.Materialize(context.Background(), "cli_execute", nil)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if mat.Env["AWS_ACCESS_KEY_ID"] != "ASIAMOCKEXAMPLE" {
+		t.Errorf("access key not surfaced: %v", mat.Env)
+	}
+	if mat.Env["AWS_SECRET_ACCESS_KEY"] == "" || mat.Env["AWS_SESSION_TOKEN"] == "" {
+		t.Errorf("missing secret/token: %v", mat.Env)
+	}
+	if mat.TTL == "" {
+		t.Error("TTL should be set")
+	}
+}
+
+func TestSTSProvider_RequestFormAndSignature(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	defer m.srv.Close()
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: mustJSON(t, Spec{
+			RoleARN:     "arn:aws:iam::123456789012:role/skill-read",
+			SessionName: "skill-alpha",
+			ExternalID:  "ext-42",
+			Duration:    "30m",
+			Endpoint:    m.srv.URL + "/",
+		}),
+	}
+	p := Provider{HTTPClient: m.srv.Client()}
+	cred, err := p.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	if _, err := cred.Materialize(context.Background(), "", nil); err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if !strings.Contains(m.lastBody, "Action=AssumeRole") {
+		t.Errorf("body missing Action: %s", m.lastBody)
+	}
+	if !strings.Contains(m.lastBody, "RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fskill-read") {
+		t.Errorf("body missing RoleArn: %s", m.lastBody)
+	}
+	if !strings.Contains(m.lastBody, "ExternalId=ext-42") {
+		t.Errorf("body missing ExternalId: %s", m.lastBody)
+	}
+	if !strings.Contains(m.lastBody, "DurationSeconds=1800") {
+		t.Errorf("body missing DurationSeconds=1800: %s", m.lastBody)
+	}
+	if !strings.HasPrefix(m.lastAuth, "AWS4-HMAC-SHA256 Credential=AKIASOURCE/") {
+		t.Errorf("Authorization malformed: %q", m.lastAuth)
+	}
+	if !strings.Contains(m.lastAuth, "/sts/aws4_request") {
+		t.Errorf("Authorization missing service scope: %q", m.lastAuth)
+	}
+	if m.lastToken != "sourceSessionToken" {
+		t.Errorf("session token not forwarded: %q", m.lastToken)
+	}
+	if m.lastDate == "" {
+		t.Error("X-Amz-Date missing")
+	}
+}
+
+func TestSTSProvider_STSErrorSurfaces(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	m.responseCode = 403
+	m.responseBody = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error>
+    <Code>AccessDenied</Code>
+    <Message>User is not authorized to perform: sts:AssumeRole</Message>
+  </Error>
+</ErrorResponse>`
+	defer m.srv.Close()
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: mustJSON(t, Spec{
+			RoleARN:  "arn:aws:iam::123:role/x",
+			Endpoint: m.srv.URL + "/",
+		}),
+	}
+	p := Provider{HTTPClient: m.srv.Client()}
+	cred, _ := p.NewCredential(context.Background(), spec)
+	_, err := cred.Materialize(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected error on STS 403")
+	}
+	if !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("error should mention STS error code: %v", err)
+	}
+}
+
+func TestSTSProvider_MissingRoleARNRejectedAtConfig(t *testing.T) {
+	p := Provider{}
+	_, err := p.NewCredential(context.Background(), credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec:     mustJSON(t, Spec{Duration: "15m"}),
+	})
+	if err == nil {
+		t.Fatal("expected error when role_arn is missing")
+	}
+}
+
+func TestSTSProvider_DurationValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		dur     string
+		wantErr bool
+	}{
+		{"exactly 15m OK", "15m", false},
+		{"1h OK", "1h", false},
+		{"12h OK", "12h", false},
+		{"below 15m rejected", "5m", true},
+		{"above 12h rejected", "13h", true},
+		{"garbage rejected", "not-a-duration", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Provider{}.NewCredential(context.Background(), credentials.CredentialSpec{
+				Provider: ProviderName,
+				Spec:     mustJSON(t, Spec{RoleARN: "arn:aws:iam::1:role/x", Duration: c.dur}),
+			})
+			if (err != nil) != c.wantErr {
+				t.Errorf("dur=%s err=%v wantErr=%v", c.dur, err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestSTSProvider_MissingSourceCredsErrors(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec:     mustJSON(t, Spec{RoleARN: "arn:aws:iam::1:role/x"}),
+	}
+	cred, err := Provider{}.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	_, err = cred.Materialize(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected error when source creds unset")
+	}
+	if !strings.Contains(err.Error(), "source creds missing") {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestSTSProvider_EmptyResponseCreds(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	m.responseBody = `<AssumeRoleResponse><AssumeRoleResult><Credentials></Credentials></AssumeRoleResult></AssumeRoleResponse>`
+	defer m.srv.Close()
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec:     mustJSON(t, Spec{RoleARN: "arn:aws:iam::1:role/x", Endpoint: m.srv.URL + "/"}),
+	}
+	p := Provider{HTTPClient: m.srv.Client()}
+	cred, _ := p.NewCredential(context.Background(), spec)
+	_, err := cred.Materialize(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected error on empty creds response")
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/forge-core/credentials/sts/sts_test.go
+++ b/forge-core/credentials/sts/sts_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/initializ/forge/forge-core/credentials"
 )
@@ -22,6 +23,7 @@ type mockSTS struct {
 	lastBody     string
 	responseBody string
 	responseCode int
+	callCount    int // number of AssumeRole POSTs received
 }
 
 func newMockSTS() *mockSTS {
@@ -33,12 +35,13 @@ func newMockSTS() *mockSTS {
       <AccessKeyId>ASIAMOCKEXAMPLE</AccessKeyId>
       <SecretAccessKey>mockSecretAccessKeyMockSecretAccessKey0</SecretAccessKey>
       <SessionToken>mockSessionTokenMockSessionToken==</SessionToken>
-      <Expiration>2026-07-02T15:00:00Z</Expiration>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
     </Credentials>
   </AssumeRoleResult>
 </AssumeRoleResponse>`,
 	}
 	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.callCount++
 		m.lastAuth = r.Header.Get("Authorization")
 		m.lastDate = r.Header.Get("X-Amz-Date")
 		m.lastToken = r.Header.Get("X-Amz-Security-Token")
@@ -252,6 +255,113 @@ func TestSTSProvider_EmptyResponseCreds(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on empty creds response")
 	}
+}
+
+// TestSTSProvider_MaterializeCachesWithinTTL is the regression test
+// for reviewer @initializ-mk's #236 fix #2: repeated Materialize calls
+// within the STS credential's TTL must return the cached credential
+// rather than issuing a fresh AssumeRole. Pre-fix, an agent running
+// `aws` N times made N STS calls, adding latency and throttle risk.
+func TestSTSProvider_MaterializeCachesWithinTTL(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	defer m.srv.Close()
+
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: mustJSON(t, Spec{
+			RoleARN:  "arn:aws:iam::1:role/x",
+			Duration: "15m",
+			Endpoint: m.srv.URL + "/",
+		}),
+	}
+	p := Provider{HTTPClient: m.srv.Client()}
+	cred, err := p.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+
+	// Materialize five times.
+	var lastKey string
+	for i := range 5 {
+		mat, err := cred.Materialize(context.Background(), "cli_execute", nil)
+		if err != nil {
+			t.Fatalf("Materialize %d: %v", i, err)
+		}
+		if mat.Env["AWS_ACCESS_KEY_ID"] == "" {
+			t.Fatalf("Materialize %d: missing key", i)
+		}
+		lastKey = mat.Env["AWS_ACCESS_KEY_ID"]
+	}
+	if lastKey != "ASIAMOCKEXAMPLE" {
+		t.Errorf("materialized access key: got %q", lastKey)
+	}
+
+	// mock STS should have been hit ONCE — subsequent calls served
+	// from cache. Assertion covered by mockSTS.callCount below.
+	if m.callCount != 1 {
+		t.Errorf("STS AssumeRole call count: got %d, want 1 (5 Materialize → 1 cold + 4 cached)", m.callCount)
+	}
+}
+
+// TestSTSProvider_ExpiredCacheReMints proves the cache respects
+// expiration — pushing the clock past expiration triggers a re-mint.
+func TestSTSProvider_ExpiredCacheReMints(t *testing.T) {
+	setSTSEnv(t)
+	m := newMockSTS()
+	defer m.srv.Close()
+
+	// Emit an STS response with a fake Expiration in the near future.
+	m.responseBody = `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAMOCKEXAMPLE</AccessKeyId>
+      <SecretAccessKey>mockSecretKey</SecretAccessKey>
+      <SessionToken>mockToken</SessionToken>
+      <Expiration>2026-07-06T12:15:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`
+
+	// Simulate a clock — start before expiration, advance past it.
+	fakeClock := mustTime("2026-07-06T12:00:00Z")
+	p := Provider{
+		HTTPClient: m.srv.Client(),
+		Now:        func() time.Time { return fakeClock },
+	}
+	spec := credentials.CredentialSpec{
+		Provider: ProviderName,
+		Spec: mustJSON(t, Spec{
+			RoleARN:  "arn:aws:iam::1:role/x",
+			Duration: "15m",
+			Endpoint: m.srv.URL + "/",
+		}),
+	}
+	cred, err := p.NewCredential(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("NewCredential: %v", err)
+	}
+	// Cold call.
+	if _, err := cred.Materialize(context.Background(), "", nil); err != nil {
+		t.Fatalf("cold: %v", err)
+	}
+	// Advance past cached expiration (12:15 - 60s skew = 12:14) →
+	// cache stale, must re-mint.
+	fakeClock = mustTime("2026-07-06T12:14:30Z")
+	if _, err := cred.Materialize(context.Background(), "", nil); err != nil {
+		t.Fatalf("re-mint: %v", err)
+	}
+	if m.callCount != 2 {
+		t.Errorf("STS AssumeRole call count: got %d, want 2 (cold + re-mint after expiry)", m.callCount)
+	}
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 func mustJSON(t *testing.T, v any) json.RawMessage {

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -65,6 +65,15 @@ const (
 	// the cancellation point. See issue #87 / FWS-3.
 	AuditLLMCallCancelled = "llm_call_cancelled"
 
+	// Credential events (governance R9). Emitted per BeforeToolExec
+	// when a JIT credential is materialized for a tool call, and again
+	// on AfterToolExec when a revocable credential is revoked. Fields:
+	// provider (plugin name), tool, ttl, scope. Payloads never carry
+	// the credential material itself — only its metadata.
+	AuditCredentialIssued  = "credential_issued"
+	AuditCredentialRevoked = "credential_revoked"
+	AuditCredentialFailed  = "credential_failed"
+
 	// AuditPolicyLoaded is emitted once at agent startup when a
 	// non-zero platform policy is present. Carries a summary of the
 	// effective policy (sizes of deny lists, max bounds) so audit

--- a/forge-core/tools/builtins/http_request.go
+++ b/forge-core/tools/builtins/http_request.go
@@ -10,11 +10,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-core/credentials"
 	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/tools"
 )
 
-type httpRequestTool struct{}
+type httpRequestTool struct {
+	// credInjector, when non-nil, mints JIT credentials per Execute
+	// call and merges the resulting headers into the outbound HTTP
+	// request. Governance R9 — the HTTP/API half of least-privilege
+	// scoping (the subprocess env half lives in cli_execute). Nil
+	// injector → no-op, preserving pre-R9 behavior.
+	credInjector *credentials.Injector
+}
+
+// WithCredentialInjector attaches an R9 JIT-credential injector.
+// Called by the runner at startup after resolving
+// ForgeConfig.Credentials. nil-safe: passing nil is equivalent to
+// not calling this.
+func (t *httpRequestTool) WithCredentialInjector(inj *credentials.Injector) *httpRequestTool {
+	t.credInjector = inj
+	return t
+}
 
 type httpRequestInput struct {
 	Method  string            `json:"method"`
@@ -65,6 +82,25 @@ func (t *httpRequestTool) Execute(ctx context.Context, args json.RawMessage) (st
 
 	for k, v := range input.Headers {
 		req.Header.Set(k, v)
+	}
+
+	// R9 JIT credentials: if the runner wired a credentials.Injector,
+	// mint fresh scoped-down creds now, merge them into request
+	// headers, and defer revocation. Nil injector → no-op.
+	// JIT headers OVERRIDE any same-named header the LLM specified
+	// via input.Headers — the operator's declared credential spec
+	// takes precedence over an LLM-authored Authorization header.
+	if t.credInjector != nil {
+		handle, err := t.credInjector.Materialize(ctx, "http_request", "", args)
+		if err != nil {
+			return "", fmt.Errorf("http_request: minting JIT credentials: %w", err)
+		}
+		if handle != nil {
+			defer func() { _ = handle.Close(ctx) }()
+			for k, v := range handle.Headers() {
+				req.Header.Set(k, v)
+			}
+		}
 	}
 
 	client := &http.Client{

--- a/forge-core/tools/builtins/http_request_creds_test.go
+++ b/forge-core/tools/builtins/http_request_creds_test.go
@@ -1,0 +1,200 @@
+package builtins
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/credentials"
+	_ "github.com/initializ/forge/forge-core/credentials/static" // register the static provider
+)
+
+// captureSink records emitted audit events so tests can assert on
+// them without wiring the full AuditLogger machinery.
+type captureSink struct {
+	mu     sync.Mutex
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	name   string
+	fields map[string]any
+}
+
+func (c *captureSink) Emit(_ context.Context, name string, fields map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, capturedEvent{name, fields})
+}
+
+// TestHTTPRequest_JITHeadersInjected is the acceptance test for the
+// R9 HTTP/API path (@initializ-mk's #236 fix #3): a spec routed to
+// http_request materializes headers and stamps them on the outbound
+// request. Verifies Headers() surface is no longer dead code.
+func TestHTTPRequest_JITHeadersInjected(t *testing.T) {
+	// Server captures the headers it received.
+	var gotAuth, gotXForge string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotXForge = r.Header.Get("X-Forge-Test")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	sink := &captureSink{}
+	inj, err := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "http_request",
+			Provider: "static",
+			Spec: json.RawMessage(`{
+				"headers": {
+					"Authorization": "Bearer jit-token-abc",
+					"X-Forge-Test": "yes"
+				},
+				"ttl": "5m"
+			}`),
+		}},
+		sink,
+	)
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+
+	tool := (&httpRequestTool{}).WithCredentialInjector(inj)
+	args, _ := json.Marshal(httpRequestInput{
+		Method: "GET",
+		URL:    srv.URL + "/api",
+	})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotAuth != "Bearer jit-token-abc" {
+		t.Errorf("Authorization: got %q want Bearer jit-token-abc", gotAuth)
+	}
+	if gotXForge != "yes" {
+		t.Errorf("X-Forge-Test: got %q want yes", gotXForge)
+	}
+
+	// Audit events fired: issued + revoked.
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.events) < 2 {
+		t.Fatalf("expected 2+ events, got %d", len(sink.events))
+	}
+	if sink.events[0].name != "credential_issued" {
+		t.Errorf("first event: got %q want credential_issued", sink.events[0].name)
+	}
+	if sink.events[len(sink.events)-1].name != "credential_revoked" {
+		t.Errorf("last event: got %q want credential_revoked", sink.events[len(sink.events)-1].name)
+	}
+}
+
+// TestHTTPRequest_JITHeadersOverrideLLMHeaders proves the security
+// property: an LLM-authored Authorization header is overridden by
+// the JIT-provided one. Same shape as the env-override test on
+// cli_execute — an LLM must not be able to bypass the operator's
+// credential scoping by inlining a competing header.
+func TestHTTPRequest_JITHeadersOverrideLLMHeaders(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	inj, _ := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "http_request",
+			Provider: "static",
+			Spec:     json.RawMessage(`{"headers": {"Authorization": "Bearer jit-wins"}}`),
+		}},
+		nil,
+	)
+
+	tool := (&httpRequestTool{}).WithCredentialInjector(inj)
+	args, _ := json.Marshal(httpRequestInput{
+		Method:  "GET",
+		URL:     srv.URL + "/api",
+		Headers: map[string]string{"Authorization": "Bearer llm-attempt"},
+	})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotAuth != "Bearer jit-wins" {
+		t.Errorf("JIT header must override LLM header: got %q", gotAuth)
+	}
+}
+
+// TestHTTPRequest_NoInjectorNoop guards backward compatibility.
+func TestHTTPRequest_NoInjectorNoop(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	tool := &httpRequestTool{} // no injector
+	args, _ := json.Marshal(httpRequestInput{
+		Method:  "GET",
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer llm-supplied"},
+	})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Without an injector, the LLM-supplied header stays.
+	if gotAuth != "Bearer llm-supplied" {
+		t.Errorf("no-injector path corrupted headers: got %q", gotAuth)
+	}
+}
+
+// TestHTTPRequest_InjectorSkipsNonMatchingTool verifies tool scoping.
+// A spec targeting cli_execute must not fire for http_request.
+func TestHTTPRequest_InjectorSkipsNonMatchingTool(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	sink := &captureSink{}
+	inj, _ := credentials.NewInjector(
+		context.Background(),
+		credentials.DefaultRegistry,
+		[]credentials.CredentialSpec{{
+			Tool:     "cli_execute", // NOT http_request
+			Provider: "static",
+			Spec:     json.RawMessage(`{"headers": {"Authorization": "must-not-appear"}}`),
+		}},
+		sink,
+	)
+
+	tool := (&httpRequestTool{}).WithCredentialInjector(inj)
+	args, _ := json.Marshal(httpRequestInput{Method: "GET", URL: srv.URL})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(gotAuth, "must-not-appear") {
+		t.Errorf("cli_execute-scoped spec leaked to http_request: %q", gotAuth)
+	}
+	// No credential_issued should have fired since no spec matched.
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	for _, e := range sink.events {
+		if e.name == "credential_issued" {
+			t.Errorf("unexpected credential_issued for non-matching tool")
+		}
+	}
+}

--- a/forge-core/tools/builtins/register.go
+++ b/forge-core/tools/builtins/register.go
@@ -1,11 +1,33 @@
 package builtins
 
-import "github.com/initializ/forge/forge-core/tools"
+import (
+	"github.com/initializ/forge/forge-core/credentials"
+	"github.com/initializ/forge/forge-core/tools"
+)
 
-// All returns all built-in tools.
-func All() []tools.Tool {
+// Options configures which optional per-tool integrations are wired
+// when constructing the builtin tools. Governance R9 uses this to
+// attach the JIT credential injector to http_request; future options
+// (per-tool tracing, per-tool rate limits) belong here too so the
+// public All() / RegisterAll() surface stays a small set of variadic
+// entry points.
+type Options struct {
+	// HTTPCredentialInjector, when non-nil, is wired into the
+	// http_request tool so per-call JIT credentials become request
+	// headers. Zero value → no JIT injection.
+	HTTPCredentialInjector *credentials.Injector
+}
+
+// All returns all built-in tools. Accepts zero or one Options
+// value; extra Options are ignored (variadic for backward-compat
+// only — callers should pass at most one).
+func All(opts ...Options) []tools.Tool {
+	var o Options
+	if len(opts) > 0 {
+		o = opts[0]
+	}
 	return []tools.Tool{
-		&httpRequestTool{},
+		(&httpRequestTool{}).WithCredentialInjector(o.HTTPCredentialInjector),
 		&jsonParseTool{},
 		&csvParseTool{},
 		&datetimeNowTool{},
@@ -17,8 +39,9 @@ func All() []tools.Tool {
 }
 
 // RegisterAll registers all built-in tools with the given registry.
-func RegisterAll(reg *tools.Registry) error {
-	for _, t := range All() {
+// Same variadic-Options convention as All(); pass at most one.
+func RegisterAll(reg *tools.Registry, opts ...Options) error {
+	for _, t := range All(opts...) {
 		if err := reg.Register(t); err != nil {
 			return err
 		}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/initializ/forge/forge-core/credentials"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,27 @@ type ForgeConfig struct {
 	// is off by default to stop workflow identity from leaking to
 	// third-party APIs.
 	WorkflowPropagation WorkflowPropagationConfig `yaml:"workflow_propagation,omitempty"`
+
+	// Credentials declares per-tool JIT credential specs (governance R9).
+	// Each entry names a provider (registered in credentials.DefaultRegistry
+	// via one of the credentials/* subpackages) plus provider-specific
+	// spec bytes. The runner materializes fresh credentials on every
+	// tool call whose Tool + Binary matches the spec; the resulting env
+	// is merged into the tool's subprocess environment. Empty → no JIT
+	// injection (pre-R9 behavior).
+	//
+	// Example:
+	//
+	//   credentials:
+	//     - tool: cli_execute
+	//       binary: aws
+	//       provider: sts_assume_role
+	//       spec:
+	//         role_arn: arn:aws:iam::123456789012:role/skill-read
+	//         duration: 15m
+	//
+	// See docs/security/least-privilege-credentials.md.
+	Credentials []credentials.CredentialSpec `yaml:"credentials,omitempty"`
 }
 
 // WorkflowPropagationConfig opts-in specific downstream hosts to

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -51,6 +51,17 @@ type ForgeConfig struct {
 	// is merged into the tool's subprocess environment. Empty → no JIT
 	// injection (pre-R9 behavior).
 	//
+	// Coupling note (per @initializ-mk's #236 review): `types` intentionally
+	// imports `credentials` here so operators get a single self-describing
+	// yaml schema type. The invariant that keeps this safe: the base
+	// `credentials` package MUST stay stdlib-only. Provider implementations
+	// with external deps (AWS SDK, Vault client, HSM libs) belong in
+	// `credentials/<provider>` subpackages — which the runner imports for
+	// its init()-time registration but which the config type never sees.
+	// Do NOT add non-stdlib imports to `forge-core/credentials/*.go`
+	// (root files) — a lint / CI check should be added if this becomes a
+	// recurring temptation.
+	//
 	// Example:
 	//
 	//   credentials:

--- a/forge-core/types/config_credentials_test.go
+++ b/forge-core/types/config_credentials_test.go
@@ -1,0 +1,170 @@
+package types
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/credentials"
+	// registers the static provider so InjectorResolveSpec can build one
+	_ "github.com/initializ/forge/forge-core/credentials/static"
+)
+
+// TestParseForgeConfig_CredentialsBlock is the regression test for
+// @initializ-mk's #236 second-round blocker: the operator-facing
+// `credentials:` block must round-trip through forge.yaml →
+// ParseForgeConfig → credentials.CredentialSpec → credentials.Injector.
+//
+// Pre-fix, `CredentialSpec.Spec` was a raw `json.RawMessage` with
+// yaml.v3 default decoding, which yaml.v3 rejected with
+// "cannot unmarshal !!map into json.RawMessage" — the whole feature
+// was unusable through its only interface. This test locks the
+// UnmarshalYAML fix in place.
+func TestParseForgeConfig_CredentialsBlock(t *testing.T) {
+	src := `
+agent_id: r9-demo
+version: 0.1.0
+framework: forge
+entrypoint: main.py
+security:
+  step_up:
+    enabled: false
+credentials:
+  - tool: cli_execute
+    binary: env
+    provider: static
+    spec:
+      env:
+        JIT_TOKEN: jit-secret-abc123
+        AWS_ACCESS_KEY_ID: AKIAJITSCOPED
+      ttl: 15m
+  - tool: http_request
+    provider: static
+    spec:
+      headers:
+        Authorization: Bearer jit-header
+        X-Jit-Auth: yes
+`
+	cfg, err := ParseForgeConfig([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseForgeConfig: %v", err)
+	}
+	if len(cfg.Credentials) != 2 {
+		t.Fatalf("expected 2 credential specs, got %d", len(cfg.Credentials))
+	}
+
+	// First spec: cli_execute env injector.
+	c0 := cfg.Credentials[0]
+	if c0.Tool != "cli_execute" || c0.Binary != "env" || c0.Provider != "static" {
+		t.Errorf("spec[0] wrong outer fields: %+v", c0)
+	}
+	if len(c0.Spec) == 0 {
+		t.Fatal("spec[0].Spec is empty — YAML sub-node dropped")
+	}
+	// The re-encoded JSON must contain the operator's map. yaml.v3
+	// produces map[string]interface{} → json.Marshal → JSON with
+	// alphabetical keys. Assert on substrings so key order doesn't
+	// matter.
+	c0JSON := string(c0.Spec)
+	for _, need := range []string{
+		`"JIT_TOKEN":"jit-secret-abc123"`,
+		`"AWS_ACCESS_KEY_ID":"AKIAJITSCOPED"`,
+		`"ttl":"15m"`,
+	} {
+		if !strings.Contains(c0JSON, need) {
+			t.Errorf("spec[0].Spec missing %q\nfull: %s", need, c0JSON)
+		}
+	}
+
+	// Second spec: http_request headers injector, no binary field.
+	c1 := cfg.Credentials[1]
+	if c1.Tool != "http_request" || c1.Binary != "" || c1.Provider != "static" {
+		t.Errorf("spec[1] wrong outer fields: %+v", c1)
+	}
+	if !strings.Contains(string(c1.Spec), `"Authorization":"Bearer jit-header"`) {
+		t.Errorf("spec[1] missing Authorization header: %s", c1.Spec)
+	}
+}
+
+// TestParseForgeConfig_Credentials_BuildsInjector proves the fix at
+// end-to-end depth: parse yaml → build a live Injector (via the
+// static provider registered above through the blank import).
+// Without the UnmarshalYAML fix the parse step errored; with the
+// fix the round-trip through NewInjector must also work — that
+// asserts the JSON round-trip produces valid provider spec bytes.
+func TestParseForgeConfig_Credentials_BuildsInjector(t *testing.T) {
+	src := `
+agent_id: r9-demo
+version: 0.1.0
+framework: forge
+entrypoint: main.py
+credentials:
+  - tool: cli_execute
+    provider: static
+    spec:
+      env: { K1: v1, K2: v2 }
+`
+	cfg, err := ParseForgeConfig([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseForgeConfig: %v", err)
+	}
+	inj, err := credentials.NewInjector(context.Background(), credentials.DefaultRegistry, cfg.Credentials, nil)
+	if err != nil {
+		t.Fatalf("NewInjector: %v", err)
+	}
+	if inj.Empty() {
+		t.Fatal("Injector unexpectedly empty after resolving 1 spec")
+	}
+}
+
+// TestParseForgeConfig_CredentialsEmptySpec — a spec with the
+// `spec:` key absent must not error. Some providers infer
+// everything from env (e.g. sts_assume_role with source_* env vars).
+func TestParseForgeConfig_CredentialsEmptySpec(t *testing.T) {
+	src := `
+agent_id: r9-demo
+version: 0.1.0
+framework: forge
+entrypoint: main.py
+credentials:
+  - tool: cli_execute
+    provider: static
+`
+	cfg, err := ParseForgeConfig([]byte(src))
+	if err != nil {
+		t.Fatalf("ParseForgeConfig: %v", err)
+	}
+	if len(cfg.Credentials) != 1 {
+		t.Fatalf("want 1 spec, got %d", len(cfg.Credentials))
+	}
+	if len(cfg.Credentials[0].Spec) != 0 {
+		t.Errorf("empty spec must decode to nil RawMessage, got: %s", cfg.Credentials[0].Spec)
+	}
+}
+
+// TestCredentialSpec_JSONRoundTripIndependence — the JSON path
+// (used by the OCI packaging pipeline + tests) still works
+// unchanged. UnmarshalYAML must not have broken the JSON side.
+func TestCredentialSpec_JSONRoundTripIndependence(t *testing.T) {
+	original := credentials.CredentialSpec{
+		Tool:     "cli_execute",
+		Binary:   "env",
+		Provider: "static",
+		Spec:     json.RawMessage(`{"env":{"K":"v"}}`),
+	}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back credentials.CredentialSpec
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Tool != original.Tool || back.Binary != original.Binary || back.Provider != original.Provider {
+		t.Errorf("JSON round trip lost outer fields: got %+v want %+v", back, original)
+	}
+	if !strings.Contains(string(back.Spec), `"K":"v"`) {
+		t.Errorf("JSON round trip lost spec: %s", back.Spec)
+	}
+}


### PR DESCRIPTION
Closes #215.

## Summary
- New `forge-core/credentials/` package: `Provider` / `Credential` interfaces, `Registry`, `Injector`, per-invocation `Handle`.
- Reference providers:
  - `static` — passthrough env/headers (bootstrap + tests).
  - `sts_assume_role` — AWS STS AssumeRole with hand-rolled SigV4 (SDK-free, matches Forge's Bedrock signer pattern). Enforces AWS 15m–12h duration bounds; supports `external_id` + inline session policy.
- `ForgeConfig.Credentials []CredentialSpec` — operators declare per-tool JIT specs in `forge.yaml`. Empty → pre-R9 behavior.
- Runner startup resolves each spec and wires the injector into `CLIExecuteTool.WithCredentialInjector(...)`.
- `cli_execute` materializes credentials on every Execute call, merges env into the subprocess, and revokes on defer.
- New audit events: `credential_issued`, `credential_revoked`, `credential_failed` — payloads carry provider/tool/binary/ttl/env_keys, **never** the credential material itself.

## Acceptance criteria (from #215)
- [x] `credentials.Credential` + `credentials.Provider` interfaces in `forge-core/credentials/`
- [x] `sts_assume_role` provider ships as the reference implementation
- [x] Skill can declare per-tool credential requirements (via `forge.yaml`)
- [x] `BeforeToolExec`-equivalent materializes the credential and scopes the tool's env accordingly (via `Injector.Materialize` inside `cli_execute.Execute`)
- [x] `credential_issued` + `credential_revoked` audit events with provider, TTL, scope
- [x] Tests: mock STS server; verify per-tool creds materialize, get injected, and are revoked
- [x] Docs: `docs/security/least-privilege-credentials.md`

## Test plan
- [x] `go test ./forge-core/credentials/...` — interfaces, registry, static provider, STS mock server (request form, SigV4 shape, error paths, duration bounds)
- [x] `go test ./forge-cli/tools/...` — end-to-end cli_execute injection: env visible in subprocess, audit events fire, binary-scoping works, no-injector fallback is a no-op
- [x] `go test ./forge-core/... ./forge-cli/...` — full sweep green
- [x] `gofmt -w` + `golangci-lint run` all clean