### PR TITLE
fix(build): don't purge curl when a skill requires it at runtime

### DIFF
--- a/forge-cli/build/dockerfile_stage.go
+++ b/forge-cli/build/dockerfile_stage.go
@@ -92,6 +92,9 @@ func (s *DockerfileStage) generateSmartDockerfile(bc *pipeline.BuildContext, man
 	data.RuntimeAptPackages = frags.RuntimeAptPackages
 	data.RuntimeApkPackages = frags.RuntimeApkPackages
 	data.PathExtensions = frags.PathExtensions
+	// When curl is a declared runtime bin, the forge bootstrap must not purge it.
+	data.KeepRuntimeCurl = containsPackage(frags.RuntimeAptPackages, "curl") ||
+		containsPackage(frags.RuntimeApkPackages, "curl")
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -345,4 +348,14 @@ Dockerfile
 	}
 	bc.AddFile(".dockerignore", ignorePath)
 	return nil
+}
+
+// containsPackage reports whether name is among the given package names.
+func containsPackage(pkgs []string, name string) bool {
+	for _, p := range pkgs {
+		if p == name {
+			return true
+		}
+	}
+	return false
 }

--- a/forge-cli/build/dockerfile_stage_curl_test.go
+++ b/forge-cli/build/dockerfile_stage_curl_test.go
@@ -1,0 +1,84 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/agentspec"
+	"github.com/initializ/forge/forge-core/packaging"
+	"github.com/initializ/forge/forge-core/pipeline"
+	"github.com/initializ/forge/forge-core/types"
+	"github.com/initializ/forge/forge-skills/contract"
+)
+
+// renderForgeDockerfile runs the DockerfileStage for a forge-framework agent
+// whose skills declare the given runtime binaries, and returns the Dockerfile.
+func renderForgeDockerfile(t *testing.T, bins ...string) string {
+	t.Helper()
+	outDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: outDir})
+	bc.Config = &types.ForgeConfig{AgentID: "test", Version: "0.1.0", Framework: "forge"}
+	bc.Spec = &agentspec.AgentSpec{
+		AgentID: "test",
+		Version: "0.1.0",
+		Runtime: &agentspec.RuntimeConfig{
+			Image:      "debian:bookworm-slim",
+			Entrypoint: []string{"forge", "serve"},
+			Port:       8080,
+		},
+	}
+	reqs := make([]contract.BinRequirement, 0, len(bins))
+	for _, b := range bins {
+		reqs = append(reqs, contract.BinRequirement{Name: b})
+	}
+	bc.BinManifest = &packaging.BinManifest{Requirements: reqs, SkillOrigin: map[string]string{}}
+
+	if err := (&DockerfileStage{}).Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, "Dockerfile"))
+	if err != nil {
+		t.Fatalf("reading Dockerfile: %v", err)
+	}
+	return string(data)
+}
+
+// TestDockerfile_ForgeBootstrapKeepsRequiredCurl pins the fix for the
+// forge-framework bootstrap clobbering a skill's declared curl. The
+// bootstrap borrows curl to fetch the forge binary and used to
+// `apt-get purge -y curl` afterwards — which removed the curl a skill
+// (e.g. weather) needs at runtime, leaving CLI Exec 0/1. When curl is a
+// declared runtime bin the purge must be skipped.
+func TestDockerfile_ForgeBootstrapKeepsRequiredCurl(t *testing.T) {
+	df := renderForgeDockerfile(t, "curl")
+
+	// Sanity: the forge bootstrap RUN is present (framework=forge).
+	if !strings.Contains(df, "forge-Linux-") {
+		t.Fatalf("expected forge bootstrap RUN, got:\n%s", df)
+	}
+	// curl must be installed as a runtime apt package...
+	if !strings.Contains(df, "curl") {
+		t.Fatalf("expected curl in Dockerfile, got:\n%s", df)
+	}
+	// ...and must NOT be purged, or the skill loses it at runtime.
+	if strings.Contains(df, "apt-get purge -y curl") {
+		t.Errorf("forge bootstrap purges curl even though it is a declared runtime bin:\n%s", df)
+	}
+}
+
+// TestDockerfile_ForgeBootstrapPurgesUnneededCurl is the complement: when
+// no skill needs curl, the bootstrap should still purge it (curl was only
+// borrowed to download the forge binary), keeping the image slim.
+func TestDockerfile_ForgeBootstrapPurgesUnneededCurl(t *testing.T) {
+	df := renderForgeDockerfile(t, "jq")
+
+	if !strings.Contains(df, "forge-Linux-") {
+		t.Fatalf("expected forge bootstrap RUN, got:\n%s", df)
+	}
+	if !strings.Contains(df, "apt-get purge -y curl") {
+		t.Errorf("bootstrap should purge the borrowed curl when no skill needs it:\n%s", df)
+	}
+}

--- a/forge-cli/templates/Dockerfile.tmpl
+++ b/forge-cli/templates/Dockerfile.tmpl
@@ -65,14 +65,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     curl -fsSL -o /tmp/forge.tar.gz "https://github.com/initializ/forge/releases/latest/download/forge-Linux-${ARCH}.tar.gz" && \
     tar xz -C /usr/local/bin forge -f /tmp/forge.tar.gz && rm /tmp/forge.tar.gz && \
     chmod +x /usr/local/bin/forge && \
+{{- if .KeepRuntimeCurl}}
+    rm -rf /var/lib/apt/lists/*
+{{- else}}
     apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+{{- end}}
 {{- else}}
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     ARCH=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x86_64/') && \
     curl -fsSL -o /tmp/forge.tar.gz "https://github.com/initializ/forge/releases/download/{{.ForgeVersion}}/forge-Linux-${ARCH}.tar.gz" && \
     tar xz -C /usr/local/bin forge -f /tmp/forge.tar.gz && rm /tmp/forge.tar.gz && \
     chmod +x /usr/local/bin/forge && \
+{{- if .KeepRuntimeCurl}}
+    rm -rf /var/lib/apt/lists/*
+{{- else}}
     apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+{{- end}}
 {{- end}}
 {{- end}}
 

--- a/forge-core/compiler/template_data.go
+++ b/forge-core/compiler/template_data.go
@@ -43,6 +43,13 @@ type TemplateSpecData struct {
 	RuntimeAptPackages []string // runtime apt packages installed in the application stage (debian).
 	RuntimeApkPackages []string // runtime apk packages installed in the application stage (alpine).
 	PathExtensions     []string // PATH directories for non-standard binary locations.
+
+	// KeepRuntimeCurl is true when curl is a declared runtime binary (present
+	// in RuntimeAptPackages/RuntimeApkPackages). The forge-framework bootstrap
+	// borrows curl to fetch the forge binary and then purges it; when a skill
+	// legitimately requires curl at runtime, that purge would clobber it, so
+	// the Dockerfile template skips the purge in that case.
+	KeepRuntimeCurl bool
 }
 
 // TemplateRuntimeData holds runtime-specific template data.


### PR DESCRIPTION
## Problem

A deployed forge agent whose skill declares `curl` starts with:

```
CLI Exec:   0/1 binaries (curl MISSING)
```

The skill (e.g. `weather`, `requires.bins: [curl]`) is non-functional.

## Root cause

The forge-framework bootstrap in `Dockerfile.tmpl` borrows curl to fetch the forge binary, then purges it:

```dockerfile
RUN apt-get install -y curl ca-certificates && \
    curl -fsSL -o /tmp/forge.tar.gz ".../forge-Linux-${ARCH}.tar.gz" && \
    ... && \
    apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
```

The prior stage installs the skill's runtime bins (`ca-certificates{{range .RuntimeAptPackages}} {{.}}{{end}}` → includes `curl`), and the bootstrap then purges curl — clobbering the required runtime binary.

This is the residual hole after #149 (which moved apt bins to the app stage and stopped losing runtime deps): the general case is fixed, but the one binary the bootstrap itself uses — curl — is still removed.

## Fix

Skip the purge when curl is a declared runtime bin:

- Add `TemplateSpecData.KeepRuntimeCurl`.
- `DockerfileStage` sets it when `curl ∈ RuntimeAptPackages ∪ RuntimeApkPackages`.
- The two bootstrap purge lines are guarded by `{{- if .KeepRuntimeCurl}}`.

When curl **isn't** required, the bootstrap still purges it (image stays slim).

## Tests

`dockerfile_stage_curl_test.go`:
- `TestDockerfile_ForgeBootstrapKeepsRequiredCurl` — curl required ⇒ no `apt-get purge -y curl`.
- `TestDockerfile_ForgeBootstrapPurgesUnneededCurl` — curl not required ⇒ purge retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)