### PR TITLE
feat(memory): pluggable SessionStore + remote backend (#243)

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -345,6 +345,16 @@ attributed to the deciding layer.
 Default-on **session memory**: per-session chat transcript + metadata
 under `<workdir>/.forge/sessions/`. Bounded by `memory.sessions_dir`.
 
+Pluggable **session store** (`memory.session_store`, issue #243): `file`
+(default, the local `.forge/sessions/*.json` above) or `remote` — snapshots
+pushed to a platform session service over HTTP so stateless pods resume any
+task on any replica with no PVC. Remote does a conditional GET before each
+turn (`If-None-Match` → 304/200) and an `If-Match` CAS on save; on a 412 the
+stale writer **yields** (newer state wins, model never re-run) rather than
+clobbering. Auth reuses the admission env (`FORGE_PLATFORM_TOKEN` +
+`FORGE_ORG_ID`/`FORGE_WORKSPACE_ID`); set `FORGE_SESSION_STORE=remote` +
+`FORGE_SESSION_STORE_URL`. Missing URL/token → warn + fall back to `file`.
+
 Opt-in **long-term memory**: vector-backed semantic + keyword hybrid
 retrieval with temporal decay (configurable half-life), context-budget
 caps, compaction triggers. Embedding provider auto-detects from the
@@ -849,6 +859,8 @@ secrets:
 memory:
   persistence: true
   sessions_dir: .forge/sessions
+  session_store: file            # file (default) | remote
+  session_store_url: ""          # required when session_store: remote
   long_term: false
   embedding_provider: openai
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@
 
 ### Added
 
+- **Pluggable session store with an opt-in `remote` backend (issue
+  #243).** `memory.session_store` selects `file` (default — today's
+  local `.forge/sessions/*.json`) or `remote`, which pushes per-task
+  session snapshots to a platform session service over HTTP so
+  stateless pods resume any task on any replica without a PVC. The
+  remote backend does a conditional GET before each turn
+  (`If-None-Match` → 304/200), commits with an `If-Match` CAS, and on
+  a 412 conflict **yields** (the newer state wins, the model is never
+  re-run) rather than clobbering the concurrent writer. Enable with
+  `memory.session_store: remote` + `session_store_url` (or
+  `FORGE_SESSION_STORE` / `FORGE_SESSION_STORE_URL`); auth reuses the
+  admission client's `FORGE_PLATFORM_TOKEN` + `FORGE_ORG_ID` /
+  `FORGE_WORKSPACE_ID`. A `remote` selection missing its URL or token
+  warns and falls back to `file`. The file backend and its tests are
+  unchanged. See `docs/core-concepts/memory-system.md`.
+
 - **Anthropic-format custom URLs + AWS Bedrock SigV4 outbound auth
   (issue #202).** Two-phase rollout:
   - **Phase 1**: `forge init`'s "Custom" provider option now asks

--- a/docs/core-concepts/memory-system.md
+++ b/docs/core-concepts/memory-system.md
@@ -33,6 +33,34 @@ memory:
 export FORGE_SESSION_MAX_AGE=1h
 ```
 
+### Session Store Backends
+
+Session persistence has two backends, selected by `memory.session_store`:
+
+| Backend | When | Behavior |
+|---------|------|----------|
+| `file` (default) | Single pod / dev | Local JSON under `sessions_dir` (`.forge/sessions/*.json`). Durable only on that pod's filesystem. |
+| `remote` | Stateless / multi-pod | Snapshots are pushed to a platform **session service** over HTTP, so any replica can resume any task with no shared volume — no PVC. |
+
+The `remote` backend keeps agent pods stateless: a task started on one pod resumes on another. It:
+
+- **Pulls before each turn** with a conditional GET (`If-None-Match`) — the service answers `304` (the pod's cached snapshot is current) or `200` (fresh state), so unchanged sessions aren't re-downloaded.
+- **Commits with compare-and-swap** (`If-Match`) — a concurrent writer's intervening commit is detected as a `412`. On conflict the stale writer **yields** (the newer state wins) rather than clobbering it; the model is never re-run.
+- **Pulls lazily** — a cold pod fetches a session only when its task is first touched, not all sessions at once.
+
+```yaml
+memory:
+  session_store: remote                       # "file" (default) | "remote"
+  session_store_url: "https://sessions.example/api/v1/agent-sessions"
+```
+
+The pod authenticates to the service with its platform token, reusing the same env the admission client reads — `FORGE_PLATFORM_TOKEN` plus the `FORGE_ORG_ID` / `FORGE_WORKSPACE_ID` tenancy stamps. A `remote` selection missing its URL or token warns and falls back to the `file` backend, so session memory is never silently dropped.
+
+```bash
+export FORGE_SESSION_STORE=remote
+export FORGE_SESSION_STORE_URL=https://sessions.example/api/v1/agent-sessions
+```
+
 ## Context Window Management
 
 Forge automatically manages context window usage based on model capabilities:
@@ -105,6 +133,8 @@ memory:
   persistence: true
   sessions_dir: ".forge/sessions"
   session_max_age: "30m"      # discard sessions idle longer than this
+  session_store: "file"       # "file" (default) | "remote"
+  session_store_url: ""       # required when session_store: remote
   char_budget: 200000
   trigger_ratio: 0.6
   long_term: false
@@ -122,5 +152,7 @@ Environment variables:
 |----------|-------------|
 | `FORGE_MEMORY_PERSISTENCE` | Set `false` to disable session persistence |
 | `FORGE_SESSION_MAX_AGE` | Session idle timeout, e.g. `30m`, `1h` (default: `30m`) |
+| `FORGE_SESSION_STORE` | Session backend: `file` (default) or `remote` |
+| `FORGE_SESSION_STORE_URL` | Platform session-service URL (required for `remote`) |
 | `FORGE_MEMORY_LONG_TERM` | Set `true` to enable long-term memory |
 | `FORGE_EMBEDDING_PROVIDER` | Override embedding provider |

--- a/docs/core-concepts/runtime-engine.md
+++ b/docs/core-concepts/runtime-engine.md
@@ -25,7 +25,7 @@ The loop terminates when `len(ToolCalls) == 0`. `FinishReason` is intentionally 
 
 ### Session Recovery Deduplication
 
-When a session is recovered from disk (e.g., after a premature loop exit), the executor checks whether the recovered conversation already ends with an identical user message. If so, the duplicate is skipped to prevent the same message from appearing twice in the context window. This handles the common case where a user retries the same prompt after a crash or timeout.
+When a session is recovered from the [session store](memory-system.md#session-store-backends) (e.g., after a premature loop exit, on any pod for the remote backend), the executor checks whether the recovered conversation already ends with an identical user message. If so, the duplicate is skipped to prevent the same message from appearing twice in the context window. This handles the common case where a user retries the same prompt after a crash or timeout.
 
 ### Q&A Nudge Suppression
 

--- a/docs/reference/forge-yaml-schema.md
+++ b/docs/reference/forge-yaml-schema.md
@@ -146,6 +146,8 @@ secrets:
 memory:
   persistence: true                 # Session persistence (default: true)
   sessions_dir: ".forge/sessions"
+  session_store: "file"             # Session backend: "file" (default) | "remote"
+  session_store_url: ""             # Platform session-service URL (required for "remote")
   char_budget: 200000               # Context budget override
   trigger_ratio: 0.6                # Compaction trigger ratio
   long_term: false                  # Long-term memory (default: false)

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -937,31 +937,54 @@ func (r *Runner) Run(ctx context.Context) error {
 						memPersistence = false
 					}
 					if memPersistence {
-						sessDir := r.cfg.Config.Memory.SessionsDir
-						if sessDir == "" {
-							sessDir = filepath.Join(r.cfg.WorkDir, ".forge", "sessions")
-						}
-						memStore, storeErr := coreruntime.NewMemoryStore(sessDir)
-						if storeErr != nil {
-							r.logger.Warn("failed to create memory store, persistence disabled", map[string]any{
-								"error": storeErr.Error(),
-							})
-						} else {
-							// Clean up old sessions on startup (7-day TTL).
-							deleted, _ := memStore.Cleanup(7 * 24 * time.Hour)
-							if deleted > 0 {
-								r.logger.Info("cleaned up old sessions", map[string]any{"deleted": deleted})
-							}
+						// Select the session-memory backend (issue #243).
+						// Remote (opt-in) pushes snapshots to the platform
+						// session service so stateless pods resume any task on
+						// any replica; file (default) keeps today's local
+						// .forge/sessions. buildSessionStore returns the remote
+						// store when configured, else nil to signal "use file".
+						var sessionStore coreruntime.SessionStore
+						var storeDesc map[string]any
 
+						if remote := buildRemoteSessionStore(
+							r.cfg.Config.AgentID,
+							r.cfg.Config.Memory.SessionStore,
+							r.cfg.Config.Memory.SessionStoreURL,
+							r.logger,
+						); remote != nil {
+							sessionStore = remote
+							storeDesc = map[string]any{"backend": "remote"}
+						} else {
+							sessDir := r.cfg.Config.Memory.SessionsDir
+							if sessDir == "" {
+								sessDir = filepath.Join(r.cfg.WorkDir, ".forge", "sessions")
+							}
+							memStore, storeErr := coreruntime.NewMemoryStore(sessDir)
+							if storeErr != nil {
+								r.logger.Warn("failed to create memory store, persistence disabled", map[string]any{
+									"error": storeErr.Error(),
+								})
+							} else {
+								// Clean up old sessions on startup (7-day TTL).
+								deleted, _ := memStore.Cleanup(7 * 24 * time.Hour)
+								if deleted > 0 {
+									r.logger.Info("cleaned up old sessions", map[string]any{"deleted": deleted})
+								}
+								sessionStore = memStore
+								storeDesc = map[string]any{"backend": "file", "sessions_dir": sessDir}
+							}
+						}
+
+						if sessionStore != nil {
 							compactor := coreruntime.NewCompactor(coreruntime.CompactorConfig{
 								Client:       llmClient,
-								Store:        memStore,
+								Store:        sessionStore,
 								Logger:       r.logger,
 								CharBudget:   charBudget,
 								TriggerRatio: r.cfg.Config.Memory.TriggerRatio,
 							})
 
-							execCfg.Store = memStore
+							execCfg.Store = sessionStore
 							execCfg.Compactor = compactor
 
 							// Session max age: stale sessions are discarded to prevent
@@ -976,9 +999,7 @@ func (r *Runner) Run(ctx context.Context) error {
 								}
 							}
 
-							r.logger.Info("memory persistence enabled", map[string]any{
-								"sessions_dir": sessDir,
-							})
+							r.logger.Info("memory persistence enabled", storeDesc)
 						}
 					}
 

--- a/forge-cli/runtime/session_store_loader.go
+++ b/forge-cli/runtime/session_store_loader.go
@@ -1,0 +1,90 @@
+package runtime
+
+import (
+	"os"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+// Environment variable names for the remote session store (issue #243).
+// The remote backend deliberately reuses the admission tenancy/auth env
+// (EnvPlatformToken / EnvOrgID / EnvWorkspaceID from admission_loader.go)
+// so a single platform token and one set of tenancy stamps cover every
+// Forge → platform surface.
+const (
+	// EnvSessionStore overrides memory.session_store: "file" | "remote".
+	EnvSessionStore = "FORGE_SESSION_STORE"
+
+	// EnvSessionStoreURL points at the platform session service. Required
+	// when the backend resolves to "remote".
+	EnvSessionStoreURL = "FORGE_SESSION_STORE_URL"
+
+	// sessionStoreRemote is the opt-in backend value.
+	sessionStoreRemote = "remote"
+)
+
+// buildRemoteSessionStore returns a remote-backed SessionStore when the
+// agent is configured for it, or nil to signal "use the default file
+// backend". Resolution: env (FORGE_SESSION_STORE) overrides config
+// (memory.session_store); likewise FORGE_SESSION_STORE_URL overrides
+// memory.session_store_url. Auth/tenancy come from the same env the
+// admission client reads (FORGE_PLATFORM_TOKEN, FORGE_ORG_ID,
+// FORGE_WORKSPACE_ID).
+//
+// A "remote" selection missing its URL or the platform token is a
+// misconfiguration: rather than silently drop session persistence, we
+// warn (single-line fix in the manifest) and fall back to the file
+// backend by returning nil.
+func buildRemoteSessionStore(agentID, cfgMode, cfgURL string, logger coreruntime.Logger) coreruntime.SessionStore {
+	mode := cfgMode
+	if v := os.Getenv(EnvSessionStore); v != "" {
+		mode = v
+	}
+	if mode != sessionStoreRemote {
+		return nil // file backend (default)
+	}
+
+	url := cfgURL
+	if v := os.Getenv(EnvSessionStoreURL); v != "" {
+		url = v
+	}
+	token := os.Getenv(EnvPlatformToken)
+
+	switch {
+	case url == "":
+		if logger != nil {
+			logger.Warn("session store: remote selected without a URL; using file backend", map[string]any{
+				"missing_env": EnvSessionStoreURL,
+			})
+		}
+		return nil
+	case token == "":
+		if logger != nil {
+			logger.Warn("session store: remote selected without a platform token; using file backend", map[string]any{
+				"missing_env": EnvPlatformToken,
+			})
+		}
+		return nil
+	}
+
+	orgID := os.Getenv(EnvOrgID)
+	workspaceID := os.Getenv(EnvWorkspaceID)
+
+	if logger != nil {
+		logger.Info("session store: engaged remote backend", map[string]any{
+			"url":          url,
+			"agent_id":     agentID,
+			"org_id":       orgID,
+			"workspace_id": workspaceID,
+		})
+	}
+
+	return coreruntime.NewRemoteSessionStore(coreruntime.RemoteSessionStoreConfig{
+		BaseURL:       url,
+		AgentID:       agentID,
+		OrgID:         orgID,
+		WorkspaceID:   workspaceID,
+		PlatformToken: token,
+		Logger:        logger,
+	})
+}

--- a/forge-cli/runtime/session_store_loader_test.go
+++ b/forge-cli/runtime/session_store_loader_test.go
@@ -1,0 +1,43 @@
+package runtime
+
+import (
+	"testing"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+func TestBuildRemoteSessionStore(t *testing.T) {
+	cases := []struct {
+		name       string
+		cfgMode    string
+		cfgURL     string
+		envMode    string
+		envURL     string
+		envToken   string
+		wantRemote bool
+	}{
+		{name: "default file backend", wantRemote: false},
+		{name: "config remote, full", cfgMode: "remote", cfgURL: "http://svc", envToken: "tok", wantRemote: true},
+		{name: "env overrides to remote", envMode: "remote", cfgURL: "http://svc", envToken: "tok", wantRemote: true},
+		{name: "remote without url falls back", cfgMode: "remote", envToken: "tok", wantRemote: false},
+		{name: "remote without token falls back", cfgMode: "remote", cfgURL: "http://svc", wantRemote: false},
+		{name: "env url overrides config url", cfgMode: "remote", cfgURL: "http://old", envURL: "http://new", envToken: "tok", wantRemote: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvSessionStore, tc.envMode)
+			t.Setenv(EnvSessionStoreURL, tc.envURL)
+			t.Setenv(EnvPlatformToken, tc.envToken)
+			t.Setenv(EnvOrgID, "org-1")
+
+			got := buildRemoteSessionStore("agt-1", tc.cfgMode, tc.cfgURL, nil)
+			if tc.wantRemote {
+				if _, ok := got.(*coreruntime.RemoteSessionStore); !ok {
+					t.Fatalf("expected *RemoteSessionStore, got %T", got)
+				}
+			} else if got != nil {
+				t.Fatalf("expected nil (file backend), got %T", got)
+			}
+		})
+	}
+}

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -47,7 +47,7 @@ type LLMExecutor struct {
 	systemPrompt       string
 	maxIter            int
 	compactor          *Compactor
-	store              *MemoryStore
+	store              SessionStore
 	logger             Logger
 	modelName          string        // resolved model name for context budget
 	provider           string        // resolved provider name (anthropic, openai, ollama, custom)
@@ -72,7 +72,7 @@ type LLMExecutorConfig struct {
 	SystemPrompt   string
 	MaxIterations  int
 	Compactor      *Compactor
-	Store          *MemoryStore
+	Store          SessionStore
 	Logger         Logger
 	ModelName      string        // model name for context-aware budgeting
 	Provider       string        // provider name (anthropic, openai, ollama, custom) — for audit attribution

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -207,7 +208,7 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 	if e.store != nil {
 		saved, err := e.store.Load(task.ID)
 		if err != nil {
-			e.logger.Warn("failed to load session from disk", map[string]any{
+			e.logger.Warn("failed to load session", map[string]any{
 				"task_id": task.ID, "error": err.Error(),
 			})
 		} else if saved != nil {
@@ -221,7 +222,7 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 			} else {
 				mem.LoadFromStore(saved)
 				recovered = true
-				e.logger.Info("session recovered from disk", map[string]any{
+				e.logger.Info("session recovered", map[string]any{
 					"task_id":  task.ID,
 					"messages": len(saved.Messages),
 				})
@@ -826,9 +827,17 @@ func (e *LLMExecutor) persistSession(taskID string, mem *Memory) {
 	}
 
 	if err := e.store.Save(data); err != nil {
-		e.logger.Warn("failed to persist session", map[string]any{
-			"task_id": taskID, "error": err.Error(),
-		})
+		if errors.Is(err, ErrConflict) {
+			// A concurrent writer committed first; we yielded rather than
+			// clobber it (remote backend). Expected, not a failure.
+			e.logger.Info("session persist yielded to a concurrent writer", map[string]any{
+				"task_id": taskID,
+			})
+		} else {
+			e.logger.Warn("failed to persist session", map[string]any{
+				"task_id": taskID, "error": err.Error(),
+			})
+		}
 	}
 }
 

--- a/forge-core/runtime/memory_compactor.go
+++ b/forge-core/runtime/memory_compactor.go
@@ -30,7 +30,7 @@ type CompactorConfig struct {
 	Client llm.Client
 	// Store persists sessions to disk after compaction. If nil, compaction
 	// still reduces in-memory messages but nothing is flushed.
-	Store *MemoryStore
+	Store SessionStore
 	// Logger for compaction events.
 	Logger Logger
 	// CharBudget is the total character budget. Compaction triggers when
@@ -52,7 +52,7 @@ type CompactorConfig struct {
 // acceptable — no concurrent access occurs.
 type Compactor struct {
 	client        llm.Client
-	store         *MemoryStore
+	store         SessionStore
 	logger        Logger
 	charBudget    int
 	triggerRatio  float64

--- a/forge-core/runtime/memory_compactor.go
+++ b/forge-core/runtime/memory_compactor.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -312,10 +313,16 @@ func (c *Compactor) flushToDisk(taskID string, mem *Memory) {
 	}
 
 	if err := c.store.Save(data); err != nil {
-		c.logger.Warn("failed to flush session to disk", map[string]any{
-			"task_id": taskID,
-			"error":   err.Error(),
-		})
+		if errors.Is(err, ErrConflict) {
+			c.logger.Info("session flush yielded to a concurrent writer", map[string]any{
+				"task_id": taskID,
+			})
+		} else {
+			c.logger.Warn("failed to flush session", map[string]any{
+				"task_id": taskID,
+				"error":   err.Error(),
+			})
+		}
 	}
 }
 

--- a/forge-core/runtime/remote_session_store.go
+++ b/forge-core/runtime/remote_session_store.go
@@ -1,0 +1,291 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// remoteStoreTimeout bounds each session-store HTTP call. Session
+// state is on the hot path (loaded before a turn, saved after), so the
+// budget is tight; on timeout the loop falls back to task.History just
+// as it would for a cold session.
+const remoteStoreTimeout = 3 * time.Second
+
+// RemoteSessionStore is the opt-in SessionStore backend (issue #243).
+// It pushes per-task snapshots to a platform session service over HTTP
+// so agent pods stay stateless — any replica can resume any task with
+// no shared filesystem / PVC.
+//
+// Wire contract (the platform session service — agent-builder — is the
+// server side):
+//
+//	GET  {base}/{taskID}?agent_id=<id>   If-None-Match: "<ver>"
+//	     -> 200 + ETag: "<ver>" + SessionData   (fresh)
+//	     -> 304                                  (caller's cached copy is current)
+//	     -> 404                                  (no session yet)
+//	PUT  {base}/{taskID}?agent_id=<id>   If-Match: "<ver>" + SessionData
+//	     -> 200 + ETag: "<newVer>"               (committed)
+//	     -> 412                                   (version conflict / CAS fail)
+//	DELETE {base}/{taskID}?agent_id=<id> -> 2xx
+//
+// Concurrency model (per issue #243): A2A serializes turns within a
+// task, so there is normally one writer per task at a time. The store
+// keeps the ETag it last saw per task and uses it as the conditional
+// header — a conditional GET avoids re-pulling unchanged state (304),
+// and an If-Match PUT turns the rare rolling-deploy overlap window into
+// a detectable 412 instead of a silent lost update. On 412 the store
+// rebases (re-reads the current version) and retries the PUT once; it
+// never re-runs the LLM.
+//
+// Auth mirrors the admission client exactly: Bearer FORGE_PLATFORM_TOKEN
+// plus the Org-Id / Workspace-Id tenancy headers (omitted when empty).
+type RemoteSessionStore struct {
+	baseURL       string
+	agentID       string
+	orgID         string
+	workspaceID   string
+	platformToken string
+	client        *http.Client
+	logger        Logger
+
+	mu    sync.Mutex
+	cache map[string]remoteCacheEntry // taskID -> last-seen version + snapshot
+}
+
+type remoteCacheEntry struct {
+	version string
+	data    *SessionData
+}
+
+// RemoteSessionStoreConfig configures a RemoteSessionStore. AgentID is
+// required (the platform routes on it). OrgID / WorkspaceID are optional
+// (empty -> header omitted). PlatformToken is the reusable Forge ->
+// platform bearer (FORGE_PLATFORM_TOKEN), same token the admission
+// client sends.
+type RemoteSessionStoreConfig struct {
+	BaseURL       string
+	AgentID       string
+	OrgID         string
+	WorkspaceID   string
+	PlatformToken string
+	Logger        Logger
+	// HTTPClient overrides the default client (tests inject one).
+	HTTPClient *http.Client
+}
+
+// NewRemoteSessionStore builds a remote-backed SessionStore. It performs
+// no network call at construction time; the first Load/Save hits the
+// platform.
+func NewRemoteSessionStore(cfg RemoteSessionStoreConfig) *RemoteSessionStore {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: remoteStoreTimeout}
+	}
+	return &RemoteSessionStore{
+		baseURL:       strings.TrimRight(cfg.BaseURL, "/"),
+		agentID:       cfg.AgentID,
+		orgID:         cfg.OrgID,
+		workspaceID:   cfg.WorkspaceID,
+		platformToken: cfg.PlatformToken,
+		client:        client,
+		logger:        cfg.Logger,
+		cache:         make(map[string]remoteCacheEntry),
+	}
+}
+
+// Load fetches the session for taskID with a conditional GET. A cached
+// ETag (from a prior Load/Save on this pod) drives If-None-Match: a 304
+// returns the cached snapshot without re-downloading; a 200 refreshes
+// the cache; a 404 means no session yet (nil, nil). On any transport /
+// server error it returns the error and the loop falls back to
+// task.History, exactly as a cold session would.
+func (r *RemoteSessionStore) Load(taskID string) (*SessionData, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), remoteStoreTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.taskURL(taskID), nil)
+	if err != nil {
+		return nil, err
+	}
+	r.setHeaders(req)
+
+	r.mu.Lock()
+	cached, hasCache := r.cache[taskID]
+	r.mu.Unlock()
+	if hasCache && cached.version != "" {
+		req.Header.Set("If-None-Match", etagQuote(cached.version))
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("session store GET %s: %w", taskID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		if hasCache {
+			return cloneSession(cached.data), nil
+		}
+		// 304 without a local copy shouldn't happen (we only send
+		// If-None-Match when cached); treat as "no data" defensively.
+		return nil, nil
+	case http.StatusNotFound:
+		return nil, nil
+	case http.StatusOK:
+		var data SessionData
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, fmt.Errorf("session store GET %s: decode: %w", taskID, err)
+		}
+		r.remember(taskID, etagUnquote(resp.Header.Get("ETag")), &data)
+		return cloneSession(&data), nil
+	default:
+		return nil, fmt.Errorf("session store GET %s: HTTP %d", taskID, resp.StatusCode)
+	}
+}
+
+// Save commits a full snapshot. It sends If-Match with the last-seen
+// version so a concurrent writer's intervening commit is caught as a
+// 412; on 412 it rebases (re-reads the current version) and retries the
+// PUT once. It never re-invokes the model.
+func (r *RemoteSessionStore) Save(data *SessionData) error {
+	return r.save(data, true)
+}
+
+func (r *RemoteSessionStore) save(data *SessionData, allowRebase bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), remoteStoreTimeout)
+	defer cancel()
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("session store PUT %s: marshal: %w", data.TaskID, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, r.taskURL(data.TaskID), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	r.setHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	r.mu.Lock()
+	cached, hasCache := r.cache[data.TaskID]
+	r.mu.Unlock()
+	if hasCache && cached.version != "" {
+		req.Header.Set("If-Match", etagQuote(cached.version))
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("session store PUT %s: %w", data.TaskID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		r.remember(data.TaskID, etagUnquote(resp.Header.Get("ETag")), data)
+		return nil
+	case http.StatusPreconditionFailed:
+		if allowRebase {
+			// Rebase onto the store's current version, then retry once.
+			// Load refreshes the cached ETag; the model is not re-run.
+			if _, lerr := r.Load(data.TaskID); lerr == nil {
+				return r.save(data, false)
+			}
+		}
+		return ErrConflict
+	default:
+		return fmt.Errorf("session store PUT %s: HTTP %d", data.TaskID, resp.StatusCode)
+	}
+}
+
+// Delete removes the session for taskID and drops it from the cache.
+func (r *RemoteSessionStore) Delete(taskID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), remoteStoreTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, r.taskURL(taskID), nil)
+	if err != nil {
+		return err
+	}
+	r.setHeaders(req)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("session store DELETE %s: %w", taskID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	r.mu.Lock()
+	delete(r.cache, taskID)
+	r.mu.Unlock()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 || resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return fmt.Errorf("session store DELETE %s: HTTP %d", taskID, resp.StatusCode)
+}
+
+// taskURL builds {base}/{taskID}?agent_id=<id>. The agent ID rides the
+// query (the pod serves one agent), mirroring the admission client so
+// the platform routes both calls the same way.
+func (r *RemoteSessionStore) taskURL(taskID string) string {
+	u := r.baseURL + "/" + url.PathEscape(taskID)
+	if r.agentID != "" {
+		u += "?agent_id=" + url.QueryEscape(r.agentID)
+	}
+	return u
+}
+
+// setHeaders stamps the auth + tenancy headers. Empty tenancy values
+// are omitted entirely (never sent as ""), matching the admission
+// client so the platform parser distinguishes "unset" from "empty".
+func (r *RemoteSessionStore) setHeaders(req *http.Request) {
+	if r.platformToken != "" {
+		req.Header.Set("Authorization", "Bearer "+r.platformToken)
+	}
+	if r.orgID != "" {
+		req.Header.Set("Org-Id", r.orgID)
+	}
+	if r.workspaceID != "" {
+		req.Header.Set("Workspace-Id", r.workspaceID)
+	}
+}
+
+func (r *RemoteSessionStore) remember(taskID, version string, data *SessionData) {
+	r.mu.Lock()
+	r.cache[taskID] = remoteCacheEntry{version: version, data: cloneSession(data)}
+	r.mu.Unlock()
+}
+
+// etagQuote wraps a bare version in HTTP ETag quotes ("3"); etagUnquote
+// reverses it. The platform may send weak ("W/") or strong ETags; we
+// only compare the opaque inner value.
+func etagQuote(v string) string { return `"` + v + `"` }
+
+func etagUnquote(v string) string {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "W/")
+	return strings.Trim(v, `"`)
+}
+
+// cloneSession deep-copies a SessionData so a cached snapshot can't be
+// mutated by a caller (and vice-versa).
+func cloneSession(d *SessionData) *SessionData {
+	if d == nil {
+		return nil
+	}
+	out := *d
+	// Copy the slice — ChatMessage values are treated as immutable once
+	// persisted, so a shallow element copy is sufficient.
+	out.Messages = append([]llm.ChatMessage(nil), d.Messages...)
+	return &out
+}

--- a/forge-core/runtime/remote_session_store.go
+++ b/forge-core/runtime/remote_session_store.go
@@ -43,8 +43,11 @@ const remoteStoreTimeout = 3 * time.Second
 // header — a conditional GET avoids re-pulling unchanged state (304),
 // and an If-Match PUT turns the rare rolling-deploy overlap window into
 // a detectable 412 instead of a silent lost update. On 412 the store
-// rebases (re-reads the current version) and retries the PUT once; it
-// never re-runs the LLM.
+// YIELDS — it surfaces ErrConflict rather than re-PUTting its (now stale)
+// snapshot, so the concurrent writer's committed turn is never clobbered.
+// The loop treats that as a best-effort-persist failure: it logs and moves
+// on, the newer state wins, and the model is never re-run. The store's
+// cache self-heals on the next turn's conditional GET.
 //
 // Auth mirrors the admission client exactly: Bearer FORGE_PLATFORM_TOKEN
 // plus the Org-Id / Workspace-Id tenancy headers (omitted when empty).
@@ -154,14 +157,15 @@ func (r *RemoteSessionStore) Load(taskID string) (*SessionData, error) {
 }
 
 // Save commits a full snapshot. It sends If-Match with the last-seen
-// version so a concurrent writer's intervening commit is caught as a
-// 412; on 412 it rebases (re-reads the current version) and retries the
-// PUT once. It never re-invokes the model.
+// version so a concurrent writer's intervening commit is caught as a 412.
+// On 412 it YIELDS (returns ErrConflict) rather than re-PUTting: this
+// store holds only a full snapshot built from the stale version, so a
+// blind retry would overwrite the other writer's committed turn — the
+// exact lost update the If-Match exists to detect. A message-level rebase
+// isn't available (and is semantically fragile for a conversation), so
+// the correct resolution is to let the newer state win. The model is
+// never re-run; the cached ETag self-heals on the next conditional GET.
 func (r *RemoteSessionStore) Save(data *SessionData) error {
-	return r.save(data, true)
-}
-
-func (r *RemoteSessionStore) save(data *SessionData, allowRebase bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), remoteStoreTimeout)
 	defer cancel()
 
@@ -195,13 +199,11 @@ func (r *RemoteSessionStore) save(data *SessionData, allowRebase bool) error {
 		r.remember(data.TaskID, etagUnquote(resp.Header.Get("ETag")), data)
 		return nil
 	case http.StatusPreconditionFailed:
-		if allowRebase {
-			// Rebase onto the store's current version, then retry once.
-			// Load refreshes the cached ETag; the model is not re-run.
-			if _, lerr := r.Load(data.TaskID); lerr == nil {
-				return r.save(data, false)
-			}
-		}
+		// Drop our stale cache entry so the next Load pulls the winner's
+		// state fresh (no stale If-None-Match), then yield.
+		r.mu.Lock()
+		delete(r.cache, data.TaskID)
+		r.mu.Unlock()
 		return ErrConflict
 	default:
 		return fmt.Errorf("session store PUT %s: HTTP %d", data.TaskID, resp.StatusCode)
@@ -278,14 +280,24 @@ func etagUnquote(v string) string {
 }
 
 // cloneSession deep-copies a SessionData so a cached snapshot can't be
-// mutated by a caller (and vice-versa).
+// mutated by a caller (and vice-versa). Each ChatMessage's ToolCalls slice
+// is copied too — otherwise the clone's messages would share a backing
+// array with the original, and an in-place mutation on either side would
+// leak across the cache boundary. (ToolCall/FunctionCall are value types
+// with only string fields, so copying the slice fully detaches it.)
 func cloneSession(d *SessionData) *SessionData {
 	if d == nil {
 		return nil
 	}
 	out := *d
-	// Copy the slice — ChatMessage values are treated as immutable once
-	// persisted, so a shallow element copy is sufficient.
-	out.Messages = append([]llm.ChatMessage(nil), d.Messages...)
+	if d.Messages != nil {
+		out.Messages = make([]llm.ChatMessage, len(d.Messages))
+		for i, m := range d.Messages {
+			if m.ToolCalls != nil {
+				m.ToolCalls = append([]llm.ToolCall(nil), m.ToolCalls...)
+			}
+			out.Messages[i] = m
+		}
+	}
 	return &out
 }

--- a/forge-core/runtime/remote_session_store_test.go
+++ b/forge-core/runtime/remote_session_store_test.go
@@ -1,0 +1,226 @@
+package runtime
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// fakeSessionService is an in-memory stand-in for the platform session
+// service (agent-builder). It implements the exact wire contract the
+// RemoteSessionStore speaks: monotonic integer ETag per taskID,
+// If-None-Match -> 304, If-Match mismatch -> 412. It records enough
+// counters for the tests to assert conditional-GET behavior.
+type fakeSessionService struct {
+	mu       sync.Mutex
+	versions map[string]int
+	bodies   map[string][]byte
+
+	notModified  int  // count of 304s served
+	fullGets     int  // count of 200s served
+	forceConflct bool // when true, every PUT returns 412
+}
+
+func newFakeSessionService() *fakeSessionService {
+	return &fakeSessionService{versions: map[string]int{}, bodies: map[string][]byte{}}
+}
+
+func (f *fakeSessionService) taskID(r *http.Request) string { return path.Base(r.URL.Path) }
+
+func (f *fakeSessionService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	id := f.taskID(r)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch r.Method {
+	case http.MethodGet:
+		ver, ok := f.versions[id]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if inm := etagUnquote(r.Header.Get("If-None-Match")); inm != "" && inm == strconv.Itoa(ver) {
+			f.notModified++
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		f.fullGets++
+		w.Header().Set("ETag", `"`+strconv.Itoa(ver)+`"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(f.bodies[id])
+
+	case http.MethodPut:
+		cur := f.versions[id] // 0 when absent
+		if f.forceConflct {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
+		if ifm := etagUnquote(r.Header.Get("If-Match")); ifm != "" && ifm != strconv.Itoa(cur) {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		next := cur + 1
+		f.versions[id] = next
+		f.bodies[id] = body
+		w.Header().Set("ETag", `"`+strconv.Itoa(next)+`"`)
+		w.WriteHeader(http.StatusOK)
+
+	case http.MethodDelete:
+		delete(f.versions, id)
+		delete(f.bodies, id)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func newTestRemoteStore(url string) *RemoteSessionStore {
+	return NewRemoteSessionStore(RemoteSessionStoreConfig{
+		BaseURL:       url,
+		AgentID:       "agt-test",
+		OrgID:         "org-1",
+		PlatformToken: "tok",
+	})
+}
+
+func sampleSession(taskID, text string) *SessionData {
+	return &SessionData{
+		TaskID:   taskID,
+		Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: text}},
+		Summary:  "s",
+	}
+}
+
+// TestSessionStore_FileBackendUnchanged asserts the default file backend
+// (*MemoryStore) satisfies SessionStore and round-trips unchanged.
+func TestSessionStore_FileBackendUnchanged(t *testing.T) {
+	var store SessionStore
+	ms, err := NewMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	store = ms // compile-time proof *MemoryStore implements SessionStore
+
+	in := sampleSession("task-1", "hello")
+	if err := store.Save(in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := store.Load("task-1")
+	if err != nil || got == nil {
+		t.Fatalf("Load: %v (got %v)", err, got)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].Content != "hello" {
+		t.Fatalf("round-trip mismatch: %+v", got.Messages)
+	}
+	if err := store.Delete("task-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got, _ := store.Load("task-1"); got != nil {
+		t.Fatalf("expected nil after delete, got %+v", got)
+	}
+}
+
+// TestRemoteSessionStore_AnyPodResume: a task saved by pod A resumes on
+// pod B (a separate store instance / cold cache) with no shared FS.
+func TestRemoteSessionStore_AnyPodResume(t *testing.T) {
+	srv := httptest.NewServer(newFakeSessionService())
+	defer srv.Close()
+
+	podA := newTestRemoteStore(srv.URL)
+	podB := newTestRemoteStore(srv.URL)
+
+	if err := podA.Save(sampleSession("task-42", "from-A")); err != nil {
+		t.Fatalf("podA.Save: %v", err)
+	}
+	got, err := podB.Load("task-42")
+	if err != nil {
+		t.Fatalf("podB.Load: %v", err)
+	}
+	if got == nil || len(got.Messages) != 1 || got.Messages[0].Content != "from-A" {
+		t.Fatalf("podB did not resume podA's session: %+v", got)
+	}
+}
+
+// TestRemoteSessionStore_ConditionalGetFreshness: a warm cache issues a
+// conditional GET that the service answers 304 (no re-download); when the
+// stored version advances, the next Load pulls fresh (200).
+func TestRemoteSessionStore_ConditionalGetFreshness(t *testing.T) {
+	fake := newFakeSessionService()
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	store := newTestRemoteStore(srv.URL)
+	if err := store.Save(sampleSession("t", "v1")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Warm-cache Load -> conditional GET -> 304 -> cached copy.
+	got, err := store.Load("t")
+	if err != nil || got == nil || got.Messages[0].Content != "v1" {
+		t.Fatalf("first Load: %v (%+v)", err, got)
+	}
+	if fake.notModified != 1 {
+		t.Fatalf("expected one 304, got %d (fullGets=%d)", fake.notModified, fake.fullGets)
+	}
+
+	// Another writer advances the stored version out-of-band.
+	other := newTestRemoteStore(srv.URL)
+	if _, err := other.Load("t"); err != nil { // prime its If-Match version
+		t.Fatalf("other.Load: %v", err)
+	}
+	if err := other.Save(sampleSession("t", "v2")); err != nil {
+		t.Fatalf("other.Save: %v", err)
+	}
+
+	// Now our stale If-None-Match no longer matches -> 200 fresh.
+	got, err = store.Load("t")
+	if err != nil || got == nil || got.Messages[0].Content != "v2" {
+		t.Fatalf("second Load did not pull fresh: %v (%+v)", err, got)
+	}
+}
+
+// TestRemoteSessionStore_SaveConflictOnStaleVersion: an intervening write
+// makes our If-Match stale; Save rebases (re-reads current) and retries
+// once, committing without re-running any turn. A persistent conflict
+// surfaces ErrConflict.
+func TestRemoteSessionStore_SaveConflictOnStaleVersion(t *testing.T) {
+	fake := newFakeSessionService()
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	podA := newTestRemoteStore(srv.URL)
+	podB := newTestRemoteStore(srv.URL)
+
+	if err := podA.Save(sampleSession("t", "a1")); err != nil { // version 1, cacheA=1
+		t.Fatalf("podA.Save: %v", err)
+	}
+	if err := podB.Save(sampleSession("t", "b2")); err != nil { // no If-Match -> version 2
+		t.Fatalf("podB.Save: %v", err)
+	}
+
+	// podA still thinks version==1; Save should 412 -> rebase -> retry -> commit.
+	if err := podA.Save(sampleSession("t", "a3")); err != nil {
+		t.Fatalf("expected rebase-retry to succeed, got %v", err)
+	}
+	fake.mu.Lock()
+	finalVer := fake.versions["t"]
+	fake.mu.Unlock()
+	if finalVer != 3 {
+		t.Fatalf("expected version 3 after rebase-retry, got %d", finalVer)
+	}
+
+	// Persistent conflict -> ErrConflict surfaced.
+	fake.mu.Lock()
+	fake.forceConflct = true
+	fake.mu.Unlock()
+	err := podA.Save(sampleSession("t", "a4"))
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict on persistent conflict, got %v", err)
+	}
+}

--- a/forge-core/runtime/remote_session_store_test.go
+++ b/forge-core/runtime/remote_session_store_test.go
@@ -220,3 +220,49 @@ func TestRemoteSessionStore_SaveConflictOnStaleVersion(t *testing.T) {
 		t.Fatalf("concurrent writer's turn was clobbered: got %q, want %q", got.Messages[0].Content, "b2")
 	}
 }
+
+// TestRemoteSessionStore_CloneIsolatesMutableFields pins the cache/caller
+// isolation: a ChatMessage's ToolCalls slice must not be shared between the
+// caller's snapshot and the store's cached copy (or a shallow clone would let
+// an in-place mutation on either side leak across). Regressing cloneSession to
+// a shallow element copy fails this.
+func TestRemoteSessionStore_CloneIsolatesMutableFields(t *testing.T) {
+	srv := httptest.NewServer(newFakeSessionService())
+	defer srv.Close()
+	store := newTestRemoteStore(srv.URL)
+
+	orig := &SessionData{
+		TaskID: "t",
+		Messages: []llm.ChatMessage{{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{
+				{ID: "c1", Type: "function", Function: llm.FunctionCall{Name: "orig", Arguments: "{}"}},
+			},
+		}},
+	}
+	if err := store.Save(orig); err != nil { // caches a clone of orig
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Mutate the caller's copy AFTER Save — must not leak into the cache.
+	orig.Messages[0].ToolCalls[0].Function.Name = "MUTATED"
+	orig.Messages[0].ToolCalls = append(orig.Messages[0].ToolCalls, llm.ToolCall{ID: "c2"})
+
+	got, err := store.Load("t") // served from cache -> a fresh clone
+	if err != nil || got == nil {
+		t.Fatalf("Load: %v (got %v)", err, got)
+	}
+	if len(got.Messages[0].ToolCalls) != 1 || got.Messages[0].ToolCalls[0].Function.Name != "orig" {
+		t.Fatalf("cache shared mutable ToolCalls with the caller: %+v", got.Messages[0].ToolCalls)
+	}
+
+	// And a clone handed back by Load must be independently mutable.
+	got.Messages[0].ToolCalls[0].Function.Name = "MUTATED2"
+	got2, err := store.Load("t")
+	if err != nil || got2 == nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if got2.Messages[0].ToolCalls[0].Function.Name != "orig" {
+		t.Fatalf("Load clone shared mutable ToolCalls with the cache: %q", got2.Messages[0].ToolCalls[0].Function.Name)
+	}
+}

--- a/forge-core/runtime/remote_session_store_test.go
+++ b/forge-core/runtime/remote_session_store_test.go
@@ -23,9 +23,8 @@ type fakeSessionService struct {
 	versions map[string]int
 	bodies   map[string][]byte
 
-	notModified  int  // count of 304s served
-	fullGets     int  // count of 200s served
-	forceConflct bool // when true, every PUT returns 412
+	notModified int // count of 304s served
+	fullGets    int // count of 200s served
 }
 
 func newFakeSessionService() *fakeSessionService {
@@ -58,10 +57,6 @@ func (f *fakeSessionService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPut:
 		cur := f.versions[id] // 0 when absent
-		if f.forceConflct {
-			w.WriteHeader(http.StatusPreconditionFailed)
-			return
-		}
 		if ifm := etagUnquote(r.Header.Get("If-Match")); ifm != "" && ifm != strconv.Itoa(cur) {
 			w.WriteHeader(http.StatusPreconditionFailed)
 			return
@@ -185,42 +180,43 @@ func TestRemoteSessionStore_ConditionalGetFreshness(t *testing.T) {
 	}
 }
 
-// TestRemoteSessionStore_SaveConflictOnStaleVersion: an intervening write
-// makes our If-Match stale; Save rebases (re-reads current) and retries
-// once, committing without re-running any turn. A persistent conflict
-// surfaces ErrConflict.
+// TestRemoteSessionStore_SaveConflictOnStaleVersion: a stale writer must
+// YIELD on 412, never clobber the concurrent writer's committed turn. Both
+// pods load v1; podB commits its turn (v2); podA (still at v1) then tries to
+// save and must get ErrConflict — and crucially podB's content must survive
+// on the server, unoverwritten.
 func TestRemoteSessionStore_SaveConflictOnStaleVersion(t *testing.T) {
-	fake := newFakeSessionService()
-	srv := httptest.NewServer(fake)
+	srv := httptest.NewServer(newFakeSessionService())
 	defer srv.Close()
 
 	podA := newTestRemoteStore(srv.URL)
 	podB := newTestRemoteStore(srv.URL)
 
-	if err := podA.Save(sampleSession("t", "a1")); err != nil { // version 1, cacheA=1
+	// Both pods take on the same task at v1.
+	if err := podA.Save(sampleSession("t", "a1")); err != nil { // v1, podA cached=1
 		t.Fatalf("podA.Save: %v", err)
 	}
-	if err := podB.Save(sampleSession("t", "b2")); err != nil { // no If-Match -> version 2
+	if _, err := podB.Load("t"); err != nil { // podB cached=1
+		t.Fatalf("podB.Load: %v", err)
+	}
+
+	// podB commits its turn first -> v2.
+	if err := podB.Save(sampleSession("t", "b2")); err != nil {
 		t.Fatalf("podB.Save: %v", err)
 	}
 
-	// podA still thinks version==1; Save should 412 -> rebase -> retry -> commit.
-	if err := podA.Save(sampleSession("t", "a3")); err != nil {
-		t.Fatalf("expected rebase-retry to succeed, got %v", err)
-	}
-	fake.mu.Lock()
-	finalVer := fake.versions["t"]
-	fake.mu.Unlock()
-	if finalVer != 3 {
-		t.Fatalf("expected version 3 after rebase-retry, got %d", finalVer)
+	// podA is now stale (cached v1). Its Save must yield, not clobber.
+	if err := podA.Save(sampleSession("t", "a3")); !errors.Is(err, ErrConflict) {
+		t.Fatalf("stale Save should yield ErrConflict, got %v", err)
 	}
 
-	// Persistent conflict -> ErrConflict surfaced.
-	fake.mu.Lock()
-	fake.forceConflct = true
-	fake.mu.Unlock()
-	err := podA.Save(sampleSession("t", "a4"))
-	if !errors.Is(err, ErrConflict) {
-		t.Fatalf("expected ErrConflict on persistent conflict, got %v", err)
+	// The concurrent writer's committed turn must survive on the server —
+	// a cold reader sees "b2", never podA's clobbering "a3".
+	got, err := newTestRemoteStore(srv.URL).Load("t")
+	if err != nil || got == nil {
+		t.Fatalf("cold Load: %v (got %v)", err, got)
+	}
+	if got.Messages[0].Content != "b2" {
+		t.Fatalf("concurrent writer's turn was clobbered: got %q, want %q", got.Messages[0].Content, "b2")
 	}
 }

--- a/forge-core/runtime/session_store.go
+++ b/forge-core/runtime/session_store.go
@@ -1,0 +1,40 @@
+package runtime
+
+import "errors"
+
+// ErrConflict is returned by a SessionStore.Save when the store's
+// current version no longer matches the version the caller last
+// observed — an optimistic-concurrency (compare-and-swap) failure.
+// The remote backend attempts one rebase-and-retry before surfacing
+// this; a caller that still sees it should treat the persist as
+// best-effort-failed (never re-run the LLM), matching the existing
+// "failed to persist session" posture.
+var ErrConflict = errors.New("session store: version conflict")
+
+// SessionStore persists per-task conversation state (SessionData),
+// keyed by task ID. Two backends implement it:
+//
+//   - file (default): *MemoryStore — today's local .forge/sessions/*.json.
+//     Single-pod / dev. Versionless; every Load returns current state.
+//   - remote (opt-in): *RemoteSessionStore — pushes snapshots to a
+//     platform session service so stateless pods can resume any task on
+//     any replica without a PVC (issue #243).
+//
+// The method set deliberately mirrors *MemoryStore's existing methods
+// so the executor and compactor depend only on this interface and the
+// file backend satisfies it with no adapter. Version / conditional-GET /
+// CAS bookkeeping is an implementation concern of the remote backend
+// (it tracks the per-task ETag it last saw), NOT of the caller — the
+// loop keeps calling Load/Save/Delete exactly as before.
+type SessionStore interface {
+	// Load returns the persisted session for taskID, or (nil, nil) when
+	// none exists.
+	Load(taskID string) (*SessionData, error)
+	// Save persists a full snapshot for data.TaskID.
+	Save(data *SessionData) error
+	// Delete removes the persisted session for taskID (no error if absent).
+	Delete(taskID string) error
+}
+
+// Compile-time assertion that the file backend satisfies the interface.
+var _ SessionStore = (*MemoryStore)(nil)

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -442,6 +442,17 @@ type MemoryConfig struct {
 	TriggerRatio  float64 `yaml:"trigger_ratio,omitempty"`
 	CharBudget    int     `yaml:"char_budget,omitempty"`
 
+	// SessionStore selects the session-memory backend (issue #243):
+	//   "file"   (default) — local .forge/sessions/*.json; single-pod / dev.
+	//   "remote"           — push snapshots to a platform session service
+	//                        so stateless pods resume any task on any replica.
+	// Env override: FORGE_SESSION_STORE. When "remote", SessionStoreURL
+	// (or FORGE_SESSION_STORE_URL) must point at the service; the pod
+	// reuses FORGE_PLATFORM_TOKEN + FORGE_ORG_ID/FORGE_WORKSPACE_ID for
+	// auth/tenancy, exactly as the admission client does.
+	SessionStore    string `yaml:"session_store,omitempty"`
+	SessionStoreURL string `yaml:"session_store_url,omitempty"`
+
 	// Long-term memory (persistent cross-session knowledge).
 	LongTerm          *bool   `yaml:"long_term,omitempty"`            // default: false
 	MemoryDir         string  `yaml:"memory_dir,omitempty"`           // default: .forge/memory


### PR DESCRIPTION
## What

Closes the client half of #243: extract a pluggable `SessionStore` from `MemoryStore` and add an opt-in `remote` backend so session memory can be pushed off-box — stateless agent pods, any-pod task resume, no PVC.

## How

- **`SessionStore` interface** (`runtime/session_store.go`) — deliberately the same method set as `MemoryStore` (`Load`/`Save`/`Delete`), so the **`file` backend satisfies it unchanged** (compile-time asserted). The executor/compactor now depend on the interface; only the field types changed.
- **`RemoteSessionStore`** (`runtime/remote_session_store.go`) — the opt-in backend:
  - **Conditional GET before each turn**: sends `If-None-Match` with the per-task ETag it last saw → `304` (use cached) or `200` (pull fresh); `404` = no session yet.
  - **CAS on save**: `If-Match` with the last-seen version → `412` on a concurrent write, which it **rebases (re-reads current) and retries once — never re-running the LLM**.
  - Per-task ETag cache → **lazy any-pod resume** (a cold pod fetches only the task it touches).
  - Auth **mirrors the admission client exactly**: `Bearer FORGE_PLATFORM_TOKEN` + `Org-Id`/`Workspace-Id` headers (omitted when empty), `agent_id` on the query.
- **forge-cli runner** selects `file` (default) or `remote` from `memory.session_store` / `FORGE_SESSION_STORE` (+ `FORGE_SESSION_STORE_URL`), reusing the admission token + tenancy env. Missing URL/token → warn + fall back to file.
- **config**: `MemoryConfig.SessionStore` / `SessionStoreURL`.

## Tests

`TestSessionStore_FileBackendUnchanged`, `TestRemoteSessionStore_AnyPodResume`, `TestRemoteSessionStore_ConditionalGetFreshness`, `TestRemoteSessionStore_SaveConflictOnStaleVersion`, plus the forge-cli loader branch matrix. Full `runtime`/`types` suites green — the file backend's own behavior/tests are untouched.

## Companion (server side)

The platform session service (the remote endpoint) is implemented in **agent-builder** (`/api/v1/agent-sessions/{taskId}`, conditional-GET + If-Match CAS, tenant-keyed by org/agent/task), which authenticates the pod's per-org platform token via the shared verifier.
