### PR TITLE
feat(security): rolling-window intent drift detector (closes #214)

### DIFF
--- a/docs/security/intent-alignment.md
+++ b/docs/security/intent-alignment.md
@@ -132,6 +132,78 @@ resulting cosine crosses the audit boundary.
   spurious high scores. Treat the embedder as part of your trust
   boundary — the same posture as any critical LLM provider.
 
+## Drift tracking (governance R7 / #214)
+
+Alignment is a per-action check. **Drift** is longitudinal — it
+watches the trend of alignment scores across many tool calls and
+flags the pattern of an agent progressively wandering from the
+stated intent even if each individual call scores above the R3
+threshold.
+
+Enable it alongside the R3 check:
+
+```yaml
+security:
+  intent_alignment:
+    enabled: true
+    provider: openai
+    model: text-embedding-3-small
+    threshold: 0.5
+    hard_threshold: 0.3
+
+  intent_drift:
+    enabled: true
+    window: 5              # last N scores considered
+    drift_threshold: 0.35  # rolling mean floor
+    monotone_n: 3          # additionally flag N-consecutive descents
+```
+
+The analyzer records every R3 score into a per-task ring buffer and
+flags drift when the last `window` scores' mean falls strictly below
+`drift_threshold`, OR the last `monotone_n` scores are strictly
+decreasing (the "boiling frog" pattern where each individual step is
+above the R3 threshold but the trend is unmistakably down).
+
+`intent_drift` events are **state-transition** — one event fires
+when the task first enters drift, one fires when it recovers.
+Long-drift stretches don't flood the audit stream.
+
+Fail-closed observations from R3 (embedder unavailable, unknown
+task) contribute to the drift ring too, treated as `-1` for the
+mean — a run of R3 failures surfaces as drift rather than
+invisible.
+
+### Audit event
+
+```json
+{
+  "event": "intent_drift",
+  "task_id": "task-abc",
+  "fields": {
+    "tool": "cli_execute",
+    "severity": "mean_below_threshold",
+    "transition": "entered",
+    "mean": 0.221,
+    "window": 5
+  }
+}
+```
+
+Severity is one of:
+
+- `mean_below_threshold` — rolling mean crossed `drift_threshold`.
+- `monotone_decrease` — last `monotone_n` scores strictly decreasing.
+- `both` — both signals fired on the same call.
+- `recovered` — task exited drift (only for `transition: "recovered"`).
+
+### Drift is telemetry, not a policy gate
+
+`intent_drift` never denies a tool call directly. Drift is meant
+for alerting and post-hoc audit; the R3 `hard_threshold` is where
+you enforce a stop. If you want drift to also stop the task, forward
+`intent_drift entered` events from your SIEM to a workflow that
+sets the R3 `hard_threshold` closer to the observed mean.
+
 Combine R3 alignment with R4a MODIFY (#209) + audit signing (#213) +
-hash chaining (#212) + JIT credentials (#215) for the governance
-framework's Section 3–9 story.
+hash chaining (#212) + JIT credentials (#215) + R7 drift (#214) for
+the governance framework's Section 3–9 story.

--- a/docs/security/intent-alignment.md
+++ b/docs/security/intent-alignment.md
@@ -164,6 +164,18 @@ flags drift when the last `window` scores' mean falls strictly below
 decreasing (the "boiling frog" pattern where each individual step is
 above the R3 threshold but the trend is unmistakably down).
 
+> **`monotone_n` must be ≤ `window`.** The ring buffer holds only
+> `window` scores; if `monotone_n > window` the monotone check has
+> nothing to look at and never fires. Startup rejects the misconfig
+> rather than silently disabling one half of the detector — an
+> operator asked for slow-drift detection and needs to know if they
+> can't get it.
+
+> **`drift_threshold: 0` is preserved.** Since scores live on cosine's
+> `[-1,1]` range, `0` is a meaningful floor (flag only when the mean
+> goes negative). The field is a `*float64` — unset uses the 0.35
+> default, an explicit `0` stays `0`.
+
 `intent_drift` events are **state-transition** — one event fires
 when the task first enters drift, one fires when it recovers.
 Long-drift stretches don't flood the audit stream.

--- a/forge-cli/runtime/intent_alignment.go
+++ b/forge-cli/runtime/intent_alignment.go
@@ -68,12 +68,29 @@ func (r *Runner) buildIntentEngine() (*intent.Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building embedder: %w", err)
 	}
-	return intent.New(intent.Config{
+	// R7 (#214) drift analyzer — opt-in on top of R3. Requires
+	// alignment to also be enabled; NewWithDrift enforces that.
+	driftCfg := r.cfg.Config.Security.IntentDrift
+	drift := intent.DriftConfig{
+		Enabled:        driftCfg.Enabled,
+		Window:         driftCfg.Window,
+		DriftThreshold: driftCfg.DriftThreshold,
+		MonotoneN:      driftCfg.MonotoneN,
+	}
+	if drift.Enabled {
+		if drift.Window == 0 {
+			drift.Window = 5
+		}
+		if drift.DriftThreshold == 0 {
+			drift.DriftThreshold = 0.35
+		}
+	}
+	return intent.NewWithDrift(intent.Config{
 		Enabled:       true,
 		Threshold:     threshold,
 		HardThreshold: hardThreshold,
 		CacheSize:     cfg.CacheSize,
-	}, embedder)
+	}, drift, embedder)
 }
 
 // registerIntentAlignmentHook wires the BeforeToolExec hook that
@@ -138,6 +155,25 @@ func (r *Runner) registerIntentAlignmentHook(hooks *coreruntime.HookRegistry, re
 			TaskID:        hctx.TaskID,
 			Fields:        fields,
 		})
+
+		// R7 (#214): the analyzer returns a non-nil Drift signal
+		// ONLY on state transitions (entered / recovered). Emit
+		// the intent_drift event alongside the per-call alignment
+		// event so SIEM queries can join on task_id.
+		if res.Drift != nil {
+			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+				Event:         coreruntime.AuditIntentDrift,
+				CorrelationID: hctx.CorrelationID,
+				TaskID:        hctx.TaskID,
+				Fields: map[string]any{
+					"tool":       hctx.ToolName,
+					"severity":   res.Drift.Severity,
+					"transition": res.Drift.Transition,
+					"mean":       res.Drift.Mean,
+					"window":     res.Drift.Window,
+				},
+			})
+		}
 
 		if res.Decision == intent.DecisionDeny {
 			return fmt.Errorf("intent_alignment: %s", res.Reason)

--- a/forge-cli/runtime/intent_alignment.go
+++ b/forge-cli/runtime/intent_alignment.go
@@ -70,20 +70,24 @@ func (r *Runner) buildIntentEngine() (*intent.Engine, error) {
 	}
 	// R7 (#214) drift analyzer — opt-in on top of R3. Requires
 	// alignment to also be enabled; NewWithDrift enforces that.
+	//
+	// drift_threshold is a pointer so an operator can distinguish
+	// "unset, apply default" from "explicit 0" — 0 is a
+	// meaningful floor on cosine's [-1,1] range and used to
+	// silently collide with the zero-value default (0.35).
 	driftCfg := r.cfg.Config.Security.IntentDrift
 	drift := intent.DriftConfig{
-		Enabled:        driftCfg.Enabled,
-		Window:         driftCfg.Window,
-		DriftThreshold: driftCfg.DriftThreshold,
-		MonotoneN:      driftCfg.MonotoneN,
+		Enabled:   driftCfg.Enabled,
+		Window:    driftCfg.Window,
+		MonotoneN: driftCfg.MonotoneN,
 	}
-	if drift.Enabled {
-		if drift.Window == 0 {
-			drift.Window = 5
-		}
-		if drift.DriftThreshold == 0 {
-			drift.DriftThreshold = 0.35
-		}
+	if driftCfg.DriftThreshold != nil {
+		drift.DriftThreshold = *driftCfg.DriftThreshold
+	} else if drift.Enabled {
+		drift.DriftThreshold = 0.35
+	}
+	if drift.Enabled && drift.Window == 0 {
+		drift.Window = 5
 	}
 	return intent.NewWithDrift(intent.Config{
 		Enabled:       true,

--- a/forge-cli/runtime/intent_drift_test.go
+++ b/forge-cli/runtime/intent_drift_test.go
@@ -1,0 +1,80 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// TestIntentDriftConfig_ThresholdZeroPreserved pins the fix for the
+// same zero-value-as-unset bug that Manoj flagged on #245, applied
+// to R7's `drift_threshold`. Explicit `drift_threshold: 0` used to
+// be silently overridden to 0.35 by `buildIntentEngine`, so an
+// operator who wanted "flag drift only when the mean goes negative"
+// couldn't express that.
+func TestIntentDriftConfig_ThresholdZeroPreserved(t *testing.T) {
+	yamlSrc := `
+agent_id: intent-drift-zero-threshold
+version: 0.1.0
+framework: forge
+entrypoint: main.py
+security:
+  intent_alignment:
+    enabled: true
+    provider: openai
+    model: text-embedding-3-small
+  intent_drift:
+    enabled: true
+    window: 5
+    drift_threshold: 0
+    monotone_n: 3
+`
+	cfg, err := types.ParseForgeConfig([]byte(yamlSrc))
+	if err != nil {
+		t.Fatalf("ParseForgeConfig: %v", err)
+	}
+	id := cfg.Security.IntentDrift
+	if id.DriftThreshold == nil {
+		t.Fatal("drift_threshold: 0 must materialize as a non-nil *float64 — pointer-zero collapsed to nil")
+	}
+	if *id.DriftThreshold != 0 {
+		t.Errorf("drift_threshold: got %f, want 0", *id.DriftThreshold)
+	}
+
+	// Simulate the runner's defaulting path — same nil-check logic
+	// as buildIntentEngine — and confirm the explicit 0 survives.
+	driftThreshold := 0.35
+	if id.DriftThreshold != nil {
+		driftThreshold = *id.DriftThreshold
+	}
+	if driftThreshold != 0 {
+		t.Errorf("runner defaulting collapsed explicit 0: got %f", driftThreshold)
+	}
+}
+
+// TestIntentDriftConfig_ThresholdUnsetGetsDefault pins the other
+// half: nil pointer means "unset, apply 0.35 default."
+func TestIntentDriftConfig_ThresholdUnsetGetsDefault(t *testing.T) {
+	yamlSrc := `
+agent_id: intent-drift-defaults
+version: 0.1.0
+framework: forge
+entrypoint: main.py
+security:
+  intent_alignment:
+    enabled: true
+    provider: openai
+    model: text-embedding-3-small
+  intent_drift:
+    enabled: true
+    window: 5
+`
+	cfg, err := types.ParseForgeConfig([]byte(yamlSrc))
+	if err != nil {
+		t.Fatalf("ParseForgeConfig: %v", err)
+	}
+	if cfg.Security.IntentDrift.DriftThreshold != nil {
+		t.Errorf("drift_threshold should be nil when omitted, got %v",
+			cfg.Security.IntentDrift.DriftThreshold)
+	}
+}

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -91,6 +91,24 @@ const (
 	// scored decision. See docs/security/intent-alignment.md.
 	AuditIntentAlignment = "intent_alignment"
 
+	// AuditIntentDrift is emitted when the R7 (#214) rolling-window
+	// drift analyzer detects a state transition — either the task
+	// entered drift (mean-below-threshold OR monotone-decrease) or
+	// recovered. State-transition semantics keep the audit stream
+	// from flooding during a long drift stretch: one event on entry,
+	// one on recovery.
+	//
+	// Fields:
+	//   - tool       : the tool call that tripped the transition
+	//   - severity   : "mean_below_threshold" | "monotone_decrease" |
+	//                  "both" | "recovered"
+	//   - transition : "entered" | "recovered"
+	//   - mean       : rolling-window mean at trip time
+	//   - window     : the configured window size
+	// Payload never carries the individual scores. See
+	// docs/security/intent-alignment.md (drift section).
+	AuditIntentDrift = "intent_drift"
+
 	// AuditPolicyLoaded is emitted once at agent startup when a
 	// non-zero platform policy is present. Carries a summary of the
 	// effective policy (sizes of deny lists, max bounds) so audit

--- a/forge-core/security/intent/drift.go
+++ b/forge-core/security/intent/drift.go
@@ -50,6 +50,16 @@ func (c DriftConfig) Validate() error {
 	if c.MonotoneN < 0 || (c.MonotoneN > 0 && c.MonotoneN < 2) {
 		return fmt.Errorf("intent_drift: monotone_n %d invalid (must be 0 or ≥ 2)", c.MonotoneN)
 	}
+	// The ring holds only Window scores. If MonotoneN > Window,
+	// checkMonotoneDown's `len(scores) < n` guard is permanently
+	// true and the monotone check silently never fires — an
+	// operator would believe they have slow-drift detection while
+	// having none. Reject rather than clamp so the misconfig is
+	// visible at startup.
+	if c.MonotoneN > c.Window {
+		return fmt.Errorf("intent_drift: monotone_n %d > window %d (ring never accumulates enough scores for the monotone check to trip; either raise window or lower monotone_n)",
+			c.MonotoneN, c.Window)
+	}
 	return nil
 }
 

--- a/forge-core/security/intent/drift.go
+++ b/forge-core/security/intent/drift.go
@@ -1,0 +1,235 @@
+package intent
+
+import (
+	"fmt"
+	"math"
+	"sync"
+)
+
+// DriftConfig configures the R7 (#214) rolling-window drift signal.
+// Where the R3 alignment check is a per-call policy gate, drift is
+// longitudinal telemetry — it watches the sequence of alignment
+// scores accumulating for a task and flags trends that suggest the
+// agent is progressively wandering from the stated intent.
+type DriftConfig struct {
+	// Enabled turns the analyzer on. When false, RecordAndCheck is
+	// a no-op and no drift signals fire.
+	Enabled bool
+
+	// Window is the number of most-recent scores considered by the
+	// rolling-mean test. Must be ≥ 2 — a window of 1 can't
+	// distinguish "trending down" from "just low."
+	Window int
+
+	// DriftThreshold is the mean-score floor. When the rolling
+	// window mean falls strictly below this value, drift enters
+	// the "mean_below_threshold" state.
+	DriftThreshold float64
+
+	// MonotoneN, when non-zero, additionally trips drift when the
+	// last N scores are strictly decreasing (even if the mean is
+	// still above DriftThreshold). Catches slow-boil patterns
+	// where each individual step is small but cumulative drift is
+	// large. Zero disables the monotone check.
+	MonotoneN int
+}
+
+// Validate returns an error when DriftConfig would produce
+// nonsensical decisions. Called at Engine construction so runners
+// fail startup rather than at first RecordAndCheck.
+func (c DriftConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Window < 2 {
+		return fmt.Errorf("intent_drift: window %d < 2 (can't distinguish trend from magnitude)", c.Window)
+	}
+	if c.DriftThreshold < -1 || c.DriftThreshold > 1 {
+		return fmt.Errorf("intent_drift: drift_threshold %.3f outside [-1,1]", c.DriftThreshold)
+	}
+	if c.MonotoneN < 0 || (c.MonotoneN > 0 && c.MonotoneN < 2) {
+		return fmt.Errorf("intent_drift: monotone_n %d invalid (must be 0 or ≥ 2)", c.MonotoneN)
+	}
+	return nil
+}
+
+// DriftSignal describes a drift-state transition. Populated on
+// engine.Score's return value when a state change happens on that
+// call; nil otherwise. The runner emits an `intent_drift` audit
+// event iff Signal != nil.
+//
+// State-transition emission (rather than "emit every call while in
+// drift") keeps the audit stream from flooding — one event when the
+// task first crosses into drift, one when it recovers.
+type DriftSignal struct {
+	// Severity is the human-readable classification. One of
+	// "mean_below_threshold", "monotone_decrease", "both", or
+	// "recovered" (transition OUT of drift).
+	Severity string
+
+	// Mean is the rolling-window mean of the last Window scores at
+	// the moment the signal fired. Included on both entry and
+	// recovery transitions for the audit event.
+	Mean float64
+
+	// Window is the number of scores in the mean.
+	Window int
+
+	// Transition is "entered" for on-entry signals or "recovered"
+	// for the exit signal. Makes SIEM queries "when did I go into
+	// drift?" trivial.
+	Transition string
+}
+
+// driftState is the per-task ring buffer + last-known-in-drift flag.
+type driftState struct {
+	// scores is a ring buffer (append + trim); order oldest→newest.
+	scores  []float64
+	inDrift bool
+}
+
+// analyzer is the drift coordinator. Owned by the Engine and gated
+// by the same mutex as the intent map (locking is coarse but
+// score-recording is cheap; the per-task ring stays small).
+type analyzer struct {
+	cfg DriftConfig
+	mu  sync.Mutex
+	// keyed by taskID; entries live as long as the task's intent
+	// entry — Forget also clears drift state for the task.
+	states map[string]*driftState
+}
+
+func newAnalyzer(cfg DriftConfig) *analyzer {
+	if !cfg.Enabled {
+		return nil // sentinel: engine treats nil analyzer as "off"
+	}
+	return &analyzer{
+		cfg:    cfg,
+		states: make(map[string]*driftState),
+	}
+}
+
+// enabled reports whether the analyzer is armed. Nil-safe.
+func (a *analyzer) enabled() bool { return a != nil && a.cfg.Enabled }
+
+// record inserts `score` into the task's ring and returns a
+// DriftSignal iff the state changed (entered or recovered from
+// drift). NaN scores (from R3 fail-closed paths) are recorded as-is
+// so the ring reflects the operator's true observation history; the
+// trip checks handle NaN by treating it as below-threshold (the
+// engine failed closed for a reason).
+func (a *analyzer) record(taskID string, score float64) *DriftSignal {
+	if !a.enabled() {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	st, ok := a.states[taskID]
+	if !ok {
+		st = &driftState{scores: make([]float64, 0, a.cfg.Window)}
+		a.states[taskID] = st
+	}
+	st.scores = append(st.scores, score)
+	if len(st.scores) > a.cfg.Window {
+		st.scores = st.scores[len(st.scores)-a.cfg.Window:]
+	}
+
+	// Not enough history to make a determination.
+	if len(st.scores) < a.cfg.Window {
+		return nil
+	}
+
+	meanBelow, mean := a.checkMeanBelow(st.scores)
+	monotoneDown := a.checkMonotoneDown(st.scores)
+	inDriftNow := meanBelow || monotoneDown
+
+	if inDriftNow && !st.inDrift {
+		st.inDrift = true
+		return &DriftSignal{
+			Severity:   driftSeverity(meanBelow, monotoneDown),
+			Mean:       mean,
+			Window:     a.cfg.Window,
+			Transition: "entered",
+		}
+	}
+	if !inDriftNow && st.inDrift {
+		st.inDrift = false
+		return &DriftSignal{
+			Severity:   "recovered",
+			Mean:       mean,
+			Window:     a.cfg.Window,
+			Transition: "recovered",
+		}
+	}
+	return nil
+}
+
+// forget clears any drift state for the given task.
+func (a *analyzer) forget(taskID string) {
+	if !a.enabled() {
+		return
+	}
+	a.mu.Lock()
+	delete(a.states, taskID)
+	a.mu.Unlock()
+}
+
+// checkMeanBelow returns (crosses, mean). Treats NaN scores as 0
+// for the mean so a fail-closed emit contributes to drift rather
+// than silently disappearing.
+func (a *analyzer) checkMeanBelow(scores []float64) (bool, float64) {
+	if len(scores) == 0 {
+		return false, 0
+	}
+	var sum float64
+	for _, s := range scores {
+		if math.IsNaN(s) {
+			// Treat fail-closed observations as maximally-mis
+			// aligned for drift purposes. Symmetric with the R3
+			// hook, which returns Deny in the same case.
+			sum += -1
+			continue
+		}
+		sum += s
+	}
+	mean := sum / float64(len(scores))
+	return mean < a.cfg.DriftThreshold, mean
+}
+
+// checkMonotoneDown returns true iff the last MonotoneN scores are
+// strictly decreasing. Uses the tail of the ring — a longer window
+// than MonotoneN still only checks the last MonotoneN entries.
+func (a *analyzer) checkMonotoneDown(scores []float64) bool {
+	n := a.cfg.MonotoneN
+	if n < 2 {
+		return false
+	}
+	if len(scores) < n {
+		return false
+	}
+	tail := scores[len(scores)-n:]
+	for i := 1; i < n; i++ {
+		// NaN comparisons are false → a NaN in the tail breaks
+		// the "strictly decreasing" claim, which is the correct
+		// conservative behavior.
+		if !(tail[i] < tail[i-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+// driftSeverity maps the (meanBelow, monotoneDown) combination to
+// the audit-facing severity token.
+func driftSeverity(meanBelow, monotoneDown bool) string {
+	switch {
+	case meanBelow && monotoneDown:
+		return "both"
+	case meanBelow:
+		return "mean_below_threshold"
+	case monotoneDown:
+		return "monotone_decrease"
+	default:
+		return ""
+	}
+}

--- a/forge-core/security/intent/drift_test.go
+++ b/forge-core/security/intent/drift_test.go
@@ -57,6 +57,12 @@ func TestDriftConfig_Validate(t *testing.T) {
 		{"monotone 1 rejected", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 1}, true},
 		{"monotone 0 disables", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 0}, false},
 		{"monotone 3 ok", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 3}, false},
+		// #246 review: monotone_n > window silently disabled the
+		// monotone check because the ring never accumulates enough
+		// scores to satisfy `len(scores) >= n`. Now rejected at
+		// startup so the operator sees the misconfig.
+		{"monotone_n > window rejected", DriftConfig{Enabled: true, Window: 3, DriftThreshold: 0.3, MonotoneN: 5}, true},
+		{"monotone_n == window ok", DriftConfig{Enabled: true, Window: 3, DriftThreshold: 0.3, MonotoneN: 3}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/forge-core/security/intent/drift_test.go
+++ b/forge-core/security/intent/drift_test.go
@@ -1,0 +1,365 @@
+package intent
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/llm"
+)
+
+// scriptedEmbedder returns a scripted sequence of vectors so tests
+// can drive exact cosine trajectories. Each call consumes one entry;
+// the intent (first) embed uses the "intent" script, and each
+// subsequent action embed pops from the "actions" queue.
+type scriptedEmbedder struct {
+	intent  []float32
+	actions [][]float32
+}
+
+func (s *scriptedEmbedder) Embed(_ context.Context, req *llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+	out := make([][]float32, len(req.Texts))
+	for i := range req.Texts {
+		if s.intent != nil {
+			out[i] = s.intent
+			s.intent = nil
+			continue
+		}
+		if len(s.actions) == 0 {
+			return nil, errActionsExhausted
+		}
+		out[i] = s.actions[0]
+		s.actions = s.actions[1:]
+	}
+	return &llm.EmbeddingResponse{Embeddings: out}, nil
+}
+
+func (s *scriptedEmbedder) Dimensions() int { return 3 }
+
+var errActionsExhausted = &scriptError{"scripted actions exhausted"}
+
+type scriptError struct{ msg string }
+
+func (e *scriptError) Error() string { return e.msg }
+
+// TestDriftConfig_Validate pins the config-time rejections.
+func TestDriftConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     DriftConfig
+		wantErr bool
+	}{
+		{"disabled ok", DriftConfig{}, false},
+		{"window 1 rejected", DriftConfig{Enabled: true, Window: 1, DriftThreshold: 0.3}, true},
+		{"window ok", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3}, false},
+		{"threshold out of range", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 1.5}, true},
+		{"monotone 1 rejected", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 1}, true},
+		{"monotone 0 disables", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 0}, false},
+		{"monotone 3 ok", DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3, MonotoneN: 3}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("err=%v wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestNewWithDrift_RejectsDriftWithoutAlignment guards the contract:
+// drift is derived from alignment, so operators can't enable one
+// without the other.
+func TestNewWithDrift_RejectsDriftWithoutAlignment(t *testing.T) {
+	_, err := NewWithDrift(
+		Config{Enabled: false},
+		DriftConfig{Enabled: true, Window: 5, DriftThreshold: 0.3},
+		&fakeEmbedder{},
+	)
+	if err == nil {
+		t.Fatal("expected error: drift without alignment")
+	}
+}
+
+// TestDrift_HighSimilaritySequenceNeverEmits — acceptance test (a):
+// a run of high-similarity scores stays out of drift.
+func TestDrift_HighSimilaritySequenceNeverEmits(t *testing.T) {
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 3, DriftThreshold: 0.35,
+	}, [][]float32{
+		{1, 0, 0}, // score 1.0
+		{1, 0, 0}, // score 1.0
+		{1, 0, 0}, // score 1.0
+		{1, 0, 0}, // score 1.0
+	})
+	drove := driveScores(e, 4)
+	for i, d := range drove {
+		if d != nil {
+			t.Errorf("call %d unexpectedly emitted drift: %+v", i, d)
+		}
+	}
+}
+
+// TestDrift_DecreasingSequenceTripsMeanBelow — acceptance test (b):
+// a monotonically-descending sequence that pulls the mean below
+// threshold trips drift on entry, and stays silent while in-drift
+// (state-transition semantics — no per-call flood).
+func TestDrift_DecreasingSequenceTripsMeanBelow(t *testing.T) {
+	// window=3, threshold=0.35. Feed scores 0.9, 0.6, 0.3, 0.1 —
+	// after call 3 the window is [0.9, 0.6, 0.3], mean 0.6 — no
+	// drift. After call 4 the window is [0.6, 0.3, 0.1], mean
+	// 0.333 → below 0.35 → drift entered.
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 3, DriftThreshold: 0.35,
+	}, [][]float32{
+		{1, 0, 0},     // sim 1.0 to intent {1,0,0} — call 1: no drift
+		{0.6, 0.8, 0}, // sim 0.6      — call 2: window incomplete
+		{0.3, float32(math.Sqrt(1 - 0.3*0.3)), 0}, // sim ≈0.3     — call 3: mean 0.633 > 0.35 → allow
+		{0.1, float32(math.Sqrt(1 - 0.1*0.1)), 0}, // sim 0.1      — call 4: mean 0.333 < 0.35 → drift!
+	})
+	drove := driveScores(e, 4)
+	// Calls 1-3: no drift signal.
+	for i := 0; i < 3; i++ {
+		if drove[i] != nil {
+			t.Fatalf("call %d unexpected drift: %+v", i, drove[i])
+		}
+	}
+	// Call 4: drift entered.
+	if drove[3] == nil {
+		t.Fatal("call 4 should have tripped drift entry")
+	}
+	if drove[3].Transition != "entered" || drove[3].Severity != "mean_below_threshold" {
+		t.Errorf("expected entered/mean_below_threshold, got %+v", drove[3])
+	}
+	if drove[3].Mean >= 0.35 {
+		t.Errorf("mean should be < threshold: %.3f", drove[3].Mean)
+	}
+}
+
+// TestDrift_StateTransitionOnlyEmitsOnce — while in drift and the
+// mean stays below threshold, subsequent tool calls MUST NOT emit
+// another drift signal. Alerting flood prevention.
+func TestDrift_StateTransitionOnlyEmitsOnce(t *testing.T) {
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 2, DriftThreshold: 0.5,
+	}, [][]float32{
+		{1, 0, 0}, // sim 1.0 — no drift (window incomplete)
+		{0, 1, 0}, // sim 0.0 — mean 0.5, NOT below threshold
+		{0, 1, 0}, // sim 0.0 — mean 0.0, below threshold → entered
+		{0, 1, 0}, // sim 0.0 — mean 0.0, still in drift, no new signal
+		{0, 1, 0}, // sim 0.0 — same
+	})
+	drove := driveScores(e, 5)
+	entryCount := 0
+	for _, d := range drove {
+		if d != nil && d.Transition == "entered" {
+			entryCount++
+		}
+	}
+	if entryCount != 1 {
+		t.Errorf("expected exactly 1 'entered' emission, got %d (all: %+v)", entryCount, drove)
+	}
+}
+
+// TestDrift_RecoveryEmits — once drift is entered, the mean climbing
+// back above threshold produces a "recovered" transition event.
+func TestDrift_RecoveryEmits(t *testing.T) {
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 2, DriftThreshold: 0.5,
+	}, [][]float32{
+		{1, 0, 0}, // sim 1.0
+		{0, 1, 0}, // sim 0.0 — mean 0.5, not below (strictly)
+		{0, 1, 0}, // sim 0.0 — mean 0.0 → entered
+		{1, 0, 0}, // sim 1.0 — mean 0.5, still not below strictly → recover
+	})
+	drove := driveScores(e, 4)
+	if drove[2] == nil || drove[2].Transition != "entered" {
+		t.Fatalf("expected entered on call 3, got %+v", drove[2])
+	}
+	if drove[3] == nil || drove[3].Transition != "recovered" {
+		t.Fatalf("expected recovered on call 4, got %+v", drove[3])
+	}
+}
+
+// TestDrift_MonotoneDecreaseTrips — even when the mean stays high,
+// N consecutive strictly-decreasing scores trigger drift under the
+// monotone check ("boiling frog" pattern).
+func TestDrift_MonotoneDecreaseTrips(t *testing.T) {
+	// window=5, threshold=0.1 (very low; won't trip on mean).
+	// monotone_n=3. Feed 0.9, 0.8, 0.7, 0.6, 0.5 — last 3 are
+	// strictly decreasing, mean is 0.7 (above 0.1) → drift on
+	// monotone alone.
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 5, DriftThreshold: 0.1, MonotoneN: 3,
+	}, [][]float32{
+		{1, 0, 0},                              // 1.0
+		{0.8, float32(math.Sqrt(1 - 0.64)), 0}, // 0.8
+		{0.7, float32(math.Sqrt(1 - 0.49)), 0}, // 0.7
+		{0.6, float32(math.Sqrt(1 - 0.36)), 0}, // 0.6
+		{0.5, float32(math.Sqrt(1 - 0.25)), 0}, // 0.5
+	})
+	drove := driveScores(e, 5)
+	if drove[4] == nil {
+		t.Fatal("expected drift on call 5 (monotone)")
+	}
+	if drove[4].Severity != "monotone_decrease" && drove[4].Severity != "both" {
+		t.Errorf("severity: got %q want monotone_decrease or both", drove[4].Severity)
+	}
+}
+
+// TestDrift_DisabledIsNoop — when the drift analyzer is off, Score
+// still works for R3 but never populates Result.Drift.
+func TestDrift_DisabledIsNoop(t *testing.T) {
+	e := newDriftEngine(t, DriftConfig{Enabled: false}, [][]float32{
+		{0, 1, 0}, // any low-sim score
+	})
+	res := driveScoreOnce(e, "task-x", "action-1")
+	if res.Drift != nil {
+		t.Errorf("disabled drift should never populate Result.Drift: %+v", res.Drift)
+	}
+}
+
+// TestDrift_ForgetClearsState — after Forget, the drift history is
+// gone; a new sequence starts fresh (needs Window fills again).
+func TestDrift_ForgetClearsState(t *testing.T) {
+	e := newDriftEngine(t, DriftConfig{
+		Enabled: true, Window: 2, DriftThreshold: 0.5,
+	}, [][]float32{
+		{0, 1, 0}, {0, 1, 0}, // both sim 0, enters drift on call 2
+		{0, 1, 0}, // after Forget: fresh — only 1 score → below Window → no signal
+	})
+	drove := driveScores(e, 2)
+	if drove[1] == nil {
+		t.Fatal("setup: expected drift entry on call 2")
+	}
+	// Now forget and issue a third score.
+	e.Forget("task-1")
+	res := driveScoreOnce(e, "task-1-fresh", "action-3")
+	// Need to re-register intent for the fresh task.
+	if res.Decision != DecisionDeny {
+		t.Errorf("fresh task w/o registered intent should fail closed, got %s", res.Decision)
+	}
+}
+
+// TestDrift_FailClosedScoresPullDownMean — the analyzer treats NaN
+// (fail-closed) scores as -1 for the mean. A run of embedder
+// failures MUST count as drift, not as invisible.
+func TestDrift_FailClosedScoresPullDownMean(t *testing.T) {
+	// Register a normal intent then force the actions embedder to
+	// error out.
+	pub, priv := setupIntent(t, "READ the bucket")
+	emb := &sequentiallyFailingEmbedder{intentReturn: pub, initialCalls: 1}
+	e, _ := NewWithDrift(
+		Config{Enabled: true, Threshold: 0.5, HardThreshold: 0.3},
+		DriftConfig{Enabled: true, Window: 3, DriftThreshold: 0.35},
+		emb,
+	)
+	_ = priv // unused here
+	if err := e.RegisterIntent(context.Background(), "task-1", "READ the bucket"); err != nil {
+		t.Fatalf("RegisterIntent: %v", err)
+	}
+
+	// Three failing embed calls → three NaN scores → each treated
+	// as -1 for the mean. Mean = -1 < 0.35 → drift.
+	var lastDrift *DriftSignal
+	for range 3 {
+		res := e.Score(context.Background(), "task-1", "some action")
+		if res.Drift != nil {
+			lastDrift = res.Drift
+		}
+	}
+	if lastDrift == nil {
+		t.Fatal("expected drift entry when embedder consistently fails")
+	}
+	if lastDrift.Transition != "entered" {
+		t.Errorf("expected entered, got %s", lastDrift.Transition)
+	}
+}
+
+// ---- helpers ----
+
+// newDriftEngine builds an engine with alignment always on and
+// scripted action vectors. Intent vector is fixed to {1,0,0} so
+// each action script's first coordinate is the cosine.
+func newDriftEngine(t *testing.T, drift DriftConfig, actions [][]float32) *Engine {
+	t.Helper()
+	emb := &scriptedEmbedder{
+		intent:  []float32{1, 0, 0},
+		actions: actions,
+	}
+	e, err := NewWithDrift(
+		Config{Enabled: true, Threshold: 0.5, HardThreshold: 0.05},
+		drift,
+		emb,
+	)
+	if err != nil {
+		t.Fatalf("NewWithDrift: %v", err)
+	}
+	if err := e.RegisterIntent(context.Background(), "task-1", "READ the bucket"); err != nil {
+		t.Fatalf("RegisterIntent: %v", err)
+	}
+	return e
+}
+
+// driveScores runs Score n times with a distinct action text each
+// call (so the LRU doesn't cache-hit between them) and returns the
+// list of Drift signals (nil where none).
+func driveScores(e *Engine, n int) []*DriftSignal {
+	out := make([]*DriftSignal, n)
+	for i := 0; i < n; i++ {
+		res := e.Score(context.Background(), "task-1",
+			// distinct action text per call
+			"call-"+string(rune('a'+i)))
+		out[i] = res.Drift
+	}
+	return out
+}
+
+// driveScoreOnce is the single-call helper for tests that don't
+// need a full sequence.
+func driveScoreOnce(e *Engine, taskID, action string) Result {
+	return e.Score(context.Background(), taskID, action)
+}
+
+// setupIntent generates deterministic vectors for the fail-closed test.
+// Returns (intentVector, unused). Kept lightweight so the test doesn't
+// pull in the crypto/ed25519 fakeEmbedder path.
+func setupIntent(t *testing.T, _ string) ([]float32, []float32) {
+	t.Helper()
+	return []float32{1, 0, 0}, nil
+}
+
+// sequentiallyFailingEmbedder returns the intent vector on the
+// first N calls, then errors thereafter. Simulates a working
+// embedder that goes down mid-session.
+type sequentiallyFailingEmbedder struct {
+	intentReturn []float32
+	initialCalls int
+	called       int
+}
+
+func (s *sequentiallyFailingEmbedder) Embed(_ context.Context, req *llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+	s.called += len(req.Texts)
+	if s.called <= s.initialCalls {
+		out := make([][]float32, len(req.Texts))
+		for i := range out {
+			out[i] = s.intentReturn
+		}
+		return &llm.EmbeddingResponse{Embeddings: out}, nil
+	}
+	return nil, errActionsExhausted
+}
+func (s *sequentiallyFailingEmbedder) Dimensions() int { return 3 }
+
+// jsonMustMarshal is a small helper that panics on a marshal error,
+// used only in tests where a compile-time-known input can't fail.
+func jsonMustMarshal(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+var _ = jsonMustMarshal // referenced by future assertions on audit-event payloads

--- a/forge-core/security/intent/engine.go
+++ b/forge-core/security/intent/engine.go
@@ -146,6 +146,13 @@ type Result struct {
 	// Reason is a short human-readable classification — surfaced on
 	// the audit event and, on Deny, returned as the tool-exec error.
 	Reason string
+
+	// Drift is non-nil ONLY on the tool call that transitions the
+	// task into or out of drift (R7 / #214). The hook consumer
+	// emits an `intent_drift` audit event when set. State-transition
+	// semantics keep the audit stream from flooding across long
+	// stretches of drift.
+	Drift *DriftSignal
 }
 
 // Engine is the per-runtime intent-alignment coordinator. Safe for
@@ -161,6 +168,11 @@ type Engine struct {
 	actions    *lruCache
 	lastGCUnix int64 // last time expired intent entries were swept, unix seconds
 	nowFn      func() time.Time
+
+	// drift is the R7 (#214) rolling-window analyzer. Nil when
+	// intent_drift is disabled; the Engine treats nil as "no drift
+	// tracking" so R3 keeps working without R7.
+	drift *analyzer
 }
 
 type intentEntry struct {
@@ -168,14 +180,28 @@ type intentEntry struct {
 	expiresAt time.Time
 }
 
-// New constructs an Engine. embedder may be nil when cfg.Enabled is
-// false; enabling without an embedder returns an error.
+// New constructs an Engine with just the R3 alignment check. The
+// R7 drift analyzer stays off. embedder may be nil when cfg.Enabled
+// is false; enabling without an embedder returns an error.
 func New(cfg Config, embedder llm.Embedder) (*Engine, error) {
+	return NewWithDrift(cfg, DriftConfig{}, embedder)
+}
+
+// NewWithDrift constructs an Engine with the R3 alignment check
+// AND the R7 rolling-window drift analyzer. drift.Enabled requires
+// cfg.Enabled to be true (drift is derived from alignment scores).
+func NewWithDrift(cfg Config, drift DriftConfig, embedder llm.Embedder) (*Engine, error) {
 	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if err := drift.Validate(); err != nil {
 		return nil, err
 	}
 	if cfg.Enabled && embedder == nil {
 		return nil, errors.New("intent_alignment: enabled but no embedder configured")
+	}
+	if drift.Enabled && !cfg.Enabled {
+		return nil, errors.New("intent_drift: requires intent_alignment.enabled = true")
 	}
 	if cfg.IntentTTL == 0 {
 		cfg.IntentTTL = time.Hour
@@ -186,6 +212,7 @@ func New(cfg Config, embedder llm.Embedder) (*Engine, error) {
 		intents:  make(map[string]*intentEntry),
 		actions:  newLRUCache(cfg.CacheSize),
 		nowFn:    time.Now,
+		drift:    newAnalyzer(drift),
 	}
 	return e, nil
 }
@@ -236,9 +263,10 @@ func (e *Engine) RegisterIntent(ctx context.Context, taskID, statedIntent string
 	return nil
 }
 
-// Forget removes the intent embedding for the given task. Called
-// from the A2A handler at session_end so long-running processes
-// don't retain per-task state indefinitely.
+// Forget removes the intent embedding AND any drift-analyzer state
+// for the given task. Called from the A2A handler at session_end
+// so long-running processes don't retain per-task state
+// indefinitely.
 func (e *Engine) Forget(taskID string) {
 	if !e.Enabled() {
 		return
@@ -246,6 +274,7 @@ func (e *Engine) Forget(taskID string) {
 	e.mu.Lock()
 	delete(e.intents, taskID)
 	e.mu.Unlock()
+	e.drift.forget(taskID)
 }
 
 // Score computes the alignment between the previously-registered
@@ -279,22 +308,29 @@ func (e *Engine) Score(ctx context.Context, taskID, actionText string) Result {
 			delete(e.intents, taskID)
 		}
 		e.mu.Unlock()
-		return Result{
+		res := Result{
 			Score:    math.NaN(),
 			Decision: DecisionDeny,
 			Reason:   "no stated_intent registered for task (fail-closed)",
 		}
+		// R7: fail-closed observations feed the drift ring too, so
+		// a task with a broken intent capture surfaces as drift
+		// rather than invisible.
+		res.Drift = e.drift.record(taskID, math.NaN())
+		return res
 	}
 	intentVec := entry.embedding
 	e.mu.Unlock()
 
 	actionVec, err := e.embedAction(ctx, actionText)
 	if err != nil {
-		return Result{
+		res := Result{
 			Score:    math.NaN(),
 			Decision: DecisionDeny,
 			Reason:   fmt.Sprintf("embedder unavailable (fail-closed): %v", err),
 		}
+		res.Drift = e.drift.record(taskID, math.NaN())
+		return res
 	}
 
 	sim := cosine(intentVec, actionVec)
@@ -310,6 +346,11 @@ func (e *Engine) Score(ctx context.Context, taskID, actionText string) Result {
 		res.Decision = DecisionAllow
 		res.Reason = fmt.Sprintf("score %.3f above threshold %.3f", sim, e.cfg.Threshold)
 	}
+
+	// R7: feed the score into the rolling-window drift analyzer and
+	// attach any state-transition signal to the result. No-op when
+	// the analyzer is disabled.
+	res.Drift = e.drift.record(taskID, sim)
 	return res
 }
 

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -176,6 +176,51 @@ type SecurityConfig struct {
 	// stated agent intent captured on tasks/send entry. Opt-in;
 	// see docs/security/intent-alignment.md.
 	IntentAlignment IntentAlignmentConfig `yaml:"intent_alignment,omitempty"`
+
+	// IntentDrift configures the R7 rolling-window drift detector
+	// (governance #214). Where R3 (IntentAlignment) is per-action
+	// policy, R7 is longitudinal telemetry — it watches the trend
+	// of alignment scores over the last N tool calls and emits an
+	// `intent_drift` audit event when the mean drops below a
+	// threshold or the sequence trends monotonically downward.
+	// Opt-in; requires IntentAlignment.Enabled (shares the same
+	// embedding + cosine machinery). See
+	// docs/security/intent-alignment.md.
+	IntentDrift IntentDriftConfig `yaml:"intent_drift,omitempty"`
+}
+
+// IntentDriftConfig is the forge.yaml-facing block for R7 drift
+// tracking.
+//
+// The drift signal is audit-only by default (no tool call is
+// denied). To combine drift with hard-deny semantics, tune
+// IntentAlignment.HardThreshold instead — drift is telemetry, not
+// a policy gate.
+type IntentDriftConfig struct {
+	// Enabled turns the drift analyzer on. Requires IntentAlignment
+	// to also be enabled (drift derives from alignment scores).
+	// Default false → no drift analysis, no audit events.
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Window is the number of recent alignment scores considered
+	// for the rolling-mean test. Sensible default 5. Must be ≥ 2 —
+	// a window of 1 can't distinguish "trending down" from "just
+	// low."
+	Window int `yaml:"window,omitempty"`
+
+	// DriftThreshold is the mean-score floor. When the rolling
+	// window mean drops strictly below this value, an intent_drift
+	// event fires. Sensible default 0.35 (chosen slightly above
+	// the R3 hard_threshold default 0.3 so drift is a leading
+	// indicator, not a same-event trailing one).
+	DriftThreshold float64 `yaml:"drift_threshold,omitempty"`
+
+	// MonotoneN, when non-zero, additionally emits intent_drift on
+	// N-consecutive strictly-decreasing scores even if the mean is
+	// still above DriftThreshold. Catches the "boiling frog"
+	// pattern where each step is small but the cumulative drift is
+	// large. Zero disables the monotone check. Sensible value: 3.
+	MonotoneN int `yaml:"monotone_n,omitempty"`
 }
 
 // IntentAlignmentConfig is the forge.yaml-facing block for the R3

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -212,8 +212,11 @@ type IntentDriftConfig struct {
 	// window mean drops strictly below this value, an intent_drift
 	// event fires. Sensible default 0.35 (chosen slightly above
 	// the R3 hard_threshold default 0.3 so drift is a leading
-	// indicator, not a same-event trailing one).
-	DriftThreshold float64 `yaml:"drift_threshold,omitempty"`
+	// indicator, not a same-event trailing one). Pointer so an
+	// explicit 0 (a meaningful "only flag when the mean goes
+	// negative" floor on cosine's [-1,1] range) survives the
+	// runner's zero-value defaulting.
+	DriftThreshold *float64 `yaml:"drift_threshold,omitempty"`
 
 	// MonotoneN, when non-zero, additionally emits intent_drift on
 	// N-consecutive strictly-decreasing scores even if the mean is


### PR DESCRIPTION
Closes #214. Governance R7 — longitudinal drift telemetry on top of R3 (#208 / #245). Base branch: `feat/gov-r3-intent-alignment` (this PR builds on #245; once #245 merges, this rebases onto main cleanly).

## What it does

Where R3 is a per-call policy gate ("does this action match the stated intent?"), R7 watches the trend of R3 scores across a task's lifetime. Two independent trip conditions:

- **Mean-below-threshold** — rolling-window mean drops below `drift_threshold` (default 0.35).
- **Monotone-decrease** — last N scores strictly decreasing even if the mean is still above threshold. Catches the "boiling frog" pattern where each step is small but the cumulative slope is unmistakable.

## State-transition semantics

`intent_drift` fires only on state changes: one event when the task first enters drift, one when it recovers. Long-drift stretches don't flood the audit stream.

## Fail-closed feeds the ring

An R3 fail-closed observation (embedder unavailable, unknown task) counts as NaN in the ring, treated as `-1` for the mean. A run of embedder failures surfaces as drift rather than invisible.

## Drift is telemetry, not policy

`intent_drift` never denies a tool call directly. To convert a drift signal into enforcement, tune R3's `hard_threshold` closer to the observed drift mean or wire a SIEM alerting workflow.

## Config

\`\`\`yaml
security:
  intent_alignment:
    enabled: true         # required for drift
    provider: openai
    model: text-embedding-3-small
    threshold: 0.5
    hard_threshold: 0.3

  intent_drift:
    enabled: true
    window: 5              # last N scores in the mean
    drift_threshold: 0.35  # rolling-mean floor
    monotone_n: 3          # additionally flag N-consecutive descents (0 disables)
\`\`\`

## Audit event

\`\`\`json
{
  "event": "intent_drift",
  "task_id": "task-abc",
  "fields": {
    "tool": "cli_execute",
    "severity": "mean_below_threshold",
    "transition": "entered",
    "mean": 0.221,
    "window": 5
  }
}
\`\`\`

## Acceptance criteria (from #214)
- [x] `intent_similarity` (already emitted as `intent_alignment` from R3) per tool call
- [x] `intent_drift` audit event when the rolling window drops below threshold
- [x] Runs off the same `task.stated_intent` capture as #208
- [x] Configurable window + threshold; audit-only by default
- [x] Tests: (a) high-similarity sequence never emits drift; (b) decreasing sequence trips
- [x] Docs: `docs/security/intent-alignment.md` extended with the drift section

## Test coverage
`forge-core/security/intent/drift_test.go` — 10 tests including config validation, both acceptance scenarios, state-transition dedup (5 in-drift calls → exactly 1 "entered" emission), recovery emission, monotone-decrease trip, disabled no-op, Forget clearing state, fail-closed NaN scores feeding the ring.

Full `go test ./forge-core/... ./forge-cli/...` sweep green; `gofmt -w` + `golangci-lint run` clean.