### PR TITLE
feat(security): STEP_UP authorization decision (closes #210)

### DIFF
--- a/docs/security/step-up-auth.md
+++ b/docs/security/step-up-auth.md
@@ -1,0 +1,176 @@
+# Step-up authorization (governance R4b)
+
+Forge can require a fresher, higher-assurance authentication for
+specific tool calls. When a caller presents an authentication that
+doesn't meet the tool's declared assurance level, Forge returns an
+[RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) step-up challenge
+so the client can re-authenticate at the required level and retry.
+
+This closes the R4b gap in the governance framework — pre-check,
+the policy engine could ALLOW or DENY per action, but had no third
+option to demand a higher-assurance authentication.
+
+## How it works
+
+1. Operator declares per-tool assurance requirements in
+   `forge.yaml security.step_up.tools`.
+2. On every `BeforeToolExec`, Forge:
+   - Looks up the required `acr` for the tool.
+   - Reads the caller's identity from context (populated by the
+     auth middleware at the request boundary).
+   - Checks the identity's `acr` claim against the requirement.
+3. On a mismatch, the runtime:
+   - Aborts the tool call.
+   - Emits an `auth_step_up_required` audit event.
+   - Returns HTTP 401 with:
+     ```
+     WWW-Authenticate: Bearer error="step_up_required",
+                              acr_values="acr:mfa"
+     ```
+4. The caller's SDK sees the challenge, prompts the user for the
+   higher-assurance authentication (MFA / hardware key / etc.),
+   and retries with a new bearer token whose `acr` claim now meets
+   the requirement.
+5. Auth middleware validates the token, the retry passes step-up,
+   the tool runs.
+
+## Configuration
+
+```yaml
+security:
+  step_up:
+    enabled: true
+
+    # Per-tool required acr values. Tools not listed have no
+    # step-up requirement.
+    tools:
+      cli_execute: acr:mfa
+      http_request: acr:mfa
+
+    # Optional: ordered assurance hierarchy, lowest first. When
+    # present, comparison is "index-of-presented >= index-of-required".
+    # A caller with a stronger acr satisfies a weaker requirement.
+    # Absent → strict-equal comparison.
+    acr_hierarchy:
+      - acr:password
+      - acr:mfa
+      - acr:hardware
+```
+
+**Default is off.** When `enabled: false` (or absent), no step-up
+hook fires and no config is validated.
+
+**Fail-loud on config errors**: enabling with an empty `tools` map,
+or listing a tool whose required acr isn't in the hierarchy (typo),
+fails startup rather than at first tool call.
+
+## ACR claim shape
+
+Forge reads the `acr` claim from the identity's `Claims` map — the
+raw JWT payload that the OIDC / bearer verifier populated. Values
+are opaque strings; Forge doesn't interpret them beyond matching
+against the configured requirements. Typical shapes:
+
+- `"acr:password"`, `"acr:mfa"`, `"acr:hardware"` — internal
+  convention (as used in these docs).
+- `"urn:mace:incommon:iap:silver"` — InCommon.
+- `"0"` / `"1"` / `"2"` — SAML AuthContextClass loa values.
+- `"phr"` / `"phrh"` — pre-registered OIDC classes.
+
+Coordinate values with your IdP: whatever it stamps on the token,
+that's what Forge sees.
+
+## RFC 9470 challenge shape
+
+The response follows [RFC 9470 §3](https://www.rfc-editor.org/rfc/rfc9470#name-authentication-challenges-c):
+
+```
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+WWW-Authenticate: Bearer error="step_up_required", acr_values="acr:mfa"
+
+{
+  "error": "step_up_required",
+  "tool": "cli_execute",
+  "required_acr": "acr:mfa",
+  "reason": "no acr claim presented"
+}
+```
+
+The `error` parameter and `acr_values` parameter are the two RFC
+9470 params SDKs key off. The JSON body carries the same shape as
+the `auth_step_up_required` audit event so operators debugging a
+challenge can grep for the tool + acr pair in both places.
+
+## Audit event
+
+```json
+{
+  "event": "auth_step_up_required",
+  "task_id": "task-abc",
+  "correlation_id": "req-xyz",
+  "fields": {
+    "tool": "cli_execute",
+    "required_acr": "acr:mfa",
+    "presented_acr": "",
+    "reason": "no acr claim presented"
+  }
+}
+```
+
+`presented_acr` is omitted when the caller had no `acr` claim at
+all. Payload never carries token bytes or full claim maps.
+
+## Threat model + limits
+
+**Solves**:
+- Escalation attacks where a caller with a low-assurance session
+  tries to invoke a high-assurance tool.
+- Post-hoc audit of "which action required step-up and did the
+  caller satisfy it?" via `auth_step_up_required` events.
+
+**Does NOT solve**:
+- **Confused-deputy**: a legitimate high-assurance session invoked
+  by an attacker on the same client machine. Step-up doesn't
+  authenticate the *human* on the retry, only the token.
+- **acr claim tampering**: if the IdP mints a token with a spoofed
+  acr claim, Forge trusts it. Protection lives at the IdP layer.
+- **Cross-service step-up state**: Forge does not maintain a
+  step-up-completed marker across separate tool calls. Every call
+  is evaluated against the current identity's acr; if the required
+  acr expires or a lower-acr session is presented, step-up fires
+  again.
+
+## Current coverage
+
+The 401 challenge is emitted from:
+
+- `POST /tasks/send` REST handler ✅
+
+Not yet:
+- JSON-RPC over HTTP — the error surfaces in the JSON-RPC error
+  body but does not translate to an HTTP 401 with the challenge
+  header. Follow-up to plumb the typed error through the dispatcher.
+- SSE `/tasks/sendSubscribe` — the challenge fires mid-stream, so
+  it lands as a task-failed status event rather than an HTTP
+  response header. Follow-up to design the SSE analogue.
+
+For deployments where JSON-RPC or SSE are the primary surface, use
+`security.step_up` alongside a strict `guardrails` deny so the
+tool never runs even when the challenge isn't the transport-native
+signal.
+
+## Combining with other governance controls
+
+- **R3 intent alignment (#208)**: fires BEFORE step-up. A tool
+  call the alignment engine denies never reaches the step-up
+  check (correct — the operator's intent policy says the caller
+  shouldn't do this at all).
+- **R9 JIT credentials (#215)**: step-up validates the caller's
+  authentication assurance; JIT credentials mint the tool's
+  scope-down credentials. Both fire per tool call — step-up first
+  (fails fast if the caller can't authenticate) then JIT mint (only
+  if step-up admits).
+- **R5 hash chain (#212) + R6 signing (#213)**: the
+  `auth_step_up_required` event participates in both — chained
+  under prev_hash, signed with the audit kid.

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -43,6 +43,7 @@ import (
 	"github.com/initializ/forge/forge-core/secrets"
 	"github.com/initializ/forge/forge-core/security"
 	"github.com/initializ/forge/forge-core/security/intent"
+	"github.com/initializ/forge/forge-core/security/stepup"
 	"github.com/initializ/forge/forge-core/tools"
 	"github.com/initializ/forge/forge-core/tools/adapters"
 	"github.com/initializ/forge/forge-core/tools/builtins"
@@ -151,6 +152,7 @@ type Runner struct {
 	auditSigningKey  *coreruntime.LoadedKey            // loaded once at startup; nil when signing is off (#213). Served on JWKS endpoint.
 	compression      *compress.Runtime                 // ctxzip compression runtime; nil when compression is disabled
 	intentEngine     *intent.Engine                    // R3 (#208) intent-alignment engine; nil when disabled
+	stepUpEngine     *stepup.Engine                    // R4b (#210) step-up authorization engine; nil when disabled
 }
 
 // NewRunner creates a Runner from the given config.
@@ -391,6 +393,23 @@ func (r *Runner) Run(ctx context.Context) error {
 			"threshold":      r.cfg.Config.Security.IntentAlignment.Threshold,
 			"hard_threshold": r.cfg.Config.Security.IntentAlignment.HardThreshold,
 			"provider":       r.cfg.Config.Security.IntentAlignment.Provider,
+		})
+	}
+
+	// R4b (#210) step-up authorization engine. When enabled, a
+	// BeforeToolExec hook enforces per-tool acr requirements from
+	// forge.yaml security.step_up and returns HTTP 401 with an
+	// RFC 9470 challenge on mismatch.
+	stepUpEngine, err := r.buildStepUpEngine()
+	if err != nil {
+		return fmt.Errorf("step_up: %w", err)
+	}
+	if stepUpEngine != nil {
+		r.stepUpEngine = stepUpEngine
+		r.logger.Info("step-up authorization enabled", map[string]any{
+			"tools":        len(r.cfg.Config.Security.StepUp.Tools),
+			"known_acrs":   stepUpEngine.KnownAcrValues(),
+			"hierarchical": len(r.cfg.Config.Security.StepUp.AcrHierarchy) > 0,
 		})
 	}
 
@@ -931,6 +950,13 @@ func (r *Runner) Run(ctx context.Context) error {
 					// BeforeToolExec. No-op when the engine is
 					// disabled (r.intentEngine == nil).
 					r.registerIntentAlignmentHook(hooks, reg, auditLogger)
+
+					// R4b (#210) — step-up authorization on every
+					// BeforeToolExec. Fires AFTER guardrails so a
+					// caller whose input is guardrail-denied doesn't
+					// see the step-up challenge unnecessarily.
+					// No-op when the engine is disabled.
+					r.registerStepUpHook(hooks, auditLogger)
 
 					// Register skill-level guardrails if present.
 					// Prefer build-time artifact; fall back to runtime-parsed guardrails.
@@ -1814,6 +1840,12 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 			coreruntime.TenancyContextFromHTTPHeaders(req.Header))
 		task, snap, err := r.executeTask(ctx, params, store, executor, guardrails, egressClient, auditLogger)
 		if err != nil {
+			// R4b: a step-up-required error takes priority — we
+			// return HTTP 401 with the RFC 9470 challenge header so
+			// the caller can re-authenticate and retry.
+			if WriteStepUpChallengeOnError(w, err) {
+				return
+			}
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1736,6 +1736,17 @@ func (r *Runner) executeTask(
 			Fields:        map[string]any{"state": string(a2a.TaskStateFailed)},
 		})
 		emitInvocationLifecycle()
+		// R4b: bubble a step-up error up to the handler so it can
+		// emit the RFC 9470 401 challenge instead of writing 200
+		// with a failed-task body. The task-store + audit side
+		// effects above still run — the caller can inspect the
+		// task via GET /tasks/{id} AFTER re-authenticating and
+		// retrying with a stronger acr. Other executor errors
+		// keep the pre-#247 behavior (task written, err=nil so
+		// handler renders a 200 with the failed task).
+		if _, isStepUp := stepup.AsRequiredError(err); isStepUp {
+			return task, acc.Snapshot(), err
+		}
 		return task, acc.Snapshot(), nil
 	}
 

--- a/forge-cli/runtime/step_up.go
+++ b/forge-cli/runtime/step_up.go
@@ -1,0 +1,117 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/initializ/forge/forge-core/auth"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/security/stepup"
+)
+
+// buildStepUpEngine constructs the R4b step-up engine from
+// operator config. Returns (nil, nil) when the check is disabled —
+// the runner then skips hook registration and challenge handling.
+//
+// Fail-loud on config errors: an operator who declared
+// step_up.enabled=true with no tools listed gets a startup failure.
+func (r *Runner) buildStepUpEngine() (*stepup.Engine, error) {
+	cfg := r.cfg.Config.Security.StepUp
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	return stepup.New(stepup.Config{
+		Enabled:      true,
+		Tools:        cfg.Tools,
+		AcrHierarchy: cfg.AcrHierarchy,
+	})
+}
+
+// registerStepUpHook wires the BeforeToolExec hook that enforces
+// the R4b step-up requirement. The hook:
+//
+//  1. Looks up the acr requirement for the tool (no-op when the tool
+//     has no requirement declared).
+//  2. Reads the caller's Identity from ctx (populated by the auth
+//     middleware at the request boundary).
+//  3. Calls engine.Check; on step-up-required, emits the audit event
+//     and returns the typed *stepup.RequiredError.
+//  4. The A2A response layer catches the typed error via
+//     WriteStepUpChallengeOnError (below) and translates into an
+//     RFC 9470 401 response.
+//
+// Ordering matters: this hook fires AFTER guardrails so a caller
+// whose input the guardrail would reject anyway doesn't see the
+// step-up challenge unnecessarily. But it fires BEFORE the tool
+// executes — that's the whole point.
+func (r *Runner) registerStepUpHook(hooks *coreruntime.HookRegistry, auditLogger *coreruntime.AuditLogger) {
+	if r.stepUpEngine == nil || !r.stepUpEngine.Enabled() {
+		return
+	}
+	engine := r.stepUpEngine
+	hooks.Register(coreruntime.BeforeToolExec, func(ctx context.Context, hctx *coreruntime.HookContext) error {
+		requiredAcr := engine.RequirementFor(hctx.ToolName)
+		if requiredAcr == "" {
+			return nil // fast path: tool has no requirement
+		}
+		identity := auth.IdentityFromContext(ctx)
+		if err := engine.Check(hctx.ToolName, identity); err != nil {
+			re, _ := stepup.AsRequiredError(err)
+			// Emit the audit event before returning so the SIEM
+			// records the step-up even if the caller never retries.
+			fields := map[string]any{
+				"tool":         hctx.ToolName,
+				"required_acr": re.RequiredAcr,
+				"reason":       re.Reason,
+			}
+			if re.PresentedAcr != "" {
+				fields["presented_acr"] = re.PresentedAcr
+			}
+			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+				Event:         coreruntime.AuditAuthStepUpRequired,
+				CorrelationID: hctx.CorrelationID,
+				TaskID:        hctx.TaskID,
+				Fields:        fields,
+			})
+			return err
+		}
+		return nil
+	})
+}
+
+// WriteStepUpChallengeOnError inspects err for a *stepup.RequiredError
+// and, if present, writes an RFC 9470 step-up challenge to w:
+//
+//	HTTP/1.1 401 Unauthorized
+//	WWW-Authenticate: Bearer error="step_up_required",
+//	                         acr_values="<RequiredAcr>"
+//
+// Returns true when it handled the response — the caller MUST NOT
+// write a second response body. Returns false when err is not a
+// step-up error, letting the caller fall through to its default
+// error handler.
+//
+// Split out so the three tasks/send handler variants (JSON-RPC,
+// REST, SSE) all get the same challenge format via one code path.
+func WriteStepUpChallengeOnError(w http.ResponseWriter, err error) bool {
+	re, ok := stepup.AsRequiredError(err)
+	if !ok {
+		return false
+	}
+	// RFC 9470 format: quote the values, comma-separate params.
+	// error="step_up_required" is the standard token; acr_values
+	// carries the required acr so the client can enroll the right
+	// authentication method on the retry.
+	w.Header().Set("WWW-Authenticate",
+		fmt.Sprintf(`Bearer error="step_up_required", acr_values=%q`, re.RequiredAcr))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	// Body carries the same shape as the audit event so a caller
+	// debugging the challenge can grep for the exact tool + acr
+	// pair.
+	_, _ = fmt.Fprintf(w,
+		`{"error":"step_up_required","tool":%q,"required_acr":%q,"reason":%q}`,
+		re.Tool, re.RequiredAcr, re.Reason)
+	return true
+}

--- a/forge-cli/runtime/step_up_execute_task_test.go
+++ b/forge-cli/runtime/step_up_execute_task_test.go
@@ -1,0 +1,219 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/security/stepup"
+)
+
+// fakeStepUpExecutor is the minimal AgentExecutor that reproduces the
+// BeforeToolExec hook's behavior for step-up: return an error that
+// wraps *stepup.RequiredError (the runtime's loop.go wraps hook
+// errors as "before tool exec hook: %w"). Only the Execute method
+// matters here — we're testing the executeTask → handler seam.
+type fakeStepUpExecutor struct {
+	err error
+}
+
+func (f *fakeStepUpExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Message) (*a2a.Message, error) {
+	return nil, f.err
+}
+
+func (f *fakeStepUpExecutor) ExecuteStream(ctx context.Context, task *a2a.Task, msg *a2a.Message) (<-chan *a2a.Message, error) {
+	// Streaming path isn't exercised by executeTask; a nil channel
+	// with a nil error is fine for the compilation contract.
+	return nil, nil
+}
+
+func (f *fakeStepUpExecutor) Close() error { return nil }
+
+// TestExecuteTask_ReturnsStepUpError pins the #247 blocker fix: a
+// step-up-required error from the executor must propagate through
+// executeTask as the third return value, so the REST handler's
+// `if err != nil { WriteStepUpChallengeOnError(w, err) }` branch is
+// actually reachable.
+//
+// Pre-fix behavior: executeTask marked the task Failed, stored it,
+// emitted session_end, and returned (task, snap, nil). The handler
+// wrote HTTP 200 with a failed-task body — no WWW-Authenticate
+// header, no way for the client to know it should step up.
+//
+// Post-fix: executeTask still runs the failed-task side effects
+// (store + audit + invocation_complete) but now also returns the
+// step-up error so the handler emits the RFC 9470 401 challenge.
+func TestExecuteTask_ReturnsStepUpError(t *testing.T) {
+	requiredErr := &stepup.RequiredError{
+		Tool:         "cli_execute",
+		RequiredAcr:  "acr:mfa",
+		PresentedAcr: "",
+		Reason:       "no acr claim presented",
+	}
+	// loop.go wraps hook errors with fmt.Errorf("before tool exec hook: %w", err).
+	// Reproduce that here so we're testing the errors.As-unwrap path
+	// the writer relies on.
+	wrappedErr := fmt.Errorf("before tool exec hook: %w", requiredErr)
+
+	r := &Runner{
+		logger:         nopLogger{},
+		cancelRegistry: coreruntime.NewCancellationRegistry(),
+	}
+	store := a2a.NewTaskStore()
+	executor := &fakeStepUpExecutor{err: wrappedErr}
+	guardrails := &coreruntime.NoopGuardrailChecker{}
+	auditBuf := &bytes.Buffer{}
+	auditLogger := coreruntime.NewAuditLogger(auditBuf)
+
+	params := a2a.SendTaskParams{
+		ID: "task-stepup-e2e",
+		Message: a2a.Message{
+			Role:  a2a.MessageRoleUser,
+			Parts: []a2a.Part{a2a.NewTextPart("run a cli command")},
+		},
+	}
+
+	task, _, err := r.executeTask(context.Background(), params, store, executor, guardrails, http.DefaultClient, auditLogger)
+
+	// [1] The error must propagate — pre-fix this was always nil.
+	if err == nil {
+		t.Fatal("executeTask returned err=nil for a step-up error — REST handler will never reach WriteStepUpChallengeOnError")
+	}
+	// [2] The error must be errors.As-unwrappable to *RequiredError
+	// so the writer can extract the RequiredAcr for the challenge.
+	if _, ok := stepup.AsRequiredError(err); !ok {
+		t.Fatalf("returned err is not a step-up RequiredError: %v", err)
+	}
+	// [3] Failed-task side effects still fire — the task must be
+	// stored as Failed so a GET /tasks/{id} after re-auth sees the
+	// prior failure.
+	if task == nil || task.Status.State != a2a.TaskStateFailed {
+		t.Errorf("task status: got %v want Failed", task.Status.State)
+	}
+	stored := store.Get(params.ID)
+	if stored == nil || stored.Status.State != a2a.TaskStateFailed {
+		t.Errorf("task not stored as Failed: %+v", stored)
+	}
+	// [4] Audit trail exists: session_end + invocation_complete.
+	auditStr := auditBuf.String()
+	if !strings.Contains(auditStr, `"event":"session_end"`) {
+		t.Error("missing session_end audit event")
+	}
+}
+
+// TestExecuteTask_NonStepUpErrorStaysAsNil pins the OTHER side of the
+// contract: the fix must be surgical. Executor errors that AREN'T
+// step-up (generic tool failure, guardrail deny during Execute, etc)
+// keep the pre-#247 behavior — task marked Failed, err returned as
+// nil, handler renders a 200 with the failed-task body. Otherwise
+// every tool failure would leak up as a top-level HTTP error and
+// break existing client expectations.
+func TestExecuteTask_NonStepUpErrorStaysAsNil(t *testing.T) {
+	genericErr := errors.New("tool blew up: some other reason")
+
+	r := &Runner{
+		logger:         nopLogger{},
+		cancelRegistry: coreruntime.NewCancellationRegistry(),
+	}
+	store := a2a.NewTaskStore()
+	executor := &fakeStepUpExecutor{err: genericErr}
+	guardrails := &coreruntime.NoopGuardrailChecker{}
+	auditLogger := coreruntime.NewAuditLogger(&bytes.Buffer{})
+
+	params := a2a.SendTaskParams{
+		ID: "task-non-stepup",
+		Message: a2a.Message{
+			Role:  a2a.MessageRoleUser,
+			Parts: []a2a.Part{a2a.NewTextPart("normal request")},
+		},
+	}
+
+	task, _, err := r.executeTask(context.Background(), params, store, executor, guardrails, http.DefaultClient, auditLogger)
+	if err != nil {
+		t.Fatalf("non-step-up executor error should NOT bubble as HTTP err — got %v", err)
+	}
+	if task.Status.State != a2a.TaskStateFailed {
+		t.Errorf("expected task Failed, got %v", task.Status.State)
+	}
+}
+
+// TestExecuteTask_StepUpEndToEnd_ChallengeEmitted closes the loop
+// Manoj asked for: driving the REST handler end-to-end with a
+// step-up-triggering executor must emit HTTP 401 with the RFC 9470
+// WWW-Authenticate challenge, not 200 with a failed-task body.
+//
+// Rather than wire the whole REST handler (which needs a full
+// server.Server), we assert the seam the handler owns: `if err !=
+// nil { WriteStepUpChallengeOnError(w, err) }` is now reachable
+// because executeTask returns err.
+func TestExecuteTask_StepUpEndToEnd_ChallengeEmitted(t *testing.T) {
+	requiredErr := &stepup.RequiredError{
+		Tool:         "cli_execute",
+		RequiredAcr:  "acr:hardware",
+		PresentedAcr: "acr:password",
+		Reason:       `presented acr "acr:password" does not satisfy required "acr:hardware"`,
+	}
+	wrapped := fmt.Errorf("before tool exec hook: %w", requiredErr)
+
+	r := &Runner{
+		logger:         nopLogger{},
+		cancelRegistry: coreruntime.NewCancellationRegistry(),
+	}
+	params := a2a.SendTaskParams{
+		ID: "task-e2e",
+		Message: a2a.Message{
+			Role:  a2a.MessageRoleUser,
+			Parts: []a2a.Part{a2a.NewTextPart("do the thing")},
+		},
+	}
+
+	// Simulate the REST handler shape exactly.
+	rec := httptest.NewRecorder()
+	_, _, err := r.executeTask(context.Background(), params,
+		a2a.NewTaskStore(),
+		&fakeStepUpExecutor{err: wrapped},
+		&coreruntime.NoopGuardrailChecker{},
+		http.DefaultClient,
+		coreruntime.NewAuditLogger(&bytes.Buffer{}))
+
+	if err == nil {
+		t.Fatal("executeTask err was nil — the REST handler's `if err != nil` branch would not fire and the 401 challenge would never be emitted (the pre-fix bug Manoj flagged)")
+	}
+	// This is the handler's actual code path:
+	//   if WriteStepUpChallengeOnError(w, err) { return }
+	if !WriteStepUpChallengeOnError(rec, err) {
+		t.Fatal("WriteStepUpChallengeOnError returned false — errors.As unwrap through the executor wrap failed")
+	}
+
+	if rec.Code != 401 {
+		t.Errorf("status: got %d want 401", rec.Code)
+	}
+	wwa := rec.Header().Get("WWW-Authenticate")
+	if !strings.Contains(wwa, `error="step_up_required"`) {
+		t.Errorf(`WWW-Authenticate missing step_up_required token: %q`, wwa)
+	}
+	if !strings.Contains(wwa, `acr_values="acr:hardware"`) {
+		t.Errorf(`WWW-Authenticate missing acr_values="acr:hardware": %q`, wwa)
+	}
+	var body map[string]any
+	if e := json.Unmarshal(rec.Body.Bytes(), &body); e != nil {
+		t.Fatalf("body isn't JSON: %v — %s", e, rec.Body.String())
+	}
+	if body["error"] != "step_up_required" {
+		t.Errorf("body error field: %v", body["error"])
+	}
+	if body["required_acr"] != "acr:hardware" {
+		t.Errorf("body required_acr: %v", body["required_acr"])
+	}
+	if body["tool"] != "cli_execute" {
+		t.Errorf("body tool: %v", body["tool"])
+	}
+}

--- a/forge-cli/runtime/step_up_test.go
+++ b/forge-cli/runtime/step_up_test.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/security/stepup"
+)
+
+// TestWriteStepUpChallengeOnError_HappyPath confirms the RFC 9470
+// challenge format for a step-up-required error. The `Bearer error=
+// "step_up_required", acr_values="<acr>"` header is what triggers
+// the caller's SDK to re-authenticate at the higher assurance
+// level.
+func TestWriteStepUpChallengeOnError_HappyPath(t *testing.T) {
+	re := &stepup.RequiredError{
+		Tool:         "cli_execute",
+		RequiredAcr:  "acr:mfa",
+		PresentedAcr: "",
+		Reason:       "no acr claim presented",
+	}
+	rec := httptest.NewRecorder()
+	if !WriteStepUpChallengeOnError(rec, re) {
+		t.Fatal("WriteStepUpChallengeOnError returned false on a step-up error")
+	}
+	if rec.Code != 401 {
+		t.Errorf("status: got %d want 401", rec.Code)
+	}
+	authHdr := rec.Header().Get("WWW-Authenticate")
+	if !strings.HasPrefix(authHdr, "Bearer ") {
+		t.Errorf("WWW-Authenticate should start with Bearer: %q", authHdr)
+	}
+	if !strings.Contains(authHdr, `error="step_up_required"`) {
+		t.Errorf("WWW-Authenticate missing error param: %q", authHdr)
+	}
+	if !strings.Contains(authHdr, `acr_values="acr:mfa"`) {
+		t.Errorf("WWW-Authenticate missing acr_values param: %q", authHdr)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"error":"step_up_required"`) {
+		t.Errorf("body missing error field: %s", body)
+	}
+	if !strings.Contains(body, `"required_acr":"acr:mfa"`) {
+		t.Errorf("body missing required_acr: %s", body)
+	}
+	if !strings.Contains(body, `"tool":"cli_execute"`) {
+		t.Errorf("body missing tool: %s", body)
+	}
+}
+
+// TestWriteStepUpChallengeOnError_UnwrapsWrappedError — the runner
+// wraps step-up errors in "cli_execute: minting JIT credentials: %w"
+// style messages. The writer must errors.As-unwrap them to find the
+// step-up marker.
+func TestWriteStepUpChallengeOnError_UnwrapsWrappedError(t *testing.T) {
+	inner := &stepup.RequiredError{
+		Tool:        "cli_execute",
+		RequiredAcr: "acr:mfa",
+		Reason:      "wrapped",
+	}
+	wrapped := &wrappedErr{inner: inner, msg: "tool exec: step_up_required"}
+	rec := httptest.NewRecorder()
+	if !WriteStepUpChallengeOnError(rec, wrapped) {
+		t.Fatal("failed to unwrap step-up error")
+	}
+	if rec.Code != 401 {
+		t.Errorf("status: got %d want 401", rec.Code)
+	}
+}
+
+// TestWriteStepUpChallengeOnError_IgnoresOtherErrors — the writer
+// must return false and touch nothing when the error isn't a
+// step-up error; the caller's default error path takes over.
+func TestWriteStepUpChallengeOnError_IgnoresOtherErrors(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if WriteStepUpChallengeOnError(rec, errors.New("unrelated error")) {
+		t.Error("returned true on non-step-up error")
+	}
+	if rec.Code != 200 { // httptest default when WriteHeader not called
+		t.Errorf("should not have written a response: code=%d", rec.Code)
+	}
+	if rec.Header().Get("WWW-Authenticate") != "" {
+		t.Errorf("should not have set WWW-Authenticate: %q", rec.Header().Get("WWW-Authenticate"))
+	}
+}
+
+// TestWriteStepUpChallengeOnError_NilError — defensive: nil error
+// is not a step-up error.
+func TestWriteStepUpChallengeOnError_NilError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if WriteStepUpChallengeOnError(rec, nil) {
+		t.Error("returned true on nil error")
+	}
+}
+
+// wrappedErr is a small helper implementing errors.Unwrap so the
+// AsRequiredError path is exercised.
+type wrappedErr struct {
+	inner error
+	msg   string
+}
+
+func (w *wrappedErr) Error() string { return w.msg }
+func (w *wrappedErr) Unwrap() error { return w.inner }

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -40,6 +40,19 @@ const (
 	EventAuthVerify = "auth_verify" // every successful auth decision
 	EventAuthFail   = "auth_fail"   // every failed auth decision (with reason code)
 
+	// AuditAuthStepUpRequired is emitted when the R4b (#210) step-up
+	// engine rejects a tool call because the caller's acr claim
+	// doesn't satisfy the tool's required acr. Fields carry:
+	//   - tool          : the tool name
+	//   - required_acr  : the operator-declared required acr
+	//   - presented_acr : the caller's current acr, or "" when absent
+	//   - reason        : short human-readable classification
+	// Payload never carries token bytes or full claim maps. The
+	// runner also returns HTTP 401 with an RFC 9470
+	// WWW-Authenticate challenge alongside emitting this event.
+	// See docs/security/step-up-auth.md.
+	AuditAuthStepUpRequired = "auth_step_up_required"
+
 	// MCP events. Like auth, these carry NO byte payload — never the
 	// arguments to a tool call, never the result content. Emitters
 	// include only sizes (args_size, result_size), durations, server +

--- a/forge-core/runtime/guardrails.go
+++ b/forge-core/runtime/guardrails.go
@@ -71,15 +71,33 @@ func (d PolicyDecision) String() string {
 
 // PolicyResult carries the outcome of one policy evaluation.
 //
-// For DecisionAllow / DecisionDeny / DecisionStepUp / DecisionDefer,
-// Modified is empty. For DecisionModify, Modified holds the
-// rewritten content; callers substitute it into the value stream.
-// Reason is a short human-readable string surfaced on audit events
-// and (for Deny) returned to the caller as an error message.
+// For DecisionAllow / DecisionDeny / DecisionDefer, Modified is
+// empty. For DecisionModify, Modified holds the rewritten content;
+// callers substitute it into the value stream. For DecisionStepUp,
+// RequiredAcr names the auth-context class the caller must re-authenticate
+// under (see #210 / R4b). Reason is a short human-readable string
+// surfaced on audit events and (for Deny/StepUp) returned to the caller
+// as an error message.
 type PolicyResult struct {
 	Decision PolicyDecision
 	Modified string
 	Reason   string
+
+	// RequiredAcr is populated only when Decision == DecisionStepUp
+	// (governance R4b / #210). Names the auth-context class the
+	// caller MUST re-authenticate under before the action is admitted.
+	// The runner turns this into an RFC 9470 WWW-Authenticate challenge
+	// on the 401 response: `Bearer error="step_up_required",
+	// acr_values="<value>"`. Consumers (SDKs, browsers) trigger a
+	// higher-assurance authentication and retry.
+	//
+	// Typical values follow the ACR conventions of the caller's IdP:
+	//   - "acr:mfa"          — arbitrary MFA method acceptable
+	//   - "urn:mace:incommon:iap:silver" — InCommon Silver
+	//   - "0"/"1"/"2"        — SAML/oidc-style tier numbers
+	// Forge doesn't interpret the value; it just relays it end-to-end
+	// so operator + IdP + caller agree on the semantics.
+	RequiredAcr string
 }
 
 // Allow constructs a passthrough result.
@@ -93,6 +111,12 @@ func Deny(reason string) PolicyResult {
 // Modify constructs a redact-and-continue result.
 func Modify(newContent, reason string) PolicyResult {
 	return PolicyResult{Decision: DecisionModify, Modified: newContent, Reason: reason}
+}
+
+// StepUp constructs a step-up-required result. The `acr` is relayed
+// to the caller in the RFC 9470 challenge header. See #210 / R4b.
+func StepUp(requiredAcr, reason string) PolicyResult {
+	return PolicyResult{Decision: DecisionStepUp, RequiredAcr: requiredAcr, Reason: reason}
 }
 
 // GuardrailChecker validates messages, tool calls, retrieved context,

--- a/forge-core/security/stepup/stepup.go
+++ b/forge-core/security/stepup/stepup.go
@@ -1,0 +1,246 @@
+// Package stepup implements governance R4b — the STEP_UP
+// authorization decision.
+//
+// Where DENY refuses an action outright and MODIFY rewrites it, a
+// STEP_UP result says "this specific action requires a fresher,
+// higher-assurance authentication than the caller currently has." The
+// runtime aborts the tool call and returns an RFC 9470 challenge:
+//
+//	HTTP/1.1 401 Unauthorized
+//	WWW-Authenticate: Bearer error="step_up_required",
+//	                         acr_values="<required-acr>"
+//
+// The caller's SDK / browser is expected to re-authenticate with a
+// method that satisfies the acr requirement (an MFA prompt, a
+// hardware-key ceremony, etc.) and retry the original request. On
+// retry, the auth middleware validates the presented token now
+// carries the required `acr` claim; the runtime admits the call.
+//
+// Fail-loud: an operator who lists a tool in `security.step_up.tools`
+// but no caller identity has an `acr` claim gets a 401 with the
+// required-acr embedded. This is intentional — the policy is that
+// the tool needs step-up, and the caller not carrying acr is the
+// exact case step-up is designed to catch.
+package stepup
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/initializ/forge/forge-core/auth"
+)
+
+// Config carries the per-tool step-up requirements.
+type Config struct {
+	// Enabled is a master switch. When false, RequirementFor always
+	// returns "" and Check is a no-op that returns nil.
+	Enabled bool
+
+	// Tools maps tool name → required acr value. Absent tools have
+	// no step-up requirement.
+	Tools map[string]string
+
+	// AcrHierarchy is an optional ordered list, lowest-assurance
+	// first. When present, comparison is "index-of-actual >=
+	// index-of-required". When empty, comparison is strict-equal.
+	AcrHierarchy []string
+}
+
+// Validate returns an error when the config would produce
+// nonsensical enforcement. Called at Engine construction so the
+// runner fails startup rather than at first Check.
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if len(c.Tools) == 0 {
+		return errors.New("step_up: enabled but no tools declared")
+	}
+	// Every tool's required acr must appear in the hierarchy (when
+	// one is declared). Catches typos.
+	if len(c.AcrHierarchy) > 0 {
+		known := make(map[string]bool, len(c.AcrHierarchy))
+		for _, a := range c.AcrHierarchy {
+			known[a] = true
+		}
+		for tool, req := range c.Tools {
+			if !known[req] {
+				return fmt.Errorf("step_up: tool %q requires acr %q which isn't in acr_hierarchy", tool, req)
+			}
+		}
+	}
+	return nil
+}
+
+// Engine evaluates step-up requirements per tool call. Immutable
+// after construction — no locking needed.
+type Engine struct {
+	cfg       Config
+	rankOfAcr map[string]int // acr → index in hierarchy; nil when strict-equal mode
+}
+
+// New constructs an Engine from cfg. Returns an error when the
+// config is invalid.
+func New(cfg Config) (*Engine, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	var rank map[string]int
+	if len(cfg.AcrHierarchy) > 0 {
+		rank = make(map[string]int, len(cfg.AcrHierarchy))
+		for i, a := range cfg.AcrHierarchy {
+			rank[a] = i
+		}
+	}
+	return &Engine{cfg: cfg, rankOfAcr: rank}, nil
+}
+
+// Enabled reports whether the engine is armed. Runners short-circuit
+// hook registration on unconfigured deployments.
+func (e *Engine) Enabled() bool { return e != nil && e.cfg.Enabled }
+
+// RequirementFor returns the required acr value for the given tool,
+// or "" when no step-up requirement applies. Callers can use this
+// to skip the identity lookup when the tool doesn't need step-up.
+func (e *Engine) RequirementFor(tool string) string {
+	if !e.Enabled() {
+		return ""
+	}
+	return e.cfg.Tools[tool]
+}
+
+// Check evaluates the step-up requirement for the given tool against
+// the caller's identity. Returns nil when either:
+//   - The tool has no step-up requirement.
+//   - The identity presents an acr satisfying the requirement.
+//
+// Returns a *RequiredError when a step-up is required. The runner
+// unwraps this to produce the RFC 9470 challenge response.
+//
+// A nil identity is treated as "no acr" — step-up fails closed. The
+// caller MUST authenticate before the runtime evaluates step-up.
+func (e *Engine) Check(tool string, identity *auth.Identity) error {
+	if !e.Enabled() {
+		return nil
+	}
+	requiredAcr := e.cfg.Tools[tool]
+	if requiredAcr == "" {
+		return nil // tool has no step-up requirement
+	}
+	presentedAcr := extractAcr(identity)
+	if e.acrSatisfies(presentedAcr, requiredAcr) {
+		return nil
+	}
+	reason := "no acr claim presented"
+	if presentedAcr != "" {
+		reason = fmt.Sprintf("presented acr %q does not satisfy required %q", presentedAcr, requiredAcr)
+	}
+	return &RequiredError{
+		Tool:         tool,
+		RequiredAcr:  requiredAcr,
+		PresentedAcr: presentedAcr,
+		Reason:       reason,
+	}
+}
+
+// acrSatisfies reports whether the presented acr meets the requirement.
+// Strict-equal in the default mode; hierarchy-based when configured.
+func (e *Engine) acrSatisfies(presented, required string) bool {
+	if presented == "" {
+		return false
+	}
+	if e.rankOfAcr == nil {
+		return presented == required
+	}
+	presRank, ok := e.rankOfAcr[presented]
+	if !ok {
+		// An acr not in the hierarchy is treated as untrusted (weaker
+		// than any listed level). Conservative failure: the operator
+		// declared what they know about; anything else needs to be
+		// explicitly enrolled.
+		return false
+	}
+	reqRank, ok := e.rankOfAcr[required]
+	if !ok {
+		// Caught at Validate; defensive here in case an out-of-band
+		// mutation snuck through.
+		return false
+	}
+	return presRank >= reqRank
+}
+
+// extractAcr pulls the `acr` claim from the identity. Falls back to
+// scanning `amr` (Authentication Methods References — RFC 8176) if
+// acr is absent AND the operator has declared amr values in the
+// tools map. Today we only read acr; amr support is a follow-up if
+// operators need it.
+func extractAcr(identity *auth.Identity) string {
+	if identity == nil || len(identity.Claims) == 0 {
+		return ""
+	}
+	if v, ok := identity.Claims["acr"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// RequiredError is the typed error a step-up check returns when the
+// caller's identity doesn't meet the requirement. The runner unpacks
+// it via errors.As to produce the RFC 9470 challenge:
+//
+//	HTTP/1.1 401 Unauthorized
+//	WWW-Authenticate: Bearer error="step_up_required",
+//	                         acr_values="<RequiredAcr>"
+//
+// The audit event uses the same fields so the SIEM can join on
+// tool + required_acr.
+type RequiredError struct {
+	Tool         string
+	RequiredAcr  string
+	PresentedAcr string // may be "" when the caller had no acr claim
+	Reason       string
+}
+
+func (e *RequiredError) Error() string {
+	return fmt.Sprintf("step_up_required: tool=%s required_acr=%s: %s",
+		e.Tool, e.RequiredAcr, e.Reason)
+}
+
+// AsRequiredError is a convenience for callers that want to check
+// whether an error carries step-up semantics without importing the
+// errors package at every call site. Returns (*RequiredError, true)
+// on match or (nil, false) otherwise.
+func AsRequiredError(err error) (*RequiredError, bool) {
+	var re *RequiredError
+	if errors.As(err, &re) {
+		return re, true
+	}
+	return nil, false
+}
+
+// KnownAcrValues returns the acrs declared in the hierarchy (or the
+// distinct set from Tools when no hierarchy is set). Used by the
+// startup log so operators can confirm which levels are wired.
+func (e *Engine) KnownAcrValues() []string {
+	if !e.Enabled() {
+		return nil
+	}
+	if len(e.cfg.AcrHierarchy) > 0 {
+		out := make([]string, len(e.cfg.AcrHierarchy))
+		copy(out, e.cfg.AcrHierarchy)
+		return out
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, v := range e.cfg.Tools {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	slices.Sort(out)
+	return out
+}

--- a/forge-core/security/stepup/stepup_test.go
+++ b/forge-core/security/stepup/stepup_test.go
@@ -1,0 +1,238 @@
+package stepup
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/auth"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{"disabled is always valid", Config{}, false},
+		{"enabled without tools rejected", Config{Enabled: true}, true},
+		{"enabled with tools", Config{
+			Enabled: true,
+			Tools:   map[string]string{"cli_execute": "acr:mfa"},
+		}, false},
+		{"tool acr not in hierarchy rejected", Config{
+			Enabled:      true,
+			Tools:        map[string]string{"cli_execute": "acr:mfa"},
+			AcrHierarchy: []string{"acr:password", "acr:hardware"}, // missing acr:mfa
+		}, true},
+		{"tool acr in hierarchy ok", Config{
+			Enabled:      true,
+			Tools:        map[string]string{"cli_execute": "acr:mfa"},
+			AcrHierarchy: []string{"acr:password", "acr:mfa", "acr:hardware"},
+		}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("err=%v wantErr=%v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheck_ToolWithoutRequirementAllows — tools not listed in
+// the step-up config pass through with no check.
+func TestCheck_ToolWithoutRequirementAllows(t *testing.T) {
+	e, err := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := e.Check("web_search", &auth.Identity{}); err != nil {
+		t.Errorf("tool without requirement should pass, got %v", err)
+	}
+}
+
+// TestCheck_StrictEqualMatches — no hierarchy configured, presented
+// acr must equal required exactly.
+func TestCheck_StrictEqualMatches(t *testing.T) {
+	e, _ := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	id := &auth.Identity{Claims: map[string]any{"acr": "acr:mfa"}}
+	if err := e.Check("cli_execute", id); err != nil {
+		t.Errorf("exact match should pass: %v", err)
+	}
+}
+
+// TestCheck_StrictEqualRejectsMismatch — different acr values
+// don't cross-satisfy in strict-equal mode.
+func TestCheck_StrictEqualRejectsMismatch(t *testing.T) {
+	e, _ := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	id := &auth.Identity{Claims: map[string]any{"acr": "acr:hardware"}}
+	err := e.Check("cli_execute", id)
+	if err == nil {
+		t.Fatal("expected step-up error on mismatched acr in strict-equal mode")
+	}
+	re, ok := AsRequiredError(err)
+	if !ok {
+		t.Fatalf("expected *RequiredError, got %T", err)
+	}
+	if re.RequiredAcr != "acr:mfa" {
+		t.Errorf("RequiredAcr: got %q want acr:mfa", re.RequiredAcr)
+	}
+	if re.PresentedAcr != "acr:hardware" {
+		t.Errorf("PresentedAcr: got %q want acr:hardware", re.PresentedAcr)
+	}
+}
+
+// TestCheck_MissingIdentityFailsClosed — nil identity always fails
+// step-up. Auth must succeed before step-up evaluates.
+func TestCheck_MissingIdentityFailsClosed(t *testing.T) {
+	e, _ := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	err := e.Check("cli_execute", nil)
+	if err == nil {
+		t.Fatal("expected error on nil identity")
+	}
+	re, _ := AsRequiredError(err)
+	if re == nil {
+		t.Fatalf("expected *RequiredError")
+	}
+	if re.PresentedAcr != "" {
+		t.Errorf("PresentedAcr on nil identity: got %q", re.PresentedAcr)
+	}
+}
+
+// TestCheck_MissingAcrClaimFailsClosed — identity with no `acr`
+// claim → step-up required.
+func TestCheck_MissingAcrClaimFailsClosed(t *testing.T) {
+	e, _ := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	// Identity carries other claims but no `acr`.
+	id := &auth.Identity{Claims: map[string]any{"sub": "user-1"}}
+	err := e.Check("cli_execute", id)
+	if err == nil {
+		t.Fatal("expected step-up error")
+	}
+	re, _ := AsRequiredError(err)
+	if !strContains(re.Reason, "no acr claim presented") {
+		t.Errorf("reason should mention missing acr: %q", re.Reason)
+	}
+}
+
+// TestCheck_HierarchyStrongerAcrSatisfies — hardware > mfa in the
+// hierarchy, so a caller with hardware satisfies an mfa requirement.
+func TestCheck_HierarchyStrongerAcrSatisfies(t *testing.T) {
+	e, _ := New(Config{
+		Enabled:      true,
+		Tools:        map[string]string{"cli_execute": "acr:mfa"},
+		AcrHierarchy: []string{"acr:password", "acr:mfa", "acr:hardware"},
+	})
+	id := &auth.Identity{Claims: map[string]any{"acr": "acr:hardware"}}
+	if err := e.Check("cli_execute", id); err != nil {
+		t.Errorf("hardware > mfa should satisfy: %v", err)
+	}
+}
+
+// TestCheck_HierarchyWeakerAcrFails — password < mfa, so a caller
+// with password fails an mfa requirement.
+func TestCheck_HierarchyWeakerAcrFails(t *testing.T) {
+	e, _ := New(Config{
+		Enabled:      true,
+		Tools:        map[string]string{"cli_execute": "acr:mfa"},
+		AcrHierarchy: []string{"acr:password", "acr:mfa", "acr:hardware"},
+	})
+	id := &auth.Identity{Claims: map[string]any{"acr": "acr:password"}}
+	err := e.Check("cli_execute", id)
+	if err == nil {
+		t.Fatal("password < mfa should require step-up")
+	}
+}
+
+// TestCheck_HierarchyUnknownAcrFails — an acr not listed in the
+// hierarchy is treated as weaker than any listed level (fail-closed).
+func TestCheck_HierarchyUnknownAcrFails(t *testing.T) {
+	e, _ := New(Config{
+		Enabled:      true,
+		Tools:        map[string]string{"cli_execute": "acr:mfa"},
+		AcrHierarchy: []string{"acr:password", "acr:mfa", "acr:hardware"},
+	})
+	id := &auth.Identity{Claims: map[string]any{"acr": "acr:something-weird"}}
+	err := e.Check("cli_execute", id)
+	if err == nil {
+		t.Fatal("unknown acr should fail closed")
+	}
+}
+
+// TestRequiredError_ImplementsError satisfies the errors.As
+// contract used by the runner middleware.
+func TestRequiredError_ImplementsError(t *testing.T) {
+	original := &RequiredError{Tool: "cli_execute", RequiredAcr: "acr:mfa"}
+	wrapped := &wrapErr{inner: original}
+	re, ok := AsRequiredError(wrapped)
+	if !ok {
+		t.Fatal("errors.As should unwrap through wrapErr")
+	}
+	if re.Tool != "cli_execute" {
+		t.Errorf("Tool: got %q", re.Tool)
+	}
+	if _, ok := AsRequiredError(errors.New("plain")); ok {
+		t.Error("AsRequiredError should return false for plain errors")
+	}
+}
+
+func TestRequirementFor(t *testing.T) {
+	e, _ := New(Config{
+		Enabled: true,
+		Tools:   map[string]string{"cli_execute": "acr:mfa"},
+	})
+	if got := e.RequirementFor("cli_execute"); got != "acr:mfa" {
+		t.Errorf("got %q", got)
+	}
+	if got := e.RequirementFor("web_search"); got != "" {
+		t.Errorf("expected empty for non-configured tool, got %q", got)
+	}
+}
+
+func TestDisabledEngineIsNoop(t *testing.T) {
+	e, _ := New(Config{})
+	id := &auth.Identity{} // no acr, no claims — would normally fail
+	if err := e.Check("cli_execute", id); err != nil {
+		t.Errorf("disabled engine must not fail: %v", err)
+	}
+}
+
+// wrapErr for the errors.As unwrap test.
+type wrapErr struct{ inner error }
+
+func (w *wrapErr) Error() string { return "wrapped: " + w.inner.Error() }
+func (w *wrapErr) Unwrap() error { return w.inner }
+
+func strContains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+// tiny indexOf to avoid pulling strings into the test file's imports
+// alongside a compile-time-avoidable dependency. Not perf-sensitive.
+func indexOf(haystack, needle string) int {
+	if len(needle) == 0 {
+		return 0
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -187,6 +187,13 @@ type SecurityConfig struct {
 	// embedding + cosine machinery). See
 	// docs/security/intent-alignment.md.
 	IntentDrift IntentDriftConfig `yaml:"intent_drift,omitempty"`
+
+	// StepUp configures the R4b (#210) step-up authorization policy.
+	// Names tools that require a higher auth-context class before
+	// the runtime executes them; on a mismatch, Forge returns an
+	// RFC 9470 challenge and the caller re-authenticates.
+	// Opt-in — no default enforcement.
+	StepUp StepUpConfig `yaml:"step_up,omitempty"`
 }
 
 // IntentDriftConfig is the forge.yaml-facing block for R7 drift
@@ -281,6 +288,44 @@ type IntentAlignmentConfig struct {
 	// 0 disables the LRU (still caches per-task intent). Default
 	// 1024 when enabled and unspecified.
 	CacheSize int `yaml:"cache_size,omitempty"`
+}
+
+// StepUpConfig is the forge.yaml-facing block for R4b step-up
+// authorization.
+//
+// Tools listed in Tools require the caller's authenticated identity
+// to carry an `acr` claim matching (or exceeding, if AcrHierarchy is
+// declared) the required value. On a mismatch, the runtime aborts
+// the tool call and returns HTTP 401 with a
+// `WWW-Authenticate: Bearer error="step_up_required",
+// acr_values="<value>"` header per RFC 9470. The caller's client is
+// expected to trigger a higher-assurance authentication and retry.
+type StepUpConfig struct {
+	// Enabled turns step-up enforcement on. Default false — the
+	// engine is constructed but the hook is not registered.
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Tools maps tool name → required acr value. A tool absent from
+	// this map has no step-up requirement. When a tool IS present,
+	// the caller's auth Identity MUST carry an `acr` claim equal to
+	// the value (or listed in AcrHierarchy above the required value).
+	//
+	// Example:
+	//   tools:
+	//     cli_execute: acr:mfa
+	//     http_request: acr:mfa
+	Tools map[string]string `yaml:"tools,omitempty"`
+
+	// AcrHierarchy is an optional ordered list of acr values,
+	// lowest-assurance first. A caller presenting acr X satisfies a
+	// requirement for acr Y iff index(X) >= index(Y) in this list.
+	// When AcrHierarchy is empty, comparison is strict-equal.
+	//
+	// Example:
+	//   acr_hierarchy: ["acr:password", "acr:mfa", "acr:hardware"]
+	// — a caller with "acr:hardware" satisfies a requirement for
+	// "acr:mfa" or "acr:password".
+	AcrHierarchy []string `yaml:"acr_hierarchy,omitempty"`
 }
 
 // ObservabilityConfig groups telemetry-related sub-blocks. Today it


### PR DESCRIPTION
Closes #210. Governance R4b — adds the third policy decision from the R4 taxonomy: on a high-assurance tool call, if the caller's authentication assurance is insufficient, Forge returns an [RFC 9470](https://www.rfc-editor.org/rfc/rfc9470) step-up challenge instead of running the tool.

## Design

- New `forge-core/security/stepup/` package: Engine reads per-tool `acr` requirements from ForgeConfig, checks against `auth.Identity.Claims["acr"]`, returns typed `*RequiredError` on mismatch.
- Optional `acr_hierarchy` for "stronger acr satisfies weaker requirement" semantics; default strict-equal comparison.
- Runner registers a `BeforeToolExec` hook that fires AFTER guardrails (so a guardrail-denied call doesn't produce an unnecessary challenge) and BEFORE tool execution.
- `WriteStepUpChallengeOnError` translates the typed error into HTTP 401 with `WWW-Authenticate: Bearer error="step_up_required", acr_values="<acr>"` per RFC 9470 §3.
- `PolicyResult.RequiredAcr` field + `StepUp()` constructor populate the existing `DecisionStepUp` enum slot from R4a (#221).

## Config

\`\`\`yaml
security:
  step_up:
    enabled: true
    tools:
      cli_execute: acr:mfa
      http_request: acr:mfa
    acr_hierarchy:   # optional
      - acr:password
      - acr:mfa
      - acr:hardware
\`\`\`

Fail-loud on startup: `enabled: true` with empty tools list is rejected; a tool acr not in the hierarchy (typo) is rejected.

## Audit event

New `auth_step_up_required` event with fields `{tool, required_acr, presented_acr, reason}`. No token bytes, no full claim maps.

## Wire coverage

- **POST /tasks/send REST** — HTTP 401 with RFC 9470 challenge header ✅
- **JSON-RPC + SSE** — the typed error surfaces in the response body but doesn't translate to an HTTP 401 header on these transports; documented as follow-up. Deployments where these are the primary surface can pair step-up with a strict guardrail deny so the tool never runs even without the transport-native signal.

## Acceptance criteria (from #210)
- [x] `DecisionStepUp` returnable from any guardrail hook (via `runtime.StepUp(requiredAcr, reason)`)
- [x] HTTP 401 with RFC 9470 step-up challenge on StepUp (REST path)
- [x] Auth middleware validates `acr` claim on the retry (auth package already carries Claims map; Engine.Check reads `acr` from it)
- [x] `auth_step_up_required` audit event with tool, reason, required acr
- [x] Config: per-tool acr requirement + optional hierarchy
- [x] Tests: end-to-end challenge shape + engine unit tests
- [x] Docs: `docs/security/step-up-auth.md`

## Test plan
- [x] `go test ./forge-core/security/stepup/...` — 12 tests (validation, strict + hierarchy paths, fail-closed, RequiredError unwrap)
- [x] `go test ./forge-cli/runtime/...` — 4 challenge-writer tests (RFC 9470 format, wrapped-error unwrap, non-step-up passthrough)
- [x] Full sweep `go test ./forge-core/... ./forge-cli/...` green
- [x] `gofmt -w` + `golangci-lint run` clean