### PR TITLE
CI: rolling vnext prerelease of the runtime on every merge to main

### DIFF
--- a/.github/workflows/edge.yaml
+++ b/.github/workflows/edge.yaml
@@ -1,0 +1,69 @@
+name: Edge (main)
+
+# Rolling prerelease of the forge runtime binaries on every merge to main.
+#
+# The Initializ platform bakes the forge RUNTIME into each agent image by
+# fetching a release tarball (forge-Linux-<arch>.tar.gz) from a GitHub release
+# tag — see forge-cli templates/Dockerfile.tmpl. Tagged releases (v*) can lag
+# main by days, so a runtime feature merged but not yet released (e.g. the
+# remote session store, #243/#244) is invisible to deployed agents even after
+# the platform side ships. This workflow republishes a fixed `vnext`
+# PRERELEASE pointing at the latest main commit, so agent-builder can pin
+# AGENT_FORGE_VERSION=vnext and test unreleased runtime changes end-to-end.
+#
+# It builds via goreleaser --snapshot (no tag needed) reusing .goreleaser.yaml,
+# so the archive names are byte-identical to a real release. It is a PRERELEASE
+# and never becomes `latest`, so tagged releases and existing agents pinned to
+# a version are unaffected.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: edge-prerelease
+  cancel-in-progress: true
+
+jobs:
+  edge:
+    name: Publish vnext prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      # Snapshot build: cross-compiles the same archives a release would, into
+      # dist/, without publishing or requiring a git tag. Publishers (brew,
+      # etc.) are skipped automatically in snapshot mode.
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-point the fixed `vnext` prerelease at this commit and replace its
+      # assets. delete --cleanup-tag drops the old tag so the new one tracks the
+      # latest main SHA; the Linux tarballs are what the agent Dockerfile pulls.
+      - name: Republish vnext prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete vnext --cleanup-tag --yes || true
+          gh release create vnext \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "vnext (main)" \
+            --notes "Rolling build of main @ ${GITHUB_SHA:0:7}. Prerelease (not latest). Pin agent-builder AGENT_FORGE_VERSION=vnext to test unreleased runtime changes." \
+            dist/forge-Linux-x86_64.tar.gz \
+            dist/forge-Linux-arm64.tar.gz \
+            dist/checksums.txt


### PR DESCRIPTION
## What

New `.github/workflows/edge.yaml`: on every push to `main` (and `workflow_dispatch`), build the release archives via `goreleaser release --snapshot --clean` and republish a fixed **`vnext` prerelease** pointing at the latest `main` commit, carrying the Linux runtime tarballs + checksums.

## Why

The Initializ platform bakes the forge **runtime** into each agent image by fetching `forge-Linux-<arch>.tar.gz` from a GitHub release tag (forge-cli `templates/Dockerfile.tmpl`, default `releases/latest`). Tagged releases lag `main`, so a runtime feature that's merged but unreleased is **silently absent from deployed agents even after the platform side ships it**.

Concretely: the remote session store (#243/#244) landed on main 2026-07-06, but `latest` is `v0.16.0` (2026-07-01). Agents built today run v0.16.0, which has no remote-session-store client — they ignore `FORGE_SESSION_STORE=remote` and no sessions reach the platform. There's currently no way to test an unreleased runtime without cutting a real release.

This publishes a rolling `vnext` the platform can pin (`AGENT_FORGE_VERSION=vnext` in agent-builder, PR initializ/agent-builder#36) to validate unreleased runtime changes end-to-end.

## Design notes

- **Snapshot build** reuses `.goreleaser.yaml`, whose archive `name_template` has no version component → `vnext` assets are byte-identical to a real release, so the existing Dockerfile template fetches them unchanged.
- **Prerelease** — never becomes `latest`. Tagged `v*` releases and agents pinned to a version are unaffected.
- `delete --cleanup-tag` + `create --target $GITHUB_SHA` re-points the `vnext` tag at the newest main commit each run.
- `concurrency` cancels superseded runs so the tag always reflects the tip of main.

## Verify after merge

Push to main → the `vnext` release exists with the two Linux tarballs → set `AGENT_FORGE_VERSION=vnext` and rebuild an agent → its pod logs print `session store: engaged remote backend` and executions appear in the console.