### PR TITLE
fix(ui): robustly extract skill draft from chat so the preview populates and can be saved

### DIFF
--- a/forge-ui/skill_validator.go
+++ b/forge-ui/skill_validator.go
@@ -11,10 +11,9 @@ import (
 )
 
 var (
-	skillNamePattern  = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
-	kebabCasePattern  = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
-	egressURLPattern  = regexp.MustCompile(`https?://([^/\s"'` + "`" + `]+)`)
-	artifactFenceExpr = regexp.MustCompile("(?s)````(skill\\.md|script:[^\n]+)\n(.*?)````")
+	skillNamePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	kebabCasePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	egressURLPattern = regexp.MustCompile(`https?://([^/\s"'` + "`" + `]+)`)
 )
 
 // validateSkillMD validates SKILL.md content and optional scripts.
@@ -198,24 +197,103 @@ func detectUndeclaredEgress(scripts map[string]string, declaredEgress []string) 
 	return undeclared
 }
 
-// extractArtifacts parses labeled code fences from an LLM response.
-// Returns the SKILL.md content and a map of script filename → content.
+// extractArtifacts parses labeled code fences from an LLM response and
+// returns the SKILL.md content and a map of script filename → content.
+//
+// It is deliberately tolerant of the ways LLMs deviate from the prompt's
+// exact quadruple-backtick format, because a missed extraction leaves the
+// preview pane empty and the user with no way to save. It accepts:
+//   - 3-or-more backticks (not strictly 4), with the closing fence needing
+//     at least as many as the opener — so an inner ```json block inside a
+//     ````skill.md block doesn't close it early;
+//   - a label with surrounding whitespace ("skill.md ", "script: foo.sh");
+//   - a block that is unlabeled or language-tagged (```yaml / ```markdown)
+//     whose content is clearly a SKILL.md (starts with `---` frontmatter
+//     carrying a `name:` key) — used only if no explicit skill.md fence
+//     was found.
 func extractArtifacts(response string) (skillMD string, scripts map[string]string) {
 	scripts = make(map[string]string)
 
-	matches := artifactFenceExpr.FindAllStringSubmatch(response, -1)
-	for _, m := range matches {
-		if len(m) < 3 {
+	lines := strings.Split(response, "\n")
+	i := 0
+	for i < len(lines) {
+		openTicks, label, isOpen := fenceOpen(lines[i])
+		if !isOpen {
+			i++
 			continue
 		}
-		label := m[1]
-		content := m[2]
-		if label == "skill.md" {
-			skillMD = strings.TrimSpace(content)
-		} else if strings.HasPrefix(label, "script:") {
-			filename := strings.TrimPrefix(label, "script:")
-			scripts[filename] = strings.TrimRight(content, "\n")
+		// Find the closing fence: a line of only backticks, at least as
+		// many as the opener (so nested lower-count fences are content).
+		j := i + 1
+		for j < len(lines) && !fenceClose(lines[j], openTicks) {
+			j++
 		}
+		content := strings.Join(lines[i+1:min(j, len(lines))], "\n")
+		classifyArtifact(label, content, &skillMD, scripts)
+		i = j + 1
 	}
 	return
+}
+
+// fenceOpen reports whether line opens a labeled code fence, returning the
+// backtick count and the trimmed label. A bare fence (no label) is not
+// treated as an opener so a stray closing fence can't start a phantom block.
+func fenceOpen(line string) (ticks int, label string, ok bool) {
+	n := 0
+	for n < len(line) && line[n] == '`' {
+		n++
+	}
+	if n < 3 {
+		return 0, "", false
+	}
+	label = strings.TrimSpace(line[n:])
+	if label == "" {
+		return 0, "", false
+	}
+	return n, label, true
+}
+
+// fenceClose reports whether line is a closing fence for an opener with
+// openTicks backticks: only backticks (optionally surrounded by space),
+// at least openTicks of them.
+func fenceClose(line string, openTicks int) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	for i := 0; i < len(t); i++ {
+		if t[i] != '`' {
+			return false
+		}
+	}
+	return len(t) >= openTicks
+}
+
+// classifyArtifact routes a fenced block to skillMD or scripts by its label,
+// with a frontmatter-based fallback for unlabeled / language-tagged blocks.
+func classifyArtifact(label, content string, skillMD *string, scripts map[string]string) {
+	low := strings.ToLower(label)
+	switch {
+	case low == "skill.md" || low == "skill":
+		*skillMD = strings.TrimSpace(content)
+	case strings.HasPrefix(low, "script:"):
+		filename := strings.TrimSpace(label[len("script:"):])
+		if filename != "" {
+			scripts[filename] = strings.TrimRight(content, "\n")
+		}
+	default:
+		if *skillMD == "" && looksLikeSkillMD(content) {
+			*skillMD = strings.TrimSpace(content)
+		}
+	}
+}
+
+// looksLikeSkillMD reports whether content is plausibly a SKILL.md body:
+// a YAML frontmatter block carrying a name key.
+func looksLikeSkillMD(content string) bool {
+	t := strings.TrimSpace(content)
+	if !strings.HasPrefix(t, "---") {
+		return false
+	}
+	return strings.Contains(t, "\nname:")
 }

--- a/forge-ui/skill_validator.go
+++ b/forge-ui/skill_validator.go
@@ -202,7 +202,11 @@ func detectUndeclaredEgress(scripts map[string]string, declaredEgress []string) 
 //
 // It is deliberately tolerant of the ways LLMs deviate from the prompt's
 // exact quadruple-backtick format, because a missed extraction leaves the
-// preview pane empty and the user with no way to save. It accepts:
+// preview pane empty and the user with no way to save. Fence-count rules
+// follow CommonMark §4.5 (a closing fence must have at least as many
+// backticks as the opener, and — after trimming whitespace — nothing but
+// backticks), so inner lower-count blocks don't terminate the outer one.
+// It accepts:
 //   - 3-or-more backticks (not strictly 4), with the closing fence needing
 //     at least as many as the opener — so an inner ```json block inside a
 //     ````skill.md block doesn't close it early;
@@ -211,6 +215,12 @@ func detectUndeclaredEgress(scripts map[string]string, declaredEgress []string) 
 //     whose content is clearly a SKILL.md (starts with `---` frontmatter
 //     carrying a `name:` key) — used only if no explicit skill.md fence
 //     was found.
+//
+// Unclosed opener: if a fence never closes, the scanner absorbs the rest
+// of the response as that block's content (up to EOF, trailing prose
+// included). This is intentional — for the user-facing bug, a populated
+// preview beats an empty one — and differs from the old regex, which
+// simply produced nothing on an unclosed fence.
 func extractArtifacts(response string) (skillMD string, scripts map[string]string) {
 	scripts = make(map[string]string)
 

--- a/forge-ui/skill_validator_test.go
+++ b/forge-ui/skill_validator_test.go
@@ -255,6 +255,68 @@ func TestExtractArtifactsNoMatch(t *testing.T) {
 	}
 }
 
+// TestExtractArtifactsTolerant covers the LLM-deviation cases that the
+// old strict quadruple-backtick regex silently dropped — each of these
+// used to leave the preview pane empty.
+func TestExtractArtifactsTolerant(t *testing.T) {
+	cases := []struct {
+		name        string
+		response    string
+		wantSkill   string // substring expected in skillMD ("" = skip)
+		scriptName  string // expected script filename ("" = skip)
+		scriptSubst string // substring expected in that script
+	}{
+		{
+			name:      "triple backticks instead of quadruple",
+			response:  "```skill.md\n---\nname: triple\ndescription: d\n---\n# T\n```",
+			wantSkill: "name: triple",
+		},
+		{
+			name:      "label has trailing whitespace",
+			response:  "````skill.md \n---\nname: trail\ndescription: d\n---\n# T\n````",
+			wantSkill: "name: trail",
+		},
+		{
+			name:        "script label with a space after colon",
+			response:    "````script: fetch-data.sh\n#!/usr/bin/env bash\nset -euo pipefail\necho hi\n````",
+			scriptName:  "fetch-data.sh",
+			scriptSubst: "echo hi",
+		},
+		{
+			name:      "five-backtick opener and closer",
+			response:  "`````skill.md\n---\nname: five\ndescription: d\n---\n# T\n`````",
+			wantSkill: "name: five",
+		},
+		{
+			name:      "language-tagged block with frontmatter (fallback)",
+			response:  "Here you go:\n```yaml\n---\nname: fallback\ndescription: d\n---\n# T\n```",
+			wantSkill: "name: fallback",
+		},
+		{
+			name:      "closing fence with more backticks than opener",
+			response:  "````skill.md\n---\nname: mism\ndescription: d\n---\n# T\n`````",
+			wantSkill: "name: mism",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skillMD, scripts := extractArtifacts(tc.response)
+			if tc.wantSkill != "" && !contains(skillMD, tc.wantSkill) {
+				t.Errorf("skillMD missing %q; got: %q", tc.wantSkill, skillMD)
+			}
+			if tc.scriptName != "" {
+				got, ok := scripts[tc.scriptName]
+				if !ok {
+					t.Fatalf("expected script %q; got scripts %v", tc.scriptName, scripts)
+				}
+				if !contains(got, tc.scriptSubst) {
+					t.Errorf("script %q missing %q; got: %q", tc.scriptName, tc.scriptSubst, got)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateSkillMDUndeclaredEgressWarning(t *testing.T) {
 	content := `---
 name: my-skill

--- a/forge-ui/skill_validator_test.go
+++ b/forge-ui/skill_validator_test.go
@@ -297,6 +297,16 @@ func TestExtractArtifactsTolerant(t *testing.T) {
 			response:  "````skill.md\n---\nname: mism\ndescription: d\n---\n# T\n`````",
 			wantSkill: "name: mism",
 		},
+		{
+			// Pins the intentional unclosed-opener behavior (review of
+			// #253): an opener that never closes absorbs the rest of the
+			// response — up to EOF, trailing prose included — rather than
+			// producing nothing (the old regex behavior). A populated
+			// preview beats an empty one for the user-facing bug.
+			name:      "unclosed opener absorbs remaining content",
+			response:  "````skill.md\n---\nname: partial\ndescription: d\n---\n# body\n\ntrailing prose the LLM never closed",
+			wantSkill: "name: partial",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

In the UI Skill Builder, a skill generated in chat often **doesn't populate the right-pane preview**, there's **no way to save it**, and **copying it from chat by hand mangles the formatting**.

All three trace to one server-side function. The builder fills the preview (and enables Save) only when it emits a `skill_draft` SSE event, which happens only if `extractArtifacts` finds the SKILL.md in the LLM reply (`forge-ui/handlers_skill_builder.go:194`). That matcher was a strict regex requiring **exactly four backticks** immediately followed by `skill.md` and a newline:

```
(?s)````(skill\.md|script:[^\n]+)\n(.*?)````
```

Any deviation the model makes — three backticks, a five-backtick fence, a language tag or trailing space after the label, or a `script: name` with a space — fails the match **silently**. No `skill_draft` fires → the preview stays empty → there's nothing to Save → the user hand-copies from chat, which collapses the nested code fences.

The frontend was correct all along: `skill_draft` → `setSkillMD` → `editor.setValue` → `handleSave` (`forge-ui/static/app.js:2660/2627/2694`). Fixing extraction unblocks the whole chain — preview populates **and** Save works, no manual copy.

## Fix

Replace the regex with a line-based parser (`forge-ui/skill_validator.go`) that tolerates real LLM output:

- **3+ backticks**, with the closing fence needing **at least as many as the opener** — so an inner ` ```json ` block inside a ` ````skill.md ` block doesn't close it early (nested-backtick behavior preserved).
- Whitespace / label variance (`skill.md `, `script: foo.sh`).
- A **frontmatter fallback**: an unlabeled or language-tagged block (` ```yaml `) whose content is clearly a SKILL.md (`---` + `name:`) is used when no explicit `skill.md` fence is found.

## Tests

`TestExtractArtifactsTolerant` covers triple/quintuple fences, trailing label whitespace, spaced script labels, mismatched closing-fence counts, and the language-tagged frontmatter fallback. Existing tests (including the nested-backticks case) stay green. Full `forge-ui` suite green; `gofmt` + `golangci-lint` clean.

## Follow-up

The durable fix is structured `{message, skill}` JSON output from the builder (issue #252) — once the skill comes back as a JSON field instead of fenced markdown, there is no fence-parsing to be fragile at all. This bug is the concrete motivation for that change.
