### PR TITLE
docs(reference): document audit env vars (capture, signing, export)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -32,6 +32,56 @@ order: 3
 | `FORGE_ORG_ID` | Organization identifier for DB guardrails |
 | `FORGE_PASSPHRASE` | Passphrase for encrypted secrets file |
 
+## Audit
+
+Environment knobs for the audit pipeline. See
+[Audit logging](../security/audit-logging.md) and
+[Audit signing](../security/audit-signing.md) for the full model.
+
+### Payload capture (FWS-8)
+
+By default audit events are **metadata only** (sizes, counts, durations —
+no prompts, completions, or raw tool I/O). These vars opt into raw
+payloads field by field. `forge.yaml`'s `audit.capture` block overrides
+these; the built-in default is all-off with redaction on. See
+[Payload capture](../security/audit-logging.md#payload-capture-fws-8).
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `FORGE_AUDIT_CAPTURE_TOOL_ARGS` | bool | `false` | Capture raw tool input on `tool_exec` (phase=start) |
+| `FORGE_AUDIT_CAPTURE_TOOL_RESULT` | bool | `false` | Capture raw tool output on `tool_exec` (phase=end) |
+| `FORGE_AUDIT_CAPTURE_LLM_MESSAGES` | bool | `false` | Capture the chat-messages array on `llm_call` |
+| `FORGE_AUDIT_CAPTURE_LLM_RESPONSE` | bool | `false` | Capture the model completion text on `llm_call` |
+| `FORGE_AUDIT_CAPTURE_REDACT` | bool | `true` | Run the vendor-secret regex scrub over captured fields before truncation. Turn off only when a downstream sink scrubs |
+| `FORGE_AUDIT_CAPTURE_MAX_BYTES` | int | `16384` | Single-knob per-field byte cap applied to every captured field |
+
+> Captured payloads can carry prompts, tool I/O, and PII even with
+> redaction on — route the audit stream to a store appropriate to that
+> sensitivity, and prefer enabling capture per-session for debugging
+> rather than always-on.
+
+### Signing (R6)
+
+Opt-in Ed25519 signing of each audit event. When the key is unset the
+stream is emitted unsigned. See
+[Audit signing](../security/audit-signing.md).
+
+| Variable | Default | Description |
+|---|---|---|
+| `FORGE_AUDIT_SIGNING_KEY_B64` | (unset) | Ed25519 private key as base64-encoded PKCS#8 DER **or** an inline PEM string. Setting it turns signing on |
+| `FORGE_AUDIT_SIGNING_KID` | `forge-audit-v1` | Key id stamped as `kid` on signed events and advertised at `/.well-known/forge-audit-keys` |
+
+### Export sinks (FWS-7)
+
+Add a second sink alongside the always-on stderr safety net. If both a
+socket and an HTTP endpoint are set, the socket wins.
+
+| Variable | Default | Description |
+|---|---|---|
+| `FORGE_AUDIT_SOCKET` | (unset) | Unix socket path the sidecar listens on; enables the socket export sink |
+| `FORGE_AUDIT_HTTP_ENDPOINT` | (unset) | HTTP endpoint for the export sink (used when `FORGE_AUDIT_SOCKET` is unset) |
+| `FORGE_AUDIT_WRITE_TIMEOUT` | (impl default) | Go duration (e.g. `2s`) bounding each sink write; applies to both socket and HTTP sinks |
+
 ## OpenTelemetry tracing (OTel v1, #108)
 
 Forge honors the standard OpenTelemetry SDK environment variables for


### PR DESCRIPTION
## Problem

The environment-variable reference (`docs/reference/environment-variables.md`) listed **no** `FORGE_AUDIT_*` variables, even though the audit pipeline reads **eleven** of them. Operators had to read the source — or the prose in `audit-logging.md` — to discover the payload-capture, signing, and export knobs. (The `audit.capture` yaml/env examples themselves already live in `audit-logging.md`; this is purely the reference-doc gap.)

## Change

Adds an **Audit** section grouping the three families, each with types + defaults and a cross-link to the detailed docs:

- **Payload capture (FWS-8)** — `FORGE_AUDIT_CAPTURE_{TOOL_ARGS, TOOL_RESULT, LLM_MESSAGES, LLM_RESPONSE, REDACT, MAX_BYTES}`, cross-linked to `audit-logging.md#payload-capture-fws-8`, with a sensitivity callout.
- **Signing (R6)** — `FORGE_AUDIT_SIGNING_KEY_B64` (base64 PKCS#8 DER or inline PEM; setting it turns signing on), `FORGE_AUDIT_SIGNING_KID` (default `forge-audit-v1`).
- **Export sinks (FWS-7)** — `FORGE_AUDIT_SOCKET`, `FORGE_AUDIT_HTTP_ENDPOINT`, `FORGE_AUDIT_WRITE_TIMEOUT`.

All 11 names/defaults verified against the source; the cross-link anchor resolves to the existing header. Docs-only, no behavior change.
