### PR TITLE
feat(skills): skill-relative file read + multi-language script execution (closes #251)

### DIFF
--- a/docs/skills/writing-custom-skills.md
+++ b/docs/skills/writing-custom-skills.md
@@ -46,6 +46,36 @@ For skills **without** scripts (binary-backed skills like `k8s-incident-triage`)
 └─────────────────────────────────────────────────┘
 ```
 
+## Skill-relative files and scripts
+
+A skill's `SKILL.md` can reference other files it ships — reference docs,
+templates, or helper scripts — by a path **relative to the skill's own
+directory** (`skills/<skill>/…`). The whole directory reaches the running
+agent (`COPY . .` at build time), and two builtins resolve those references
+against the skill dir (path-confined — no `..` or absolute escapes):
+
+- **Read a bundled file** — the agent calls `read_skill` with its `file`
+  argument. Write instructions like "read `reference/runbook.md`" and the
+  agent loads `skills/<skill>/reference/runbook.md`.
+- **Run a bundled script** — the agent calls `run_skill_script`. Write "run
+  `scripts/check.py`" and the agent executes `skills/<skill>/scripts/check.py`
+  **with the skill directory as the working directory** (so the script's own
+  relative reads resolve), picking the interpreter by extension:
+
+  | Extension | Interpreter | `requires.bins` |
+  |---|---|---|
+  | `.sh` / `.bash` | `bash` | (built in) |
+  | `.py` | `python3` | add `python3` |
+  | `.js` | `node` | add `node` |
+
+  JSON supplied in the tool's `args` is passed to the script as its first
+  positional argument (`$1`). TypeScript must be shipped as compiled `.js`.
+
+This is distinct from a `## Tool:` entry backed by `scripts/<name>.sh`, which
+is registered as a first-class callable tool the model invokes by name (see
+above). Skill-relative scripts are invoked by path via `run_skill_script` and
+can be any of the three languages.
+
 ## Skill Execution Security
 
 Skill scripts run in a restricted environment via `SkillCommandExecutor`:

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -816,6 +816,23 @@ func (r *Runner) Run(ctx context.Context) error {
 				}
 			}
 
+			// run_skill_script (#251): execute a skill's own bundled
+			// helper scripts (shell / python / javascript) by path,
+			// resolved relative to the skill directory and run with that
+			// dir as CWD. Registered independently of cli_execute — a
+			// skill may ship only non-.sh helper scripts. Shares the
+			// egress proxy + skill env passthrough.
+			{
+				var envPass []string
+				if r.derivedCLIConfig != nil {
+					envPass = r.derivedCLIConfig.EnvPassthrough
+				}
+				rss := clitools.NewRunSkillScriptTool(r.cfg.WorkDir, proxyURL, envPass)
+				if regErr := reg.Register(rss); regErr != nil {
+					r.logger.Warn("failed to register run_skill_script", map[string]any{"error": regErr.Error()})
+				}
+			}
+
 			// Discover custom tools in tools/ directory
 			toolsDir := filepath.Join(r.cfg.WorkDir, "tools")
 			discovered := clitools.DiscoverTools(toolsDir)
@@ -3244,11 +3261,15 @@ func (r *Runner) buildSystemPrompt() string {
 //
 // This deliberately mirrors registerSkillTools' `.sh`-only lookup, NOT the
 // full set of script languages. A tool backed by a `.py`/`.js` script is
-// not yet registered as a callable tool, so it stays in "provides" (the
-// LLM reaches it by loading the skill), and read_skill's file listing
-// surfaces the actual script. Keep this in lockstep with
-// registerSkillTools: if it learns to register other script languages,
-// broaden this check at the same time or those tools vanish from both.
+// not a directly-callable registered tool, so it correctly stays in
+// "provides" — and that is now sufficient, not a gap: the LLM reaches it
+// by loading the skill (read_skill's file listing surfaces the script) and
+// runs it with the `run_skill_script` tool, which resolves the path
+// relative to the skill dir and picks the interpreter by extension (#251).
+// So `.sh`/`.py`/`.js` scripts are all runnable; only `.sh` also gets the
+// first-class `## Tool:` registration. Keep this in lockstep with
+// registerSkillTools: if IT ever registers other languages as callable
+// tools, broaden this check at the same time or those tools vanish from both.
 func (r *Runner) skillEntryHasScript(skillDir, toolName string) bool {
 	scriptName := strings.ReplaceAll(toolName, "_", "-")
 	if skillDir != "" {

--- a/forge-cli/tools/run_skill_script.go
+++ b/forge-cli/tools/run_skill_script.go
@@ -75,29 +75,34 @@ func (t *RunSkillScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 		return "", fmt.Errorf("parsing run_skill_script input: %w", err)
 	}
 	if input.Skill == "" || input.Path == "" {
-		return `{"error": "skill and path are required"}`, nil
+		return jsonError("skill and path are required"), nil
+	}
+
+	// args, when present, must be a JSON object — it becomes the script's
+	// $1 and the script does json.loads(...) expecting a dict.
+	jsonArgs := "{}"
+	if len(input.Args) > 0 && string(input.Args) != "null" {
+		if trimmed := strings.TrimSpace(string(input.Args)); trimmed == "" || trimmed[0] != '{' {
+			return jsonError("args must be a JSON object"), nil
+		}
+		jsonArgs = string(input.Args)
 	}
 
 	dir, ok := builtins.SkillDir(t.workDir, input.Skill)
 	if !ok {
-		return fmt.Sprintf(`{"error": "skill %q not found"}`, input.Skill), nil
+		return jsonError(fmt.Sprintf("skill %q not found", input.Skill)), nil
 	}
 	full, err := builtins.SafeSkillJoin(dir, input.Path)
 	if err != nil {
-		return `{"error": "invalid path (must stay within the skill directory)"}`, nil
+		return jsonError("invalid path (must stay within the skill directory)"), nil
 	}
 	if fi, statErr := os.Stat(full); statErr != nil || fi.IsDir() {
-		return fmt.Sprintf(`{"error": "script %q not found in skill %q"}`, input.Path, input.Skill), nil
+		return jsonError(fmt.Sprintf("script %q not found in skill %q", input.Path, input.Skill)), nil
 	}
 
 	interp, ierr := interpreterForScript(input.Path)
 	if ierr != nil {
-		return fmt.Sprintf(`{"error": %q}`, ierr.Error()), nil
-	}
-
-	jsonArgs := "{}"
-	if len(input.Args) > 0 && string(input.Args) != "null" {
-		jsonArgs = string(input.Args)
+		return jsonError(ierr.Error()), nil
 	}
 
 	// CWD = the skill dir so `input.Path` (relative) and the script's own
@@ -111,10 +116,27 @@ func (t *RunSkillScriptTool) Execute(ctx context.Context, args json.RawMessage) 
 	}
 	out, runErr := exec.Run(ctx, interp, []string{input.Path, jsonArgs}, nil)
 	if runErr != nil {
-		return fmt.Sprintf(`{"error": %q, "output": %q}`, runErr.Error(), truncate(out, 8192)), nil
+		// Build via json.Marshal, not fmt %q: script output can carry raw
+		// bytes / invalid UTF-8 that %q would emit as \xNN escapes, which
+		// are not valid JSON and break the tool-result parser. Marshal
+		// replaces invalid UTF-8 with U+FFFD and escapes correctly.
+		return jsonObj(map[string]any{"error": runErr.Error(), "output": truncate(out, 8192)}), nil
 	}
 	return out, nil
 }
+
+// jsonObj marshals m to a JSON string, falling back to a static error
+// string if marshaling somehow fails.
+func jsonObj(m map[string]any) string {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return `{"error": "internal: could not encode result"}`
+	}
+	return string(b)
+}
+
+// jsonError builds a well-formed JSON error object for the given message.
+func jsonError(msg string) string { return jsonObj(map[string]any{"error": msg}) }
 
 // interpreterForScript picks the interpreter for a script by extension.
 // TypeScript is intentionally unsupported — `node` can't run raw `.ts`;

--- a/forge-cli/tools/run_skill_script.go
+++ b/forge-cli/tools/run_skill_script.go
@@ -1,0 +1,140 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	coretools "github.com/initializ/forge/forge-core/tools"
+	"github.com/initializ/forge/forge-core/tools/builtins"
+)
+
+// RunSkillScriptTool executes a helper script that ships inside a skill's
+// own directory — the kind a SKILL.md body references by relative path
+// ("run owl/scripts/check.py"). Unlike a `## Tool:` entry (registered as a
+// first-class callable tool via registerSkillTools, `.sh`-only), this tool
+// resolves an arbitrary script path relative to the skill directory, picks
+// the interpreter from the extension (shell / python / javascript), and
+// runs it with the skill directory as the working directory so the
+// script's own relative references resolve. See issue #251.
+//
+// Path resolution is confined to the skill directory (no `..` / absolute
+// escape) via builtins.SafeSkillJoin. The subprocess inherits the same
+// egress proxy + env passthrough as cli_execute and skill scripts.
+type RunSkillScriptTool struct {
+	workDir  string
+	proxyURL string
+	envVars  []string
+	timeout  time.Duration
+}
+
+// NewRunSkillScriptTool constructs the tool rooted at the agent working
+// directory, wired to the egress proxy and the skill env passthrough.
+func NewRunSkillScriptTool(workDir, proxyURL string, envVars []string) *RunSkillScriptTool {
+	return &RunSkillScriptTool{
+		workDir:  workDir,
+		proxyURL: proxyURL,
+		envVars:  envVars,
+		timeout:  120 * time.Second,
+	}
+}
+
+func (t *RunSkillScriptTool) Name() string                 { return "run_skill_script" }
+func (t *RunSkillScriptTool) Category() coretools.Category { return coretools.CategoryBuiltin }
+
+func (t *RunSkillScriptTool) Description() string {
+	return "Execute a helper script bundled inside a skill's directory (shell .sh, python .py, or javascript .js). " +
+		"The path is resolved relative to the skill and the script runs with the skill's directory as its working " +
+		"directory, so the script's own relative references resolve. Use for skill instructions like " +
+		"'run owl/scripts/check.py'. JSON in 'args' is passed to the script as its first positional argument ($1)."
+}
+
+func (t *RunSkillScriptTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"skill": {"type": "string", "description": "Skill name exactly as shown in Available Skills (the identifier before the colon)."},
+			"path": {"type": "string", "description": "Script path RELATIVE TO THE SKILL directory (e.g. 'scripts/check.py'). Supported: .sh, .py, .js."},
+			"args": {"type": "object", "description": "Optional JSON object passed to the script as its first positional argument ($1)."}
+		},
+		"required": ["skill", "path"]
+	}`)
+}
+
+func (t *RunSkillScriptTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var input struct {
+		Skill string          `json:"skill"`
+		Path  string          `json:"path"`
+		Args  json.RawMessage `json:"args"`
+	}
+	if err := json.Unmarshal(args, &input); err != nil {
+		return "", fmt.Errorf("parsing run_skill_script input: %w", err)
+	}
+	if input.Skill == "" || input.Path == "" {
+		return `{"error": "skill and path are required"}`, nil
+	}
+
+	dir, ok := builtins.SkillDir(t.workDir, input.Skill)
+	if !ok {
+		return fmt.Sprintf(`{"error": "skill %q not found"}`, input.Skill), nil
+	}
+	full, err := builtins.SafeSkillJoin(dir, input.Path)
+	if err != nil {
+		return `{"error": "invalid path (must stay within the skill directory)"}`, nil
+	}
+	if fi, statErr := os.Stat(full); statErr != nil || fi.IsDir() {
+		return fmt.Sprintf(`{"error": "script %q not found in skill %q"}`, input.Path, input.Skill), nil
+	}
+
+	interp, ierr := interpreterForScript(input.Path)
+	if ierr != nil {
+		return fmt.Sprintf(`{"error": %q}`, ierr.Error()), nil
+	}
+
+	jsonArgs := "{}"
+	if len(input.Args) > 0 && string(input.Args) != "null" {
+		jsonArgs = string(input.Args)
+	}
+
+	// CWD = the skill dir so `input.Path` (relative) and the script's own
+	// relative references resolve there. Same subprocess posture as
+	// cli_execute / skill scripts (egress proxy + env passthrough).
+	exec := &SkillCommandExecutor{
+		Timeout:  t.timeout,
+		WorkDir:  dir,
+		EnvVars:  t.envVars,
+		ProxyURL: t.proxyURL,
+	}
+	out, runErr := exec.Run(ctx, interp, []string{input.Path, jsonArgs}, nil)
+	if runErr != nil {
+		return fmt.Sprintf(`{"error": %q, "output": %q}`, runErr.Error(), truncate(out, 8192)), nil
+	}
+	return out, nil
+}
+
+// interpreterForScript picks the interpreter for a script by extension.
+// TypeScript is intentionally unsupported — `node` can't run raw `.ts`;
+// ship a compiled `.js` instead.
+func interpreterForScript(path string) (string, error) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".sh", ".bash":
+		return "bash", nil
+	case ".py":
+		return "python3", nil
+	case ".js", ".cjs", ".mjs":
+		return "node", nil
+	default:
+		return "", fmt.Errorf("unsupported script type %q (supported: .sh, .py, .js)", filepath.Ext(path))
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…[truncated]"
+}

--- a/forge-cli/tools/run_skill_script_test.go
+++ b/forge-cli/tools/run_skill_script_test.go
@@ -118,6 +118,46 @@ func TestRunSkillScript_UnknownSkill(t *testing.T) {
 	}
 }
 
+// TestRunSkillScript_InvalidUTF8OutputIsValidJSON pins the #257 fix: a
+// script that fails while emitting raw / invalid-UTF-8 bytes must still
+// produce a well-formed JSON tool result (built via json.Marshal, not
+// fmt %q which would emit non-JSON \xNN escapes).
+func TestRunSkillScript_InvalidUTF8OutputIsValidJSON(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+	root := t.TempDir()
+	writeSkillScript(t, root, "owl", "SKILL.md", "---\nname: owl\ndescription: d\n---\n")
+	writeSkillScript(t, root, "owl", "scripts/bad.py",
+		"import sys\nsys.stdout.buffer.write(b'\\xff\\xfe not utf8 ')\nsys.stdout.flush()\nsys.exit(1)\n")
+	out := runScript(t, root, "owl", "scripts/bad.py", map[string]any{})
+	var anyJSON map[string]any
+	if err := json.Unmarshal([]byte(out), &anyJSON); err != nil {
+		t.Fatalf("tool result is not valid JSON: %v\nraw: %q", err, out)
+	}
+	if _, hasErr := anyJSON["error"]; !hasErr {
+		t.Errorf("expected an error field on script failure: %v", anyJSON)
+	}
+}
+
+// TestRunSkillScript_ArgsMustBeObject pins the #257 fix: non-object args
+// (string / number / array) are rejected before hitting the script.
+func TestRunSkillScript_ArgsMustBeObject(t *testing.T) {
+	root := t.TempDir()
+	writeSkillScript(t, root, "owl", "SKILL.md", "---\nname: owl\ndescription: d\n---\n")
+	writeSkillScript(t, root, "owl", "scripts/x.sh", "#!/usr/bin/env bash\necho '{}'\n")
+	for _, badArgs := range []string{`"hello"`, `42`, `[1,2]`, `true`} {
+		in := `{"skill":"owl","path":"scripts/x.sh","args":` + badArgs + `}`
+		out, err := NewRunSkillScriptTool(root, "", nil).Execute(context.Background(), json.RawMessage(in))
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(out, "args must be a JSON object") {
+			t.Errorf("args=%s not rejected: %s", badArgs, out)
+		}
+	}
+}
+
 func TestInterpreterForScript(t *testing.T) {
 	ok := map[string]string{"a.sh": "bash", "a.bash": "bash", "a.py": "python3", "a.js": "node", "a.mjs": "node"}
 	for path, want := range ok {

--- a/forge-cli/tools/run_skill_script_test.go
+++ b/forge-cli/tools/run_skill_script_test.go
@@ -1,0 +1,132 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkillScript lays out skills/<skill>/<rel> under root.
+func writeSkillScript(t *testing.T, root, skill, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, "skills", skill, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+}
+
+func runScript(t *testing.T, root, skill, path string, args map[string]any) string {
+	t.Helper()
+	argsJSON, _ := json.Marshal(args)
+	in, _ := json.Marshal(map[string]any{"skill": skill, "path": path, "args": json.RawMessage(argsJSON)})
+	out, err := NewRunSkillScriptTool(root, "", nil).Execute(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Execute(%s): %v", path, err)
+	}
+	return out
+}
+
+// TestRunSkillScript_Languages runs a shell, python, and javascript helper
+// script that (a) echoes back the JSON args it received on $1 and (b) reads
+// a sibling file by a relative path — proving both the args contract and
+// that CWD is the skill directory.
+func TestRunSkillScript_Languages(t *testing.T) {
+	root := t.TempDir()
+	const skill = "owl"
+	writeSkillScript(t, root, skill, "SKILL.md", "---\nname: owl\ndescription: d\n---\n# Owl\n")
+	writeSkillScript(t, root, skill, "reference/data.txt", "HELLO")
+
+	// Each script prints JSON: {"got": <args>, "ref": "<reference/data.txt>"}.
+	writeSkillScript(t, root, skill, "scripts/check.sh",
+		"#!/usr/bin/env bash\nset -euo pipefail\nINPUT=\"${1:-}\"\nprintf '{\"got\": %s, \"ref\": \"%s\"}\\n' \"$INPUT\" \"$(cat reference/data.txt)\"\n")
+	writeSkillScript(t, root, skill, "scripts/check.py",
+		"import sys, json\na = json.loads(sys.argv[1])\nref = open('reference/data.txt').read().strip()\nprint(json.dumps({'got': a, 'ref': ref}))\n")
+	writeSkillScript(t, root, skill, "scripts/check.js",
+		"const a = JSON.parse(process.argv[2]);\nconst fs = require('fs');\nconst ref = fs.readFileSync('reference/data.txt','utf8').trim();\nconsole.log(JSON.stringify({got: a, ref}));\n")
+
+	cases := []struct {
+		name, path, interp string
+	}{
+		{"shell", "scripts/check.sh", "bash"},
+		{"python", "scripts/check.py", "python3"},
+		{"javascript", "scripts/check.js", "node"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := exec.LookPath(tc.interp); err != nil {
+				t.Skipf("%s not installed", tc.interp)
+			}
+			out := runScript(t, root, skill, tc.path, map[string]any{"n": 42})
+			var got struct {
+				Got map[string]any `json:"got"`
+				Ref string         `json:"ref"`
+			}
+			if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+				t.Fatalf("output not the expected JSON: %v\nraw: %s", err, out)
+			}
+			if got.Ref != "HELLO" {
+				t.Errorf("relative file read failed (CWD not skill dir?): ref=%q", got.Ref)
+			}
+			if got.Got["n"] != float64(42) {
+				t.Errorf("args not passed as $1: got=%v", got.Got)
+			}
+		})
+	}
+}
+
+// TestRunSkillScript_Traversal rejects paths escaping the skill directory.
+func TestRunSkillScript_Traversal(t *testing.T) {
+	root := t.TempDir()
+	writeSkillScript(t, root, "owl", "SKILL.md", "---\nname: owl\ndescription: d\n---\n")
+	// A secret outside the skill dir the traversal must not reach.
+	if err := os.WriteFile(filepath.Join(root, "secret.sh"), []byte("echo LEAK\n"), 0o755); err != nil { //nolint:gosec // test
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"../../secret.sh", "../secret.sh", "/etc/hostname"} {
+		out := runScript(t, root, "owl", bad, nil)
+		if !strings.Contains(out, "error") || strings.Contains(out, "LEAK") {
+			t.Errorf("traversal %q not rejected: %s", bad, out)
+		}
+	}
+}
+
+// TestRunSkillScript_UnsupportedExt returns a clear error for non-runnable
+// extensions (e.g. .ts).
+func TestRunSkillScript_UnsupportedExt(t *testing.T) {
+	root := t.TempDir()
+	writeSkillScript(t, root, "owl", "SKILL.md", "---\nname: owl\ndescription: d\n---\n")
+	writeSkillScript(t, root, "owl", "scripts/x.ts", "console.log(1)\n")
+	out := runScript(t, root, "owl", "scripts/x.ts", nil)
+	if !strings.Contains(out, "unsupported script type") {
+		t.Errorf("expected unsupported-type error, got: %s", out)
+	}
+}
+
+// TestRunSkillScript_UnknownSkill returns not-found for an unknown skill.
+func TestRunSkillScript_UnknownSkill(t *testing.T) {
+	root := t.TempDir()
+	out := runScript(t, root, "ghost", "scripts/x.sh", nil)
+	if !strings.Contains(out, "not found") {
+		t.Errorf("expected skill-not-found, got: %s", out)
+	}
+}
+
+func TestInterpreterForScript(t *testing.T) {
+	ok := map[string]string{"a.sh": "bash", "a.bash": "bash", "a.py": "python3", "a.js": "node", "a.mjs": "node"}
+	for path, want := range ok {
+		got, err := interpreterForScript(path)
+		if err != nil || got != want {
+			t.Errorf("interpreterForScript(%q) = %q,%v want %q", path, got, err, want)
+		}
+	}
+	if _, err := interpreterForScript("a.rb"); err == nil {
+		t.Error("expected error for .rb")
+	}
+}

--- a/forge-core/tools/builtins/read_skill.go
+++ b/forge-core/tools/builtins/read_skill.go
@@ -3,6 +3,7 @@ package builtins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,14 +32,17 @@ func (t *ReadSkillTool) Category() tools.Category { return tools.CategoryBuiltin
 func (t *ReadSkillTool) Description() string {
 	return "Read the full instructions for an available skill. " +
 		"Pass the skill name exactly as listed under 'Available Skills'. " +
-		"Returns the skill's SKILL.md content with usage details, parameters, and examples."
+		"Returns the skill's SKILL.md content with usage details, parameters, and examples. " +
+		"Pass the optional 'file' argument to read a specific file relative to the skill's directory " +
+		"(e.g. a reference doc the instructions point to) instead of SKILL.md."
 }
 
 func (t *ReadSkillTool) InputSchema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
-			"name": {"type": "string", "description": "Skill name exactly as shown in the Available Skills list (e.g. 'k8s-incident-triage')"}
+			"name": {"type": "string", "description": "Skill name exactly as shown in the Available Skills list (e.g. 'k8s-incident-triage')"},
+			"file": {"type": "string", "description": "Optional. A file path RELATIVE TO THE SKILL's directory to read instead of SKILL.md (e.g. 'reference/runbook.md', 'owl.md'). Use for skill instructions like 'read reference/runbook.md'."}
 		},
 		"required": ["name"]
 	}`)
@@ -47,6 +51,7 @@ func (t *ReadSkillTool) InputSchema() json.RawMessage {
 func (t *ReadSkillTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
 	var input struct {
 		Name string `json:"name"`
+		File string `json:"file"`
 	}
 	if err := json.Unmarshal(args, &input); err != nil {
 		return "", fmt.Errorf("parsing read_skill input: %w", err)
@@ -58,6 +63,29 @@ func (t *ReadSkillTool) Execute(_ context.Context, args json.RawMessage) (string
 	// Security: prevent directory traversal.
 	if strings.ContainsAny(input.Name, `/\`) || strings.Contains(input.Name, "..") {
 		return `{"error": "invalid skill name"}`, nil
+	}
+
+	// Skill-relative file read: a SKILL.md may instruct "read
+	// reference/runbook.md" — resolve that path against the skill's own
+	// directory (confined; no escaping) and return its contents.
+	if input.File != "" {
+		dir, ok := SkillDir(t.workDir, input.Name)
+		if !ok {
+			if _, available := t.buildNameIndex(); len(available) > 0 {
+				list, _ := json.Marshal(available)
+				return fmt.Sprintf(`{"error": "skill %q not found", "available_skills": %s}`, input.Name, list), nil
+			}
+			return fmt.Sprintf(`{"error": "skill %q not found"}`, input.Name), nil
+		}
+		full, err := SafeSkillJoin(dir, input.File)
+		if err != nil {
+			return `{"error": "invalid file path (must stay within the skill directory)"}`, nil
+		}
+		data, err := os.ReadFile(full) //nolint:gosec // confined to the skill dir by SafeSkillJoin
+		if err != nil {
+			return fmt.Sprintf(`{"error": "file %q not found in skill %q"}`, input.File, input.Name), nil
+		}
+		return string(data), nil
 	}
 
 	// Resolve the SKILL.md path: direct filesystem lookup first, then a
@@ -118,6 +146,69 @@ func (t *ReadSkillTool) resolvePath(name string) string {
 func fileExists(p string) bool {
 	info, err := os.Stat(p)
 	return err == nil && !info.IsDir()
+}
+
+// SkillDir resolves a skill's loadable name to its on-disk directory
+// (`<workDir>/skills/<dir>`), matching read_skill's resolution: the
+// directory name (and its underscore->hyphen variant) first, then the
+// frontmatter `name` of any subdirectory skill (normalized for case and
+// separator drift). Returns ("", false) for an unknown name or a flat
+// single-file skill (which has no companion directory). Shared with the
+// run_skill_script tool so skill-relative reads and executions resolve
+// the same skill dir.
+func SkillDir(workDir, name string) (string, bool) {
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return "", false
+	}
+	skillsDir := filepath.Join(workDir, "skills")
+	variants := []string{name}
+	if h := strings.ReplaceAll(name, "_", "-"); h != name {
+		variants = append(variants, h)
+	}
+	for _, n := range variants {
+		dir := filepath.Join(skillsDir, n)
+		if fileExists(filepath.Join(dir, "SKILL.md")) {
+			return dir, true
+		}
+	}
+	// Frontmatter-name / normalized match across subdirectory skills.
+	ents, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return "", false
+	}
+	want := normalizeSkillKey(name)
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		md := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+		if !fileExists(md) {
+			continue
+		}
+		if normalizeSkillKey(e.Name()) == want || normalizeSkillKey(frontmatterName(md)) == want {
+			return filepath.Join(skillsDir, e.Name()), true
+		}
+	}
+	return "", false
+}
+
+// SafeSkillJoin joins a skill-relative path onto the skill directory and
+// confines the result to that directory — rejecting absolute paths and
+// any `..` traversal that would escape the skill. Same posture as
+// read_skill's traversal guard and cli_execute's workdir confinement.
+func SafeSkillJoin(skillDir, rel string) (string, error) {
+	if rel == "" {
+		return "", errors.New("path is required")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.New("path must be relative to the skill directory")
+	}
+	full := filepath.Join(skillDir, rel)
+	within, err := filepath.Rel(skillDir, full)
+	if err != nil || within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) {
+		return "", errors.New("path escapes the skill directory")
+	}
+	return full, nil
 }
 
 // scriptLang maps a file extension to the interpreter language, for

--- a/forge-core/tools/builtins/read_skill.go
+++ b/forge-core/tools/builtins/read_skill.go
@@ -193,9 +193,14 @@ func SkillDir(workDir, name string) (string, bool) {
 }
 
 // SafeSkillJoin joins a skill-relative path onto the skill directory and
-// confines the result to that directory — rejecting absolute paths and
-// any `..` traversal that would escape the skill. Same posture as
-// read_skill's traversal guard and cli_execute's workdir confinement.
+// confines the result to that directory — rejecting absolute paths, `..`
+// traversal, AND symlinks that resolve outside the skill. The symlink
+// check matters because a skill package ships whatever the author writes
+// (COPY . .): a bundled symlink like `skills/owl/leak -> /etc/shadow`
+// passes a purely-textual guard (no `..`, not absolute) but `os.ReadFile`
+// / the script interpreter would follow it out of the skill dir. Same
+// confinement posture as read_skill's traversal guard and cli_execute's
+// workdir confinement.
 func SafeSkillJoin(skillDir, rel string) (string, error) {
 	if rel == "" {
 		return "", errors.New("path is required")
@@ -204,9 +209,31 @@ func SafeSkillJoin(skillDir, rel string) (string, error) {
 		return "", errors.New("path must be relative to the skill directory")
 	}
 	full := filepath.Join(skillDir, rel)
+	// Textual guard first (cheap; also handles a target that doesn't exist).
 	within, err := filepath.Rel(skillDir, full)
 	if err != nil || within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) {
 		return "", errors.New("path escapes the skill directory")
+	}
+	// Symlink guard: resolve symlinks on both the skill dir and the deepest
+	// existing part of the target, then re-check containment against the
+	// resolved root. Catches a leaf symlink (target exists) and an
+	// intermediate symlinked directory (target's parent exists).
+	root, err := filepath.EvalSymlinks(skillDir)
+	if err != nil {
+		return "", errors.New("resolving skill directory: " + err.Error())
+	}
+	// Anchor to the RESOLVED root so a symlinked temp root (e.g. macOS
+	// /var -> /private/var) doesn't cause a spurious prefix mismatch when
+	// the target doesn't exist yet.
+	resolved := filepath.Join(root, within)
+	if r, e := filepath.EvalSymlinks(full); e == nil {
+		resolved = r
+	} else if r, e := filepath.EvalSymlinks(filepath.Dir(full)); e == nil {
+		resolved = filepath.Join(r, filepath.Base(full))
+	}
+	rw, err := filepath.Rel(root, resolved)
+	if err != nil || rw == ".." || strings.HasPrefix(rw, ".."+string(filepath.Separator)) {
+		return "", errors.New("path escapes the skill directory (symlink)")
 	}
 	return full, nil
 }

--- a/forge-core/tools/builtins/read_skill_test.go
+++ b/forge-core/tools/builtins/read_skill_test.go
@@ -219,6 +219,43 @@ func TestSkillDirAndSafeJoin(t *testing.T) {
 	}
 }
 
+// TestSafeSkillJoin_SymlinkEscape pins the #257 security fix: a bundled
+// symlink whose target is outside the skill dir must be rejected even
+// though the textual path (no `..`, not absolute) looks confined.
+func TestSafeSkillJoin_SymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "owl", "owl", "# body\n")
+	dir := filepath.Join(root, "skills", "owl")
+	// A host secret outside the skill dir.
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Leaf symlink escaping the skill dir.
+	if err := os.Symlink(secret, filepath.Join(dir, "leak")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := SafeSkillJoin(dir, "leak"); err == nil {
+		t.Error("SafeSkillJoin followed a symlink escaping the skill dir")
+	}
+	// Intermediate symlinked directory escaping the skill dir.
+	if err := os.Symlink(root, filepath.Join(dir, "up")); err == nil {
+		if _, err := SafeSkillJoin(dir, "up/secret.txt"); err == nil {
+			t.Error("SafeSkillJoin followed an intermediate symlink escaping the skill dir")
+		}
+	}
+	// A symlink that stays INSIDE the skill dir is fine.
+	inside := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(inside, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(inside, filepath.Join(dir, "alias")); err == nil {
+		if _, err := SafeSkillJoin(dir, "alias"); err != nil {
+			t.Errorf("SafeSkillJoin rejected an in-skill symlink: %v", err)
+		}
+	}
+}
+
 // TestReadSkill_TraversalRejected keeps the directory-traversal guard.
 func TestReadSkill_TraversalRejected(t *testing.T) {
 	root := t.TempDir()

--- a/forge-core/tools/builtins/read_skill_test.go
+++ b/forge-core/tools/builtins/read_skill_test.go
@@ -35,6 +35,16 @@ func readSkill(t *testing.T, root, name string) string {
 
 func mustJSON(s string) string { b, _ := json.Marshal(s); return string(b) }
 
+func readSkillFile(t *testing.T, root, name, file string) string {
+	t.Helper()
+	out, err := NewReadSkillTool(root).Execute(context.Background(),
+		json.RawMessage(`{"name":`+mustJSON(name)+`,"file":`+mustJSON(file)+`}`))
+	if err != nil {
+		t.Fatalf("Execute(%q,%q): %v", name, file, err)
+	}
+	return out
+}
+
 // TestReadSkill_ResolvesByFrontmatterNameWhenDirDiffers is the core
 // regression for the skill-lookup bug: the loadable name advertised to
 // the LLM (the frontmatter name) must resolve even when the skill
@@ -147,6 +157,65 @@ func TestReadSkill_FlatFormatNoFileListing(t *testing.T) {
 	}
 	if out := readSkill(t, root, "weather"); strings.Contains(out, "## Skill files") {
 		t.Errorf("flat skill should have no file listing: %s", out)
+	}
+}
+
+// TestReadSkill_FileParam reads a file relative to the skill's directory
+// (issue #251) — the "read reference/runbook.md" case.
+func TestReadSkill_FileParam(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "owl", "owl", "# Owl\n")
+	base := filepath.Join(root, "skills", "owl")
+	if err := os.MkdirAll(filepath.Join(base, "reference"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "reference", "runbook.md"), []byte("# Runbook\nsteps"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := readSkillFile(t, root, "owl", "reference/runbook.md")
+	if !strings.Contains(out, "# Runbook") {
+		t.Errorf("expected runbook contents, got: %s", out)
+	}
+	if o := readSkillFile(t, root, "owl", "nope.md"); !strings.Contains(o, "not found") {
+		t.Errorf("expected not-found for missing file, got: %s", o)
+	}
+}
+
+// TestReadSkill_FileParamTraversal rejects file paths escaping the skill dir.
+func TestReadSkill_FileParamTraversal(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "owl", "owl", "# Owl\n")
+	if err := os.WriteFile(filepath.Join(root, "secret.txt"), []byte("LEAK"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"../../secret.txt", "../secret.txt", "/etc/hostname"} {
+		out := readSkillFile(t, root, "owl", bad)
+		if strings.Contains(out, "LEAK") || !strings.Contains(out, "error") {
+			t.Errorf("traversal %q not rejected: %s", bad, out)
+		}
+	}
+}
+
+func TestSkillDirAndSafeJoin(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "kube", "k8s-incident-triage", "# body\n")
+	for _, name := range []string{"kube", "k8s-incident-triage", "k8s_incident_triage"} {
+		dir, ok := SkillDir(root, name)
+		if !ok || filepath.Base(dir) != "kube" {
+			t.Errorf("SkillDir(%q) = %q,%v", name, dir, ok)
+		}
+	}
+	if _, ok := SkillDir(root, "ghost"); ok {
+		t.Error("SkillDir should fail for unknown skill")
+	}
+	dir, _ := SkillDir(root, "kube")
+	if _, err := SafeSkillJoin(dir, "scripts/x.sh"); err != nil {
+		t.Errorf("SafeSkillJoin rejected a legit path: %v", err)
+	}
+	for _, bad := range []string{"../escape", "/abs/path", "a/../../b"} {
+		if _, err := SafeSkillJoin(dir, bad); err == nil {
+			t.Errorf("SafeSkillJoin allowed escape %q", bad)
+		}
 	}
 }
 

--- a/forge-ui/skill_builder_context.go
+++ b/forge-ui/skill_builder_context.go
@@ -177,6 +177,24 @@ Example: k8s-incident-triage uses ` + "`" + `kubectl` + "`" + ` — it only need
 For custom logic, provide executable scripts in a ` + "`" + `scripts/` + "`" + ` directory.
 Tool name maps to script: underscores → hyphens (e.g. ` + "`" + `my_search` + "`" + ` → ` + "`" + `scripts/my-search.sh` + "`" + `).
 
+### Skill-relative references (files & scripts the instructions point to)
+Everything a skill ships lives in its OWN directory and can be referenced by a
+path RELATIVE TO THE SKILL in the instructions — no absolute paths, no ` + "`" + `..` + "`" + `:
+- To have the agent READ a bundled file, write e.g. "read ` + "`" + `reference/runbook.md` + "`" + `";
+  the agent loads it with ` + "`" + `read_skill` + "`" + ` (its ` + "`" + `file` + "`" + ` argument), resolved against the
+  skill directory.
+- To have the agent RUN a bundled helper script, write e.g. "run
+  ` + "`" + `scripts/check.py` + "`" + `"; the agent runs it with ` + "`" + `run_skill_script` + "`" + `, which resolves the
+  path against the skill directory, picks the interpreter by extension
+  (` + "`" + `.sh` + "`" + `→bash, ` + "`" + `.py` + "`" + `→python3, ` + "`" + `.js` + "`" + `→node), and executes it WITH THE SKILL
+  DIRECTORY AS THE WORKING DIRECTORY (so the script's own relative reads
+  resolve). JSON args are passed to the script as its first positional
+  argument (` + "`" + `$1` + "`" + `).
+
+Runnable helper-script languages: shell (` + "`" + `.sh` + "`" + `), Python (` + "`" + `.py` + "`" + `), JavaScript
+(` + "`" + `.js` + "`" + `). Add the interpreter to ` + "`" + `requires.bins` + "`" + ` (` + "`" + `python3` + "`" + ` / ` + "`" + `node` + "`" + `) when the
+skill ships that kind of script. TypeScript must be shipped as compiled ` + "`" + `.js` + "`" + `.
+
 ## Script Decision Logic
 
 Prefer this order:


### PR DESCRIPTION
Closes #251.

## Problem

A `SKILL.md` body references sibling files by a path relative to the skill's own directory ("read `reference/runbook.md`", "run `scripts/check.py`"). Those files ship in `skills/<skill>/` and reach the agent, but nothing resolved a skill-relative reference: `cli_execute` and the skill-script executor run with CWD = agent root, and only `.sh` `## Tool:` entries were runnable. A reasonable skill silently failed at runtime.

## Change (approach 1 — skill-scoped tools)

- **`read_skill` gains an optional `file` argument** — reads a file relative to the skill's directory (confined; no `..`/absolute escape) instead of `SKILL.md`. Handles "read `reference/runbook.md`".
- **New `run_skill_script` builtin** — executes a bundled script by path relative to the skill dir, picking the interpreter by extension (`.sh`→bash, `.py`→python3, `.js`→node) and running it **with the skill directory as CWD** so the script's own relative reads resolve. JSON `args` are passed as the script's first positional argument (`$1`). Path-confined; the subprocess inherits the same egress proxy + env passthrough as `cli_execute`/skill scripts. Registered independently of `cli_execute` (a skill may ship only non-`.sh` helpers).
- **Shared helpers** `builtins.SkillDir` + `builtins.SafeSkillJoin` resolve a skill's loadable name → directory and confine a relative path, used by both.
- **`skillEntryHasScript`** stays `.sh`-aligned by design: a `.py`/`.js` tool is now runnable via `run_skill_script` while correctly staying in the catalog `provides:` list — closing the #250 "falls between not-callable and in-provides" note without a code change (comment updated).

## Acceptance criteria

- [x] Relative file reference reads from the skill directory (`read_skill` `file`).
- [x] Relative script executes with the correct interpreter by extension, CWD = skill dir, inheriting egress proxy + env passthrough.
- [x] Path resolution confined to the skill directory (traversal / absolute-escape rejected), with tests.
- [x] `skillEntryHasScript` / `provides:` classification reconciled (rationale documented; `run_skill_script` makes py/js runnable so `provides:` is correct as-is).
- [x] Docs: Skill Designer prompt (`forge-ui/skill_builder_context.go`) + `docs/skills/writing-custom-skills.md` explain skill-relative references and runnable languages.
- [x] Tests: read + execute for shell/python/javascript + traversal guard.

## Tests

`run_skill_script_test.go` executes real shell/python/javascript scripts, each proving CWD=skill dir by reading a sibling `reference/data.txt`, plus traversal/absolute-escape rejection, unsupported-extension (`.ts`) error, and unknown-skill. `read_skill_test.go` adds the `file`-arg read + its traversal guard and the `SkillDir`/`SafeSkillJoin` helpers.

Full `forge-core/tools/builtins`, `forge-cli/tools`, and `forge-cli/runtime` suites green; `gofmt` + `golangci-lint` clean.

## Notes / scope

- TypeScript is intentionally unsupported (`node` can't run raw `.ts`) — ship compiled `.js`. Error is explicit.
- This is the runtime resolution layer. Registering `.py`/`.js` `## Tool:` entries as first-class callable tools (Model A) remains out of scope — `run_skill_script` (Model B) covers the referenced-by-path case the issue describes.
