### PR TITLE
feat(ui): skill-builder interview convergence + custom-binary install recipes (#252 part 1)

### DIFF
--- a/docs/ui/skill-builder-llm.md
+++ b/docs/ui/skill-builder-llm.md
@@ -140,6 +140,43 @@ about where it came from:
 | `openai/gpt-4.1` + **API key not configured (env: OPENAI_API_KEY)** | Config resolved but the named env var is empty in the `forge ui` process. Set it and reload. |
 | **Workspace skill-builder LLM is not configured** | First-run state. Click Configure. |
 
+## How the builder converses
+
+The Skill Builder is a multi-turn chat: the full conversation is replayed
+to the LLM on every turn with the Skill Designer system prompt
+(`forge-ui/skill_builder_context.go`). The prompt enforces an
+**interview-with-convergence** style so the session produces a skill fast
+instead of looping:
+
+- Reads the whole conversation each turn and **never re-asks** an answered
+  question.
+- Asks **at most one** clarifying question per turn, and only when a
+  genuinely blocking unknown remains.
+- Drafts the moment it knows the three essentials — the task + tool(s),
+  the credentials/env, and the command-line tools the scripts invoke —
+  preferring a sensible default (noted in the skill) over another question.
+
+### Custom binaries
+
+A skill's `requires.bins` entry can be a bare name (already in the base
+image) **or** a mapping that also tells the build how to install a binary
+the base image lacks — the builder emits the right one:
+
+- `- {name: ripgrep, apt: ripgrep}` (or `apk:` on the Alpine base)
+- `- {name: mytool, url: "https://…/mytool", dest: /usr/local/bin/mytool, chmod: "0755"}`
+- `- {name: foo, run: ["curl -L https://… | tar xz -C /usr/local/bin"]}`
+
+The builder will ask for a package name or download URL rather than invent
+one.
+
+### What it always gets right
+
+Regardless of the conversation, generated skills keep the Forge runtime
+contract: scripts read their JSON input from `$1` (`INPUT="${1:-}"`), emit
+structured JSON (never raw text), each `## Tool:` section carries an Input
+table + Output schema + request→input examples, and edit mode preserves
+existing `## Tool:` names (renaming breaks wired agents — issue #193).
+
 ## Why split `ui.yaml` and `.env`?
 
 Same trust-boundary reasoning as `forge init`'s `forge.yaml` / `.env`

--- a/forge-ui/skill_builder_context.go
+++ b/forge-ui/skill_builder_context.go
@@ -88,7 +88,7 @@ The goal is to PRODUCE a skill; questions are only a means to that end. A stuck 
 
 - Read the ENTIRE conversation before replying. NEVER re-ask something the user has already answered, even if it was phrased differently — re-asking an answered question is the worst thing you can do.
 - Ask AT MOST ONE clarifying question per turn, and only when a genuinely blocking unknown remains.
-- To draft a skill you need only three things: (1) the task and the tool(s) it exposes, (2) the credentials / env vars it needs, (3) the command-line tools its scripts invoke — plus, for any binary the base image lacks, its install details (see requires.bins below). The moment you know these three, STOP asking and return the complete SKILL.md.
+- To draft a skill you need FOUR things: (1) the task and the tool(s) it exposes, (2) the credentials / env vars it needs, (3) the command-line tools its scripts invoke, and (4) an install recipe for every binary the base image lacks (see requires.bins below). The moment you know all four, STOP asking and return the complete SKILL.md. NEVER draft with an invented package name or download URL — if a needed binary isn't standard and you weren't told how to install it, that fourth thing is still unknown: ask for it.
 - Prefer a sensible default (and note it in the description or ## Important Notes) over asking. E.g. "review a GitHub PR and comment, authenticating with a GitHub PAT" is already enough to draft: tool = the gh CLI (or curl to api.github.com), credential = GITHUB_TOKEN (secret), egress = api.github.com.
 - Egress domains can usually be inferred from the task — don't ask for them.
 - On later turns, apply the user's change and return the FULL updated skill (honoring the edit-mode rules when editing an existing skill).

--- a/forge-ui/skill_builder_context.go
+++ b/forge-ui/skill_builder_context.go
@@ -82,6 +82,17 @@ You help users design skills by:
 3. Generating a complete, valid SKILL.md file
 4. Optionally generating helper scripts if the skill requires them
 
+## Conversation Style — Converge Quickly
+
+The goal is to PRODUCE a skill; questions are only a means to that end. A stuck or looping interview is a failure. Follow these rules every turn:
+
+- Read the ENTIRE conversation before replying. NEVER re-ask something the user has already answered, even if it was phrased differently — re-asking an answered question is the worst thing you can do.
+- Ask AT MOST ONE clarifying question per turn, and only when a genuinely blocking unknown remains.
+- To draft a skill you need only three things: (1) the task and the tool(s) it exposes, (2) the credentials / env vars it needs, (3) the command-line tools its scripts invoke — plus, for any binary the base image lacks, its install details (see requires.bins below). The moment you know these three, STOP asking and return the complete SKILL.md.
+- Prefer a sensible default (and note it in the description or ## Important Notes) over asking. E.g. "review a GitHub PR and comment, authenticating with a GitHub PAT" is already enough to draft: tool = the gh CLI (or curl to api.github.com), credential = GITHUB_TOKEN (secret), egress = api.github.com.
+- Egress domains can usually be inferred from the task — don't ask for them.
+- On later turns, apply the user's change and return the FULL updated skill (honoring the edit-mode rules when editing an existing skill).
+
 ## SKILL.md Format
 
 A SKILL.md file has two parts:
@@ -113,6 +124,16 @@ metadata:
     # timeout_hint: 300                # Suggested timeout in seconds
 ---
 ` + "```" + `
+
+### Declaring binaries and their install recipe
+
+Each entry in ` + "`" + `requires.bins` + "`" + ` is EITHER a bare name (already present in the base image — most standard tools: curl, jq, git, kubectl, aws, gh) OR a mapping that also tells the build how to install a binary the base image lacks:
+
+- Distro package: ` + "`" + `- {name: ripgrep, apt: ripgrep}` + "`" + ` (use ` + "`" + `apk:` + "`" + ` for the Alpine base).
+- Direct download: ` + "`" + `- {name: initializ-cli, url: "https://.../initializ-cli", dest: /usr/local/bin/initializ-cli, chmod: "0755"}` + "`" + `.
+- Custom steps: ` + "`" + `- {name: foo, run: ["curl -L https://… | tar xz -C /usr/local/bin"]}` + "`" + `.
+
+Only add an install recipe for a binary that is NOT already available. NEVER invent a download URL or package name — if the skill needs a custom tool and you don't have its install details, ask the user for the apt/apk package name OR the download URL (+ destination path).
 
 ### 2. Markdown Body
 

--- a/forge-ui/skill_builder_prompt_test.go
+++ b/forge-ui/skill_builder_prompt_test.go
@@ -16,6 +16,13 @@ func TestSkillBuilderPrompt_ConvergenceRules(t *testing.T) {
 		"AT MOST ONE clarifying question",
 		"STOP asking and return the complete SKILL.md",
 		"Prefer a sensible default",
+		// The convergence trigger must count the install recipe as a
+		// first-class criterion, not hide it in a parenthetical — else the
+		// LLM drafts once it has task+creds+tools and invents a plausible
+		// install URL/package for a missing binary (#258 review).
+		"you need FOUR things",
+		"install recipe for every binary the base image lacks",
+		"NEVER draft with an invented package name or download URL",
 	} {
 		if !strings.Contains(p, want) {
 			t.Errorf("convergence prompt missing directive: %q", want)

--- a/forge-ui/skill_builder_prompt_test.go
+++ b/forge-ui/skill_builder_prompt_test.go
@@ -1,0 +1,81 @@
+package forgeui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSkillBuilderPrompt_ConvergenceRules pins the interview/convergence
+// discipline (issue #252) so it can't be silently dropped — a stuck or
+// looping interview is the main UX failure mode for a chat builder.
+func TestSkillBuilderPrompt_ConvergenceRules(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeCreate, nil)
+	for _, want := range []string{
+		"Converge Quickly",
+		"NEVER re-ask",
+		"AT MOST ONE clarifying question",
+		"STOP asking and return the complete SKILL.md",
+		"Prefer a sensible default",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("convergence prompt missing directive: %q", want)
+		}
+	}
+}
+
+// TestSkillBuilderPrompt_InstallRecipes pins the custom-binary install
+// guidance — requires.bins supports a mapping form (apt/apk/url+dest+chmod)
+// per BinRequirement, and the prompt must teach it.
+func TestSkillBuilderPrompt_InstallRecipes(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeCreate, nil)
+	for _, want := range []string{
+		"install recipe",
+		"apt:",
+		"url:",
+		"dest:",
+		"chmod:",
+		"NEVER invent a download URL",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("install-recipe prompt missing: %q", want)
+		}
+	}
+}
+
+// TestSkillBuilderPrompt_ForgeCorrectnessRetained guards the Forge-runtime
+// rules that must survive any interview-architecture edit (#252): the $1
+// JSON input contract, structured JSON output, the per-tool section shape
+// the agent selects on, and python-via-bins.
+func TestSkillBuilderPrompt_ForgeCorrectnessRetained(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeCreate, nil)
+	for _, want := range []string{
+		`INPUT="${1:-}"`,               // $1 input contract
+		"structured JSON output",       // never raw text
+		"## Tool:",                     // per-tool section
+		"**Input:**",                   // input parameter table
+		"**Output:**",                  // output schema
+		"Examples:",                    // request -> tool input examples
+		"Safety Constraints",           // safety section
+		"set -euo pipefail",            // bash safety
+		"add python3 to requires.bins", // python-via-bins
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("Forge-correctness rule dropped from prompt: %q", want)
+		}
+	}
+}
+
+// TestSkillBuilderPrompt_EditModePreservesToolNames guards issue #193's
+// edit-mode rule: renaming a `## Tool:` heading breaks wired agents.
+func TestSkillBuilderPrompt_EditModePreservesToolNames(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeEdit, &existingSkillContext{
+		Name:    "demo",
+		SkillMD: "---\nname: demo\n---\n## Tool: do_thing\n",
+	})
+	if !strings.Contains(p, "Preserve every `## Tool: <name>` heading exactly") {
+		t.Error("edit mode dropped the tool-name-preservation rule")
+	}
+	if !strings.Contains(p, "Converge Quickly") {
+		t.Error("edit mode should still carry the convergence rules (base prompt)")
+	}
+}


### PR DESCRIPTION
Part 1 of #252 — the interview architecture, without the streaming/frontend refactor.

## What this does

The UI Skill Builder is already multi-turn, but the Skill Designer prompt had no convergence discipline. This adds two prompt sections (`forge-ui/skill_builder_context.go`):

- **Conversation Style — Converge Quickly**: read the whole conversation, never re-ask an answered question, at most one question per turn, draft the moment task + credentials + tools are known, prefer a sensible default over asking, infer egress from the task.
- **Custom-binary install recipes**: `requires.bins` frontmatter already accepts a scalar name OR a mapping (`apt` / `apk` / `url`+`dest`+`chmod` / `run`) via `BinRequirement`'s scalar-or-mapping `UnmarshalYAML`. The prompt now teaches the mapping form and forbids inventing a URL/package name (ask instead).

The Forge-runtime rules the prompt already gets right are **retained and now guarded by tests** — the `$1` JSON input contract, structured JSON output, per-tool Input/Output/Examples sections, python-via-bins, and edit-mode `## Tool:` name preservation (#193).

Docs: `docs/ui/skill-builder-llm.md` gains a "How the builder converses" section.

## Tests

`skill_builder_prompt_test.go` pins the convergence directives, install-recipe guidance, retained correctness rules, and edit-mode tool-name preservation, so none can be silently dropped. Full `forge-ui` suite green; `gofmt` + `golangci-lint` clean.

## Deferred (tracked on #252)

The **structured `{message, skill}` JSON output envelope** — criteria 2 & 4 — is a larger change touching the SSE streaming format, the handler (replacing `extractArtifacts`), a JSON→SKILL.md compiler, and the frontend. It's de-risked (not blocked) by #253, which made the current fenced-artifact extraction tolerant. Splitting it out keeps this PR focused and low-risk.

## Acceptance criteria (this PR)

- [x] Convergence rules (one-question-max, no re-asking, draft-when-sufficient) — pinned by test
- [x] `bins` custom install recipes (apt / url+dest+chmod)
- [x] Forge-correctness rules retained (`$1` input, JSON output, `.sh`/python-via-bins, safety, edit-mode tool-name preservation) — pinned by test
- [x] Docs updated
- [ ] Structured `{message, skill}` output envelope — **follow-up**
- [ ] Per-tool `{input, output, examples}` capture in a JSON shape — **follow-up** (the prose `## Tool:` section requirements remain enforced)
