### PR TITLE
feat(build): expose env_required/env_optional in build-manifest.json

### DIFF
--- a/forge-cli/build/manifest_stage.go
+++ b/forge-cli/build/manifest_stage.go
@@ -57,6 +57,14 @@ func (s *ManifestStage) Execute(ctx context.Context, bc *pipeline.BuildContext) 
 	if len(bc.ToolCategoryCounts) > 0 {
 		manifest["tool_categories"] = bc.ToolCategoryCounts
 	}
+	if bc.Spec.Requirements != nil {
+		if len(bc.Spec.Requirements.EnvRequired) > 0 {
+			manifest["env_required"] = bc.Spec.Requirements.EnvRequired
+		}
+		if len(bc.Spec.Requirements.EnvOptional) > 0 {
+			manifest["env_optional"] = bc.Spec.Requirements.EnvOptional
+		}
+	}
 
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {

--- a/forge-cli/build/manifest_stage_test.go
+++ b/forge-cli/build/manifest_stage_test.go
@@ -55,3 +55,41 @@ func TestManifestStage_Execute(t *testing.T) {
 		t.Errorf("expected at least 2 files, got %d", len(files))
 	}
 }
+
+func TestManifestStage_EnvRequirements(t *testing.T) {
+	outDir := t.TempDir()
+	bc := pipeline.NewBuildContext(pipeline.PipelineOptions{OutputDir: outDir})
+	bc.Spec = &agentspec.AgentSpec{
+		AgentID: "test-agent",
+		Version: "0.1.0",
+		Requirements: &agentspec.AgentRequirements{
+			EnvRequired: []string{"OPENAI_API_KEY", "SLACK_BOT_TOKEN"},
+			EnvOptional: []string{"LOG_LEVEL"},
+		},
+	}
+
+	stage := &ManifestStage{}
+	if err := stage.Execute(context.Background(), bc); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outDir, "build-manifest.json"))
+	if err != nil {
+		t.Fatalf("reading build-manifest.json: %v", err)
+	}
+
+	var manifest struct {
+		EnvRequired []string `json:"env_required"`
+		EnvOptional []string `json:"env_optional"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshalling manifest: %v", err)
+	}
+
+	if len(manifest.EnvRequired) != 2 || manifest.EnvRequired[0] != "OPENAI_API_KEY" || manifest.EnvRequired[1] != "SLACK_BOT_TOKEN" {
+		t.Errorf("env_required = %v, want [OPENAI_API_KEY SLACK_BOT_TOKEN]", manifest.EnvRequired)
+	}
+	if len(manifest.EnvOptional) != 1 || manifest.EnvOptional[0] != "LOG_LEVEL" {
+		t.Errorf("env_optional = %v, want [LOG_LEVEL]", manifest.EnvOptional)
+	}
+}


### PR DESCRIPTION
## Summary
- `forge build` now writes the image's declared env-var union (`env_required` / `env_optional`) into `build-manifest.json`, sourced from the same `AgentSpec.Requirements` lists that already feed `secrets.yaml.tmpl` — skills' `requirements.env` ∪ channel env vars ∪ model-provider keys.

## Why
CI deploy tooling (the new `initializ` CLI, initializ/cli-next) needs the structured env contract of the image it just built, to preflight required-var coverage before deploying. Today the only machine-readable trace is `k8s/secrets.yaml`, where required-vs-optional is encoded as a `# optional` YAML comment — not parseable robustly. The manifest stage runs after AgentSpecStage/K8sStage, so the data is already on `bc.Spec.Requirements`; this is a pure addition to the manifest map.

## Testing
- `go test ./forge-cli/build/` — new `TestManifestStage_EnvRequirements` + existing suite pass
- `golangci-lint run ./forge-cli/build/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)