### PR TITLE
fix(ui): keep Skill Builder Edit button visible with long name/description (closes #261)

### DIFF
--- a/forge-ui/static/style.css
+++ b/forge-ui/static/style.css
@@ -1786,6 +1786,11 @@ body {
   border-right: 1px solid var(--border-color);
   height: 100%;
   overflow: hidden;
+  /* Grid items default to min-width: auto, which lets long content (a
+     skill's name/description) force this track wider than its 55% and,
+     because overflow is hidden, clip the row's Edit button off-screen.
+     min-width: 0 makes the track honor its width so children truncate. */
+  min-width: 0;
 }
 
 .skill-builder-right {
@@ -2198,6 +2203,16 @@ body {
   align-items: center;
   gap: 6px;
   font-weight: 600;
+  min-width: 0;
+}
+
+/* Truncate a long skill name too, so it doesn't push the description /
+   Edit button. The <code> is a flex child; min-width:0 lets it shrink. */
+.sb-custom-skill-name code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sb-custom-skill-desc {
@@ -2205,6 +2220,12 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* The Edit button must never be the element that shrinks/clips when the
+   name + description are long. */
+.sb-custom-skill-row .btn {
+  flex-shrink: 0;
 }
 
 .sb-custom-skills-footer {

--- a/forge-ui/static/style.css
+++ b/forge-ui/static/style.css
@@ -1822,6 +1822,28 @@ body {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
+  /* Flex item in the wrapping .sb-header; without min-width:0 a long
+     model name forces it past the panel width and the name clips under
+     Settings. Lay the children out in a row and truncate the model. */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* First child is the "provider/model" span — truncate it so a long
+   model name gets an ellipsis instead of clipping. */
+.provider-banner > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Settings button stays fully visible. */
+.provider-banner .btn {
+  flex-shrink: 0;
 }
 
 .provider-banner-error {
@@ -2172,6 +2194,13 @@ body {
   border: 1px solid var(--border-color);
   border-radius: var(--radius);
   padding: 6px 10px;
+  /* THE fix for the clipped Edit button: this is a flex item in the
+     display:flex .sb-header. With the default min-width:auto its
+     min-content is the full nowrap skill description, so it refuses to
+     shrink and overflows the 55% panel (clipped by overflow:hidden),
+     taking the row's Edit button off-screen. min-width:0 lets it honor
+     its flex-basis so the row's existing ellipsis truncation engages. */
+  min-width: 0;
 }
 
 .sb-custom-skills summary {


### PR DESCRIPTION
Closes #261.

## Problem

In the Skill Builder "Skills attached to this agent" list, a skill whose name + description are long pushed the row's **Edit** button off the right edge of the left panel, where it was clipped and unreachable.

## Root cause

The row already truncates correctly (`.sb-custom-skill-info { flex:1; min-width:0 }`, `.sb-custom-skill-desc { …ellipsis }`), so the failure was an ancestor **min-width blowout**: `.skill-builder-left` is a `55%` grid item (`.skill-builder` is `grid-template-columns: 55% 45%`) with the default `min-width: auto`, so long content forced the track wider than `55%`; because the panel is `overflow: hidden`, the Edit button at the end of the row was clipped rather than scrolled into view.

## Fix (CSS only, `forge-ui/static/style.css`)

- `min-width: 0` on `.skill-builder-left` — the track now honors its `55%` width, so the row's existing ellipsis truncation actually engages.
- `flex-shrink: 0` on `.sb-custom-skill-row .btn` — the Edit button is never the element that shrinks/clips.
- `min-width: 0` + ellipsis on `.sb-custom-skill-name` / its `<code>` — a long name truncates too, so it can't push the description or button.

## Verification

`go build ./forge-ui/...` passes (static assets are `go:embed`ed). Manual check: with a long name+description the Edit button stays fully visible and the name/description truncate within the panel; behavior holds at both the desktop `55%/45%` layout and the stacked mobile layout (`@media` at `style.css` ~2131).

No automated test — this is a pure CSS layout fix with no Go test surface.
