### PR TITLE
feat(ui): structured {message, skill} JSON output for Skill Builder (#252 part 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,15 +25,16 @@ jobs:
           cd forge-core && go mod verify
           cd ../forge-cli && go mod verify
           cd ../forge-plugins && go mod verify
+          cd ../forge-ui && go mod verify
 
       - name: Vet
-        run: go vet ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/...
+        run: go vet ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/... ./forge-ui/...
 
       - name: Check formatting
-        run: test -z "$(gofmt -l forge-core forge-cli forge-skills forge-plugins)"
+        run: test -z "$(gofmt -l forge-core forge-cli forge-skills forge-plugins forge-ui)"
 
       - name: Test
-        run: go test -race -coverprofile=coverage.out ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/...
+        run: go test -race -coverprofile=coverage.out ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/... ./forge-ui/...
 
       - name: Check coverage threshold
         run: |
@@ -62,7 +63,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.10.1
-          args: ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/...
+          args: ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/... ./forge-ui/...
 
   integration:
     name: Integration Tests
@@ -76,7 +77,7 @@ jobs:
           go-version: "1.25"
 
       - name: Integration tests
-        run: go test -race -tags=integration ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/...
+        run: go test -race -tags=integration ./forge-core/... ./forge-cli/... ./forge-skills/... ./forge-plugins/... ./forge-ui/...
 
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})

--- a/docs/ui/skill-builder-llm.md
+++ b/docs/ui/skill-builder-llm.md
@@ -152,9 +152,11 @@ instead of looping:
   question.
 - Asks **at most one** clarifying question per turn, and only when a
   genuinely blocking unknown remains.
-- Drafts the moment it knows the three essentials — the task + tool(s),
-  the credentials/env, and the command-line tools the scripts invoke —
-  preferring a sensible default (noted in the skill) over another question.
+- Drafts the moment it knows the four essentials — the task + tool(s), the
+  credentials/env, the command-line tools the scripts invoke, and an install
+  recipe for any binary the base image lacks — preferring a sensible default
+  (noted in the skill) over another question. It will not draft with an
+  invented package name or download URL.
 
 ### Custom binaries
 
@@ -168,6 +170,41 @@ the base image lacks — the builder emits the right one:
 
 The builder will ask for a package name or download URL rather than invent
 one.
+
+### Structured output (`{message, skill}`)
+
+Each turn the builder returns a single JSON envelope, not markdown fences:
+
+```json
+{
+  "message": "<the chat reply: a question, a chosen default, or a draft summary>",
+  "skill": null
+}
+```
+
+`skill` stays `null` while the interview is still converging. The moment the
+skill is draftable it becomes the full artifact:
+
+```json
+{
+  "message": "Here's your skill.",
+  "skill": {
+    "skill_md": "<the complete SKILL.md content>",
+    "scripts": { "my-tool.sh": "<complete script>" }
+  }
+}
+```
+
+The chat handler parses this envelope (`parseSkillEnvelope`), streaming a
+content-free `progress` keepalive during generation and delivering the
+`message` and `skill_draft` at completion — the UI renders `message` in the
+chat and loads `skill_md`/`scripts` into the editor. This replaces the old
+quadruple-backtick fence format, which LLMs frequently mis-nested. A model
+that still emits the legacy fences degrades gracefully: the handler falls
+back to fence extraction so the draft is never silently lost.
+
+In edit mode the full updated skill still comes back in `skill.skill_md`
+(never a partial diff), with the `**Changed:**` summary in `message`.
 
 ### What it always gets right
 

--- a/forge-ui/handlers_skill_builder.go
+++ b/forge-ui/handlers_skill_builder.go
@@ -184,14 +184,29 @@ func (s *UIServer) handleSkillBuilderChat(w http.ResponseWriter, r *http.Request
 		SystemPrompt: systemPrompt,
 		Messages:     req.Messages,
 		OnChunk: func(chunk string) {
+			// Accumulate for the OnDone parse. We deliberately do NOT
+			// forward raw chunks to the chat: the response is now a
+			// structured {message, skill} JSON envelope (#252 part 2), and
+			// streaming raw JSON tokens into the chat bubble would show the
+			// user a half-formed object. A `progress` ping keeps the
+			// connection warm and lets the UI animate a "designing" state
+			// without exposing the JSON.
 			fullResponse.WriteString(chunk)
-			data, _ := json.Marshal(map[string]string{"content": chunk})
-			_, _ = fmt.Fprintf(w, "event: chunk\ndata: %s\n\n", data)
+			_, _ = fmt.Fprint(w, "event: progress\ndata: {}\n\n")
 			flusher.Flush()
 		},
 		OnDone: func(response string) {
-			// Extract artifacts from the full response
-			skillMD, scripts := extractArtifacts(response)
+			// Parse the {message, skill} envelope. Falls back to legacy
+			// fence extraction if the model didn't emit JSON, so an older
+			// model degrades gracefully instead of showing nothing.
+			message, skillMD, scripts, _ := parseSkillEnvelope(response)
+
+			if message != "" {
+				msgData, _ := json.Marshal(map[string]string{"content": message})
+				_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", msgData)
+				flusher.Flush()
+			}
+
 			if skillMD != "" {
 				draftData, _ := json.Marshal(map[string]any{
 					"skill_md": skillMD,

--- a/forge-ui/handlers_skill_builder.go
+++ b/forge-ui/handlers_skill_builder.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/initializ/forge/forge-skills/parser"
 	"github.com/initializ/forge/forge-ui/uiconfig"
@@ -177,6 +178,7 @@ func (s *UIServer) handleSkillBuilderChat(w http.ResponseWriter, r *http.Request
 	systemPrompt := skillBuilderSystemPrompt(mode, existing)
 
 	var fullResponse strings.Builder
+	var lastProgress time.Time
 
 	err = s.cfg.LLMStreamFunc(r.Context(), LLMStreamOptions{
 		LLM:          llm,
@@ -191,9 +193,16 @@ func (s *UIServer) handleSkillBuilderChat(w http.ResponseWriter, r *http.Request
 			// user a half-formed object. A `progress` ping keeps the
 			// connection warm and lets the UI animate a "designing" state
 			// without exposing the JSON.
+			//
+			// Throttle the pings to ~2/sec: one SSE write+flush per token
+			// would be hundreds of events for a 10-20KB draft. The UI only
+			// needs a periodic keepalive, not a per-token signal (#276 review).
 			fullResponse.WriteString(chunk)
-			_, _ = fmt.Fprint(w, "event: progress\ndata: {}\n\n")
-			flusher.Flush()
+			if now := time.Now(); now.Sub(lastProgress) >= 500*time.Millisecond {
+				lastProgress = now
+				_, _ = fmt.Fprint(w, "event: progress\ndata: {}\n\n")
+				flusher.Flush()
+			}
 		},
 		OnDone: func(response string) {
 			// Parse the {message, skill} envelope. Falls back to legacy

--- a/forge-ui/handlers_skill_builder_chat_test.go
+++ b/forge-ui/handlers_skill_builder_chat_test.go
@@ -19,13 +19,13 @@ type sseEvent struct {
 
 func parseSSE(body string) []sseEvent {
 	var out []sseEvent
-	for _, frame := range strings.Split(body, "\n\n") {
+	for frame := range strings.SplitSeq(body, "\n\n") {
 		frame = strings.TrimSpace(frame)
 		if frame == "" {
 			continue
 		}
 		var ev sseEvent
-		for _, line := range strings.Split(frame, "\n") {
+		for line := range strings.SplitSeq(frame, "\n") {
 			if v, ok := strings.CutPrefix(line, "event: "); ok {
 				ev.event = v
 			} else if v, ok := strings.CutPrefix(line, "data: "); ok {

--- a/forge-ui/handlers_skill_builder_chat_test.go
+++ b/forge-ui/handlers_skill_builder_chat_test.go
@@ -1,0 +1,164 @@
+package forgeui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sseEvent is one parsed `event:`/`data:` SSE frame.
+type sseEvent struct {
+	event string
+	data  string
+}
+
+func parseSSE(body string) []sseEvent {
+	var out []sseEvent
+	for _, frame := range strings.Split(body, "\n\n") {
+		frame = strings.TrimSpace(frame)
+		if frame == "" {
+			continue
+		}
+		var ev sseEvent
+		for _, line := range strings.Split(frame, "\n") {
+			if v, ok := strings.CutPrefix(line, "event: "); ok {
+				ev.event = v
+			} else if v, ok := strings.CutPrefix(line, "data: "); ok {
+				ev.data = v
+			}
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+func chatTestServer(t *testing.T, stream LLMStreamFunc) (*UIServer, string) {
+	t.Helper()
+	isolateHome(t)
+	root := t.TempDir()
+	agentID := "test-agent"
+	agentDir := filepath.Join(root, agentID)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(agentDir, "forge.yaml"), `agent_id: test-agent
+version: 0.1.0
+framework: forge
+model:
+  provider: openai
+  name: gpt-4o
+`)
+	wsConfig := filepath.Join(root, ".forge", "ui.yaml")
+	if err := os.MkdirAll(filepath.Dir(wsConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, wsConfig, `skill_builder:
+  provider: openai
+  model: gpt-4o
+  api_key_env: OPENAI_API_KEY
+`)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	srv := NewUIServer(UIServerConfig{
+		Port:          4200,
+		WorkDir:       root,
+		ExePath:       "/usr/bin/false",
+		AgentPort:     9100,
+		LLMStreamFunc: stream,
+	})
+	return srv, agentID
+}
+
+func postChat(t *testing.T, srv *UIServer, agentID string) []sseEvent {
+	t.Helper()
+	body, _ := json.Marshal(SkillBuilderChatRequest{
+		Messages: []SkillBuilderMessage{{Role: "user", Content: "make a skill"}},
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/agents/"+agentID+"/skill-builder/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", agentID)
+	w := httptest.NewRecorder()
+	srv.handleSkillBuilderChat(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", w.Code, w.Body.String())
+	}
+	return parseSSE(w.Body.String())
+}
+
+// TestChat_SSESequence_StructuredEnvelope pins the wire contract (#276
+// review): a structured {message, skill} response produces progress →
+// message → skill_draft → done, with the message and draft on the right
+// events (never the raw JSON in the message).
+func TestChat_SSESequence_StructuredEnvelope(t *testing.T) {
+	envelope := `{"message": "Here you go.", "skill": {"skill_md": "---\nname: t\n---\n# T", "scripts": {}}}`
+	srv, agentID := chatTestServer(t, func(_ context.Context, opts LLMStreamOptions) error {
+		for _, ch := range envelope {
+			opts.OnChunk(string(ch))
+		}
+		opts.OnDone(envelope)
+		return nil
+	})
+
+	events := postChat(t, srv, agentID)
+
+	var sawProgress, sawMessage, sawDraft, sawDone bool
+	for _, e := range events {
+		switch e.event {
+		case "progress":
+			sawProgress = true
+		case "message":
+			sawMessage = true
+			var m map[string]string
+			_ = json.Unmarshal([]byte(e.data), &m)
+			if m["content"] != "Here you go." {
+				t.Errorf("message content = %q, want %q", m["content"], "Here you go.")
+			}
+			if strings.Contains(m["content"], "{") {
+				t.Errorf("raw JSON leaked into the message: %q", m["content"])
+			}
+		case "skill_draft":
+			sawDraft = true
+			var d map[string]any
+			_ = json.Unmarshal([]byte(e.data), &d)
+			if md, _ := d["skill_md"].(string); !strings.Contains(md, "name: t") {
+				t.Errorf("skill_draft skill_md = %q", md)
+			}
+		case "done":
+			sawDone = true
+		}
+	}
+	if !sawProgress || !sawMessage || !sawDraft || !sawDone {
+		t.Errorf("missing events: progress=%v message=%v skill_draft=%v done=%v",
+			sawProgress, sawMessage, sawDraft, sawDone)
+	}
+	// done must be last.
+	if events[len(events)-1].event != "done" {
+		t.Errorf("last event = %q, want done", events[len(events)-1].event)
+	}
+}
+
+// TestChat_SSESequence_EmptyResponse pins the empty edge the UI handles: an
+// empty model response emits no message/skill_draft — only done — so the UI
+// clears its pending placeholder without a stale bubble.
+func TestChat_SSESequence_EmptyResponse(t *testing.T) {
+	srv, agentID := chatTestServer(t, func(_ context.Context, opts LLMStreamOptions) error {
+		opts.OnDone("")
+		return nil
+	})
+
+	events := postChat(t, srv, agentID)
+	for _, e := range events {
+		if e.event == "message" || e.event == "skill_draft" {
+			t.Errorf("empty response should emit neither message nor skill_draft, got %q", e.event)
+		}
+	}
+	if len(events) == 0 || events[len(events)-1].event != "done" {
+		t.Errorf("empty response must still terminate with done; events=%+v", events)
+	}
+}

--- a/forge-ui/skill_builder_context.go
+++ b/forge-ui/skill_builder_context.go
@@ -47,9 +47,9 @@ func skillBuilderSystemPrompt(mode skillBuilderMode, existing *existingSkillCont
 		existing.Name)
 	b.WriteString("Rules for edit mode:\n\n")
 	b.WriteString("1. Preserve every `## Tool: <name>` heading exactly as it is now. Renaming a tool is a breaking change for any agent already wired to that tool name — only rename if the user explicitly asks for it.\n")
-	b.WriteString("2. Default to minimal patches. Re-emit the FULL `skill.md` fence so the editor can swap atomically, but call out what changed.\n")
-	b.WriteString("3. After the closing fence, add a `**Changed:**` bullet list summarizing the diff (one line per change).\n")
-	b.WriteString("4. If a helper script needs to be dropped entirely, say so in the **Changed:** list — do NOT re-emit it.\n\n")
+	b.WriteString("2. Default to minimal patches. Still return the FULL updated skill in the `skill.skill_md` field of the JSON envelope so the editor can swap atomically — never a partial diff.\n")
+	b.WriteString("3. Put a `**Changed:**` bullet list (one line per change) in the `message` field summarizing what you altered.\n")
+	b.WriteString("4. To drop a helper script entirely, omit it from `skill.scripts` and note the removal in the **Changed:** list. `skill.scripts` is the complete set of scripts the skill should have after your edit.\n\n")
 	b.WriteString("Current state of the skill being edited:\n\n")
 	b.WriteString("````current-skill.md\n")
 	b.WriteString(strings.TrimRight(existing.SkillMD, "\n"))
@@ -237,31 +237,32 @@ Always justify why a script is needed if you create one.
 - **denied_tools**: List tools the skill must NOT use (e.g. http_request if using cli_execute)
 - **No ` + "`" + `sh -c` + "`" + `**: Never use shell command strings; use proper scripts instead
 
-## Output Format
+## Output Format — STRUCTURED JSON
 
-When you generate skill content, use QUADRUPLE-backtick labeled fences (` + "````" + ` not ` + "```" + `).
-This is critical — inner triple-backtick code blocks (JSON schemas, etc.) must nest safely.
+Every reply you send is a SINGLE JSON object and NOTHING else. No prose before or after, no markdown code fences around it. The object has exactly two fields:
 
-For the SKILL.md content:
-` + "`````" + `
-` + "````" + `skill.md
----
-name: example-skill
-...
----
-# Example Skill
-...
-` + "````" + `
-` + "`````" + `
+` + "```" + `json
+{
+  "message": "<your chat reply to the user: a clarifying question, a note about a default you chose, or a short summary of the skill you just drafted>",
+  "skill": null
+}
+` + "```" + `
 
-For optional scripts (only if needed):
-` + "`````" + `
-` + "````" + `script:my-search.sh
-#!/bin/bash
-set -euo pipefail
-...
-` + "````" + `
-` + "`````" + `
+- ` + "`" + `message` + "`" + ` (string, required) — what the user reads in the chat. While you are still interviewing, this is your ONE clarifying question. When you draft or update a skill, this is a brief summary (and, in edit mode, the **Changed:** bullet list).
+- ` + "`" + `skill` + "`" + ` (object or null) — set to ` + "`" + `null` + "`" + ` on any turn where you are still gathering requirements. The moment the skill is draftable (all four things known), set it to:
+
+` + "```" + `json
+{
+  "skill_md": "<the COMPLETE SKILL.md content: frontmatter + full markdown body>",
+  "scripts": { "my-search.sh": "<complete script content>" }
+}
+` + "```" + `
+
+- ` + "`" + `skill_md` + "`" + ` is the entire SKILL.md as a single string (embedded newlines as ` + "`" + `\n` + "`" + `, embedded quotes escaped — it is a JSON string value). It MUST contain the full frontmatter AND the full markdown body with every required ` + "`" + `## Tool:` + "`" + ` section (Input table, Output JSON schema, Examples table, detection heuristics), Safety Constraints, and Important Notes — exactly as the examples below show.
+- ` + "`" + `scripts` + "`" + ` maps script filename → complete script content. Omit it or use ` + "`" + `{}` + "`" + ` for binary-backed skills with no scripts.
+- Return the FULL skill_md every time you draft or revise — never a diff or a fragment. The editor swaps the whole file atomically.
+
+The two worked examples below show SKILL.md CONTENT. When you respond, that content goes INSIDE the ` + "`" + `skill_md` + "`" + ` string of the JSON envelope — do not wrap your actual reply in backtick fences.
 
 ## Complete Example: Binary-backed Skill (k8s-incident-triage)
 

--- a/forge-ui/skill_builder_prompt_test.go
+++ b/forge-ui/skill_builder_prompt_test.go
@@ -49,6 +49,46 @@ func TestSkillBuilderPrompt_InstallRecipes(t *testing.T) {
 	}
 }
 
+// TestSkillBuilderPrompt_StructuredOutput pins the #252 part 2 output
+// contract: the builder must instruct a single {message, skill} JSON
+// envelope (skill:null while interviewing, {skill_md, scripts} once drafted)
+// so the handler consumes JSON instead of fragile fence-parsing.
+func TestSkillBuilderPrompt_StructuredOutput(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeCreate, nil)
+	for _, want := range []string{
+		"STRUCTURED JSON",
+		"SINGLE JSON object",
+		`"message"`,
+		`"skill"`,
+		"skill_md",
+		"scripts",
+		"null",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("structured-output prompt missing: %q", want)
+		}
+	}
+}
+
+// TestSkillBuilderPrompt_EditModeStructuredOutput pins that edit mode routes
+// the updated skill through skill.skill_md and the change summary through the
+// message field (not the old fence + trailing **Changed:** shape).
+func TestSkillBuilderPrompt_EditModeStructuredOutput(t *testing.T) {
+	p := skillBuilderSystemPrompt(modeEdit, &existingSkillContext{
+		Name:    "demo",
+		SkillMD: "---\nname: demo\n---\n## Tool: do_thing\n",
+	})
+	for _, want := range []string{
+		"`skill.skill_md` field",
+		"`message` field",
+		"`skill.scripts`",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("edit-mode structured-output rule missing: %q", want)
+		}
+	}
+}
+
 // TestSkillBuilderPrompt_ForgeCorrectnessRetained guards the Forge-runtime
 // rules that must survive any interview-architecture edit (#252): the $1
 // JSON input contract, structured JSON output, the per-tool section shape

--- a/forge-ui/skill_envelope.go
+++ b/forge-ui/skill_envelope.go
@@ -50,16 +50,31 @@ func parseSkillEnvelope(response string) (message, skillMD string, scripts map[s
 	// in prose hijacking the parse, and a valid envelope after a brace-bearing
 	// preamble being abandoned to the legacy path.
 	for from := 0; from < len(response); {
-		cand, end := jsonObjectAt(response, from)
+		cand, start := jsonObjectAt(response, from)
 		if cand == "" {
 			break
 		}
-		from = end
+		// On any rejection, advance to just past this candidate's opening `{`
+		// (not past the whole object), so a real envelope NESTED inside a
+		// wrapper — e.g. `{"response": {"message":…, "skill":…}}` — is still
+		// reachable on the next iteration (#276 review hardening).
+		next := start + 1
 		if !looksLikeEnvelope(cand) {
+			from = next
 			continue
 		}
 		var env skillEnvelope
 		if err := json.Unmarshal([]byte(cand), &env); err != nil {
+			from = next
+			continue
+		}
+		// Reject a zero-value "envelope": a wrapper like
+		// `{"response": {...}}` contains both key substrings and unmarshals
+		// cleanly (unknown top-level field ignored) but yields no message and
+		// no skill. Skip it so the inner real envelope (or the legacy
+		// fallback) wins instead of committing an empty structured result.
+		if env.Message == "" && env.Skill == nil {
+			from = next
 			continue
 		}
 		message = strings.TrimSpace(env.Message)
@@ -100,15 +115,16 @@ func extractJSONObject(s string) string {
 // tolerating a leading ```json fence or surrounding prose. It scans by brace
 // depth while skipping string literals (so a '}' inside a JSON string — very
 // likely in an embedded SKILL.md — doesn't terminate the object early).
-// Returns the object substring and the index just past it, so the caller can
-// resume scanning for the next candidate. Returns ("", len(s)) when no
-// complete object remains at/after `from`.
-func jsonObjectAt(s string, from int) (string, int) {
+// Returns the object substring and the index of its opening '{', so the
+// caller can resume scanning just past it (start+1) to reach nested
+// candidates. Returns ("", -1) when no complete object remains at/after
+// `from`.
+func jsonObjectAt(s string, from int) (obj string, start int) {
 	rel := strings.IndexByte(s[from:], '{')
 	if rel < 0 {
-		return "", len(s)
+		return "", -1
 	}
-	start := from + rel
+	start = from + rel
 	depth := 0
 	inString := false
 	escaped := false
@@ -133,9 +149,9 @@ func jsonObjectAt(s string, from int) (string, int) {
 		case '}':
 			depth--
 			if depth == 0 {
-				return s[start : i+1], i + 1
+				return s[start : i+1], start
 			}
 		}
 	}
-	return "", len(s) // unbalanced — no complete object
+	return "", -1 // unbalanced — no complete object
 }

--- a/forge-ui/skill_envelope.go
+++ b/forge-ui/skill_envelope.go
@@ -1,0 +1,115 @@
+package forgeui
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// skillEnvelope is the structured output the Skill Builder LLM returns
+// each turn (issue #252 part 2), replacing the fragile quadruple-backtick
+// fence format. `message` is the human-facing chat text (a clarifying
+// question while interviewing, or a summary once a skill is drafted).
+// `skill` is null while the interview is still converging and carries the
+// full draft the moment it becomes draftable.
+type skillEnvelope struct {
+	Message string        `json:"message"`
+	Skill   *skillPayload `json:"skill"`
+}
+
+// skillPayload is the drafted skill: the complete SKILL.md markdown plus
+// any helper scripts keyed by filename. This mirrors the {skill_md,
+// scripts} shape the editor/preview and the save endpoint already consume,
+// so only the transport (fences -> JSON) changes, not the artifact model.
+type skillPayload struct {
+	SkillMD string            `json:"skill_md"`
+	Scripts map[string]string `json:"scripts"`
+}
+
+// parseSkillEnvelope extracts the {message, skill} envelope from a raw LLM
+// response. It is deliberately forgiving:
+//
+//  1. Structured path — the response is (or contains) a JSON object with a
+//     `message` field. Returns structured=true. `skill` may be null (still
+//     interviewing) or a full draft.
+//  2. Legacy fallback — the model ignored the JSON instruction and emitted
+//     the old quadruple-backtick fences. We still recover the skill via
+//     extractArtifacts and surface the raw text as the message, so a model
+//     that hasn't adopted the new format degrades gracefully instead of
+//     showing the user nothing. Returns structured=false.
+//
+// message is always safe to display; skillMD is "" when no draft is present.
+func parseSkillEnvelope(response string) (message, skillMD string, scripts map[string]string, structured bool) {
+	scripts = make(map[string]string)
+
+	if jsonStr := extractJSONObject(response); jsonStr != "" {
+		var env skillEnvelope
+		if err := json.Unmarshal([]byte(jsonStr), &env); err == nil && looksLikeEnvelope(jsonStr) {
+			message = strings.TrimSpace(env.Message)
+			if env.Skill != nil {
+				skillMD = strings.TrimSpace(env.Skill.SkillMD)
+				if env.Skill.Scripts != nil {
+					scripts = env.Skill.Scripts
+				}
+			}
+			return message, skillMD, scripts, true
+		}
+	}
+
+	// Legacy fallback: recover artifacts from fenced output and show the
+	// raw response as the message.
+	skillMD, scripts = extractArtifacts(response)
+	return strings.TrimSpace(response), skillMD, scripts, false
+}
+
+// looksLikeEnvelope guards against a false-positive structured parse when
+// the model emits some *other* JSON object (e.g. a bare tool-output sample)
+// that happens to unmarshal into skillEnvelope with all-zero fields. We
+// require the literal "message" or "skill" key to be present.
+func looksLikeEnvelope(jsonStr string) bool {
+	return strings.Contains(jsonStr, `"message"`) || strings.Contains(jsonStr, `"skill"`)
+}
+
+// extractJSONObject returns the outermost JSON object in s, tolerating the
+// common ways an LLM wraps it: a leading ```json fence, surrounding prose,
+// or a clean bare object. Returns "" when no braces are found.
+//
+// It scans for the first '{' and the matching '}' by brace depth while
+// skipping over string literals (so a '}' inside a JSON string value —
+// very likely in an embedded SKILL.md — doesn't terminate the object
+// early). This is what makes the {skill_md: "...markdown with { }..."}
+// payload parse reliably.
+func extractJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/forge-ui/skill_envelope.go
+++ b/forge-ui/skill_envelope.go
@@ -41,18 +41,35 @@ type skillPayload struct {
 func parseSkillEnvelope(response string) (message, skillMD string, scripts map[string]string, structured bool) {
 	scripts = make(map[string]string)
 
-	if jsonStr := extractJSONObject(response); jsonStr != "" {
-		var env skillEnvelope
-		if err := json.Unmarshal([]byte(jsonStr), &env); err == nil && looksLikeEnvelope(jsonStr) {
-			message = strings.TrimSpace(env.Message)
-			if env.Skill != nil {
-				skillMD = strings.TrimSpace(env.Skill.SkillMD)
-				if env.Skill.Scripts != nil {
-					scripts = env.Skill.Scripts
-				}
-			}
-			return message, skillMD, scripts, true
+	// Try EVERY balanced {...} candidate in order, not just the first. A model
+	// may precede the real envelope with prose that itself contains JSON —
+	// tool-output examples are JSON in this domain — so the first object isn't
+	// necessarily the envelope. Iterate until one both parses AND carries the
+	// envelope keys; only then commit to the structured path. This closes two
+	// silent-draft-loss holes (#276 review): an incidental `{"message":"ok"}`
+	// in prose hijacking the parse, and a valid envelope after a brace-bearing
+	// preamble being abandoned to the legacy path.
+	for from := 0; from < len(response); {
+		cand, end := jsonObjectAt(response, from)
+		if cand == "" {
+			break
 		}
+		from = end
+		if !looksLikeEnvelope(cand) {
+			continue
+		}
+		var env skillEnvelope
+		if err := json.Unmarshal([]byte(cand), &env); err != nil {
+			continue
+		}
+		message = strings.TrimSpace(env.Message)
+		if env.Skill != nil {
+			skillMD = strings.TrimSpace(env.Skill.SkillMD)
+			if env.Skill.Scripts != nil {
+				scripts = env.Skill.Scripts
+			}
+		}
+		return message, skillMD, scripts, true
 	}
 
 	// Legacy fallback: recover artifacts from fenced output and show the
@@ -61,28 +78,37 @@ func parseSkillEnvelope(response string) (message, skillMD string, scripts map[s
 	return strings.TrimSpace(response), skillMD, scripts, false
 }
 
-// looksLikeEnvelope guards against a false-positive structured parse when
-// the model emits some *other* JSON object (e.g. a bare tool-output sample)
-// that happens to unmarshal into skillEnvelope with all-zero fields. We
-// require the literal "message" or "skill" key to be present.
+// looksLikeEnvelope guards against a false-positive structured parse on some
+// OTHER JSON object in the response. It requires BOTH the "message" and
+// "skill" keys — the prompt mandates exactly those two fields, so a real
+// envelope always carries both (even while interviewing, `skill` is present
+// as null). Requiring only one would let an incidental `{"message":"ok"}` in
+// prose hijack the parse and drop a fenced draft (#276 review).
 func looksLikeEnvelope(jsonStr string) bool {
-	return strings.Contains(jsonStr, `"message"`) || strings.Contains(jsonStr, `"skill"`)
+	return strings.Contains(jsonStr, `"message"`) && strings.Contains(jsonStr, `"skill"`)
 }
 
-// extractJSONObject returns the outermost JSON object in s, tolerating the
-// common ways an LLM wraps it: a leading ```json fence, surrounding prose,
-// or a clean bare object. Returns "" when no braces are found.
-//
-// It scans for the first '{' and the matching '}' by brace depth while
-// skipping over string literals (so a '}' inside a JSON string value —
-// very likely in an embedded SKILL.md — doesn't terminate the object
-// early). This is what makes the {skill_md: "...markdown with { }..."}
-// payload parse reliably.
+// extractJSONObject returns the FIRST balanced {...} object in s, or "".
+// Retained for callers/tests that only need the first object;
+// parseSkillEnvelope iterates all candidates via jsonObjectAt.
 func extractJSONObject(s string) string {
-	start := strings.IndexByte(s, '{')
-	if start < 0 {
-		return ""
+	obj, _ := jsonObjectAt(s, 0)
+	return obj
+}
+
+// jsonObjectAt finds the next balanced {...} object at or after `from`,
+// tolerating a leading ```json fence or surrounding prose. It scans by brace
+// depth while skipping string literals (so a '}' inside a JSON string — very
+// likely in an embedded SKILL.md — doesn't terminate the object early).
+// Returns the object substring and the index just past it, so the caller can
+// resume scanning for the next candidate. Returns ("", len(s)) when no
+// complete object remains at/after `from`.
+func jsonObjectAt(s string, from int) (string, int) {
+	rel := strings.IndexByte(s[from:], '{')
+	if rel < 0 {
+		return "", len(s)
 	}
+	start := from + rel
 	depth := 0
 	inString := false
 	escaped := false
@@ -107,9 +133,9 @@ func extractJSONObject(s string) string {
 		case '}':
 			depth--
 			if depth == 0 {
-				return s[start : i+1]
+				return s[start : i+1], i + 1
 			}
 		}
 	}
-	return ""
+	return "", len(s) // unbalanced — no complete object
 }

--- a/forge-ui/skill_envelope_test.go
+++ b/forge-ui/skill_envelope_test.go
@@ -1,0 +1,100 @@
+package forgeui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseSkillEnvelope_Interviewing — while still gathering requirements
+// the model returns a message with skill:null; no draft is surfaced.
+func TestParseSkillEnvelope_Interviewing(t *testing.T) {
+	resp := `{"message": "What credential should the skill use?", "skill": null}`
+	msg, skillMD, scripts, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("expected structured parse")
+	}
+	if msg != "What credential should the skill use?" {
+		t.Errorf("message = %q", msg)
+	}
+	if skillMD != "" {
+		t.Errorf("skillMD should be empty while interviewing, got %q", skillMD)
+	}
+	if len(scripts) != 0 {
+		t.Errorf("scripts should be empty, got %v", scripts)
+	}
+}
+
+// TestParseSkillEnvelope_Draft — once draftable, skill carries the full
+// skill_md and any scripts. The skill_md contains braces/newlines (an
+// embedded JSON output schema) that must not confuse the brace scanner.
+func TestParseSkillEnvelope_Draft(t *testing.T) {
+	resp := `{
+  "message": "Here is your skill.",
+  "skill": {
+    "skill_md": "---\nname: demo\n---\n# Demo\n## Tool: demo_tool\n**Output:**\n{\"ok\": true}\n",
+    "scripts": {"demo-tool.sh": "#!/bin/bash\nset -euo pipefail\necho '{}'\n"}
+  }
+}`
+	msg, skillMD, scripts, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("expected structured parse")
+	}
+	if msg != "Here is your skill." {
+		t.Errorf("message = %q", msg)
+	}
+	if wantSub := "## Tool: demo_tool"; !strings.Contains(skillMD, wantSub) {
+		t.Errorf("skillMD missing %q; got %q", wantSub, skillMD)
+	}
+	if !strings.Contains(skillMD, `{"ok": true}`) {
+		t.Errorf("skillMD lost the embedded JSON braces: %q", skillMD)
+	}
+	if scripts["demo-tool.sh"] == "" {
+		t.Errorf("script not recovered: %v", scripts)
+	}
+}
+
+// TestParseSkillEnvelope_FencedJSON — the model wraps its JSON in a ```json
+// fence or adds prose; extractJSONObject still isolates the object.
+func TestParseSkillEnvelope_FencedJSON(t *testing.T) {
+	resp := "Sure! Here you go:\n```json\n{\"message\": \"done\", \"skill\": null}\n```\n"
+	msg, _, _, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("expected structured parse from fenced JSON")
+	}
+	if msg != "done" {
+		t.Errorf("message = %q", msg)
+	}
+}
+
+// TestParseSkillEnvelope_LegacyFallback — a model that ignored the JSON
+// instruction and emitted the old quadruple-backtick fences still yields a
+// recovered skill (structured=false) so nothing is silently lost.
+func TestParseSkillEnvelope_LegacyFallback(t *testing.T) {
+	resp := "Here's the skill:\n````skill.md\n---\nname: legacy\n---\n# Legacy\n````\n"
+	_, skillMD, _, structured := parseSkillEnvelope(resp)
+	if structured {
+		t.Fatal("expected legacy (non-structured) path")
+	}
+	if !strings.Contains(skillMD, "name: legacy") {
+		t.Errorf("legacy fence extraction failed: %q", skillMD)
+	}
+}
+
+// TestExtractJSONObject_BraceInString — a '}' inside a string value must not
+// terminate the object early (the core reason we scan by depth, skipping
+// string literals, instead of using LastIndexByte).
+func TestExtractJSONObject_BraceInString(t *testing.T) {
+	in := `prefix {"a": "has a } brace", "b": 1} suffix`
+	got := extractJSONObject(in)
+	want := `{"a": "has a } brace", "b": 1}`
+	if got != want {
+		t.Errorf("extractJSONObject = %q, want %q", got, want)
+	}
+}
+
+// TestExtractJSONObject_None — no object present.
+func TestExtractJSONObject_None(t *testing.T) {
+	if got := extractJSONObject("no json here"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}

--- a/forge-ui/skill_envelope_test.go
+++ b/forge-ui/skill_envelope_test.go
@@ -134,6 +134,39 @@ func TestParseSkillEnvelope_BracePreambleFindsEnvelope(t *testing.T) {
 	}
 }
 
+// TestParseSkillEnvelope_WrapperObjectReachesInnerEnvelope (#276 re-review
+// hardening): a wrapper like {"response": {…real envelope…}} passes the
+// both-keys substring guard but unmarshals to a zero-value envelope. The
+// parser must reject the zero-value and descend to the nested real envelope
+// rather than committing an empty structured result.
+func TestParseSkillEnvelope_WrapperObjectReachesInnerEnvelope(t *testing.T) {
+	resp := `{"response": {"message": "Here you go.", "skill": {"skill_md": "---\nname: demo\n---\n", "scripts": {}}}}`
+	msg, skillMD, _, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("nested real envelope should be found (structured)")
+	}
+	if msg != "Here you go." {
+		t.Errorf("message = %q, want the inner envelope's message", msg)
+	}
+	if !strings.Contains(skillMD, "name: demo") {
+		t.Errorf("inner skill_md not extracted: %q", skillMD)
+	}
+}
+
+// TestParseSkillEnvelope_ZeroValueWrapperNoInnerFallsBack — a wrapper whose
+// inner object is NOT an envelope must fall back to legacy, not commit an
+// empty structured result.
+func TestParseSkillEnvelope_ZeroValueWrapperNoInnerFallsBack(t *testing.T) {
+	resp := "prefix {\"response\": {\"foo\": 1}} suffix\n````skill.md\n---\nname: fb\n---\n````\n"
+	_, skillMD, _, structured := parseSkillEnvelope(resp)
+	if structured {
+		t.Fatal("a non-envelope wrapper must not parse as structured")
+	}
+	if !strings.Contains(skillMD, "name: fb") {
+		t.Errorf("legacy fence draft lost: %q", skillMD)
+	}
+}
+
 // TestParseSkillEnvelope_InterviewingBothKeys — an interviewing turn carries
 // both keys with skill:null and must parse structured (both-keys guard must
 // not reject the legitimate null-skill case).

--- a/forge-ui/skill_envelope_test.go
+++ b/forge-ui/skill_envelope_test.go
@@ -98,3 +98,52 @@ func TestExtractJSONObject_None(t *testing.T) {
 		t.Errorf("expected empty, got %q", got)
 	}
 }
+
+// TestParseSkillEnvelope_IncidentalJSONDoesNotHijack (#276 review finding 1):
+// a legacy-format response whose prose contains an incidental JSON sample
+// (with only a "message" key) must NOT be mistaken for the envelope — the
+// fenced draft must still be recovered via the legacy path.
+func TestParseSkillEnvelope_IncidentalJSONDoesNotHijack(t *testing.T) {
+	resp := "The tool returns {\"message\": \"ok\"} on success. Here's the skill:\n" +
+		"````skill.md\n---\nname: real-skill\n---\n# Real\n````\n"
+	msg, skillMD, _, structured := parseSkillEnvelope(resp)
+	if structured {
+		t.Fatalf("incidental {\"message\":\"ok\"} must not be treated as the envelope; msg=%q", msg)
+	}
+	if !strings.Contains(skillMD, "name: real-skill") {
+		t.Errorf("fenced draft was lost; skillMD=%q", skillMD)
+	}
+}
+
+// TestParseSkillEnvelope_BracePreambleFindsEnvelope (#276 review finding 2):
+// a valid envelope preceded by brace-bearing prose (or a small JSON sample)
+// must be found by iterating candidates — not abandoned to the legacy path
+// (which would show the raw JSON as the message).
+func TestParseSkillEnvelope_BracePreambleFindsEnvelope(t *testing.T) {
+	resp := "Sure — for parsing {json} data, here you go: " +
+		`{"message": "Here is your skill.", "skill": {"skill_md": "---\nname: demo\n---\n# Demo\n", "scripts": {}}}`
+	msg, skillMD, _, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("valid envelope after brace-bearing preamble should parse as structured")
+	}
+	if msg != "Here is your skill." {
+		t.Errorf("message = %q", msg)
+	}
+	if !strings.Contains(skillMD, "name: demo") {
+		t.Errorf("skill_md not extracted: %q", skillMD)
+	}
+}
+
+// TestParseSkillEnvelope_InterviewingBothKeys — an interviewing turn carries
+// both keys with skill:null and must parse structured (both-keys guard must
+// not reject the legitimate null-skill case).
+func TestParseSkillEnvelope_InterviewingBothKeys(t *testing.T) {
+	resp := `{"message": "What credential?", "skill": null}`
+	msg, skillMD, _, structured := parseSkillEnvelope(resp)
+	if !structured {
+		t.Fatal("interviewing envelope (skill:null) must parse structured")
+	}
+	if msg != "What credential?" || skillMD != "" {
+		t.Errorf("msg=%q skillMD=%q", msg, skillMD)
+	}
+}

--- a/forge-ui/static/app.js
+++ b/forge-ui/static/app.js
@@ -2678,10 +2678,15 @@ function SkillBuilderPage({ agentId }) {
           setError(errMsg);
         },
         onDone() {
-          // If the model returned only a skill and no message, clear the
-          // pending state so the placeholder doesn't spin forever.
+          // Clear pending so the "designing" placeholder doesn't spin forever
+          // when the model returned only a skill (or nothing) with no message.
           if (assistantMsg.pending) {
             assistantMsg.pending = false;
+            // Empty model response with no draft loaded: show a placeholder
+            // rather than a blank bubble (#276 review).
+            if (!assistantMsg.content) {
+              assistantMsg.content = '_(no response)_';
+            }
             setMessages([...newMessages, { ...assistantMsg }]);
           }
         },

--- a/forge-ui/static/app.js
+++ b/forge-ui/static/app.js
@@ -140,7 +140,7 @@ async function fetchSkillBuilderProvider(agentId) {
   return res.json();
 }
 
-async function streamSkillBuilderChat(agentId, messages, { onChunk, onSkillDraft, onError, onDone, signal, mode, editingName }) {
+async function streamSkillBuilderChat(agentId, messages, { onProgress, onMessage, onSkillDraft, onError, onDone, signal, mode, editingName }) {
   const body = { messages };
   if (mode === 'edit' && editingName) {
     body.mode = 'edit';
@@ -179,7 +179,12 @@ async function streamSkillBuilderChat(agentId, messages, { onChunk, onSkillDraft
         const data = line.slice(6);
         try {
           const parsed = JSON.parse(data);
-          if (eventType === 'chunk' && onChunk) onChunk(parsed.content || '');
+          // #252 part 2: the builder now returns a structured {message, skill}
+          // envelope. `progress` is a content-free keepalive during
+          // generation; `message` carries the assistant's chat reply
+          // (delivered once, at completion); `skill_draft` carries the draft.
+          if (eventType === 'progress' && onProgress) onProgress();
+          else if (eventType === 'message' && onMessage) onMessage(parsed.content || '');
           else if (eventType === 'skill_draft' && onSkillDraft) onSkillDraft(parsed);
           else if (eventType === 'error' && onError) onError(parsed.error || 'Unknown error');
           else if (eventType === 'done' && onDone) onDone();
@@ -2640,8 +2645,10 @@ function SkillBuilderPage({ agentId }) {
     setStreaming(true);
     setError(null);
 
-    // Add placeholder assistant message
-    const assistantMsg = { role: 'assistant', content: '' };
+    // Add placeholder assistant message. The response is a structured
+    // {message, skill} envelope delivered at completion (not token-streamed),
+    // so show a "designing" affordance until the message arrives.
+    const assistantMsg = { role: 'assistant', content: '', pending: true };
     setMessages([...newMessages, assistantMsg]);
 
     const abort = new AbortController();
@@ -2652,8 +2659,13 @@ function SkillBuilderPage({ agentId }) {
         signal: abort.signal,
         mode,
         editingName: editingSkillName,
-        onChunk(content) {
-          assistantMsg.content += content;
+        onProgress() {
+          // Content-free keepalive; the pending placeholder stays until the
+          // message arrives. No per-token rendering (the stream is JSON).
+        },
+        onMessage(content) {
+          assistantMsg.content = content;
+          assistantMsg.pending = false;
           setMessages([...newMessages, { ...assistantMsg }]);
         },
         onSkillDraft(draft) {
@@ -2666,7 +2678,12 @@ function SkillBuilderPage({ agentId }) {
           setError(errMsg);
         },
         onDone() {
-          // streaming complete
+          // If the model returned only a skill and no message, clear the
+          // pending state so the placeholder doesn't spin forever.
+          if (assistantMsg.pending) {
+            assistantMsg.pending = false;
+            setMessages([...newMessages, { ...assistantMsg }]);
+          }
         },
       });
     } catch (err) {
@@ -2891,7 +2908,9 @@ function SkillBuilderPage({ agentId }) {
           `}
           ${messages.map((msg, i) => html`
             <div key=${i} class="sb-message sb-message-${msg.role}">
-              <div class="sb-message-content" dangerouslySetInnerHTML=${{ __html: renderMarkdown(msg.content) }} />
+              ${msg.pending && !msg.content
+                ? html`<div class="sb-message-content sb-message-pending"><em>Designing your skill…</em></div>`
+                : html`<div class="sb-message-content" dangerouslySetInnerHTML=${{ __html: renderMarkdown(msg.content) }} />`}
             </div>
           `)}
           ${streaming && html`<div class="sb-typing"><span class="spinner" /> Generating...</div>`}


### PR DESCRIPTION
## What

Part 2 of #252 — replace the Skill Builder's fragile quadruple-backtick fence output with a structured `{message, skill}` JSON envelope. (Part 1, #258, shipped the convergence rules + install recipes.)

Each turn the builder returns a single JSON object:

```json
{"message": "<chat reply>", "skill": null | {"skill_md": "…", "scripts": {…}}}
```

`skill` is `null` while interviewing and carries the full draft once draftable. The UI renders `message` in chat and loads `skill_md`/`scripts` into the editor.

## Why

LLMs frequently mis-nested the old `` ````skill.md `` / `` ````script: `` fences — inner triple-backtick JSON schemas had to nest safely inside quadruple fences. A JSON envelope is far more robust to produce and consume (issue #252, motivation #2).

## Design decisions

- **`skill: {skill_md, scripts}`** (LLM writes the full SKILL.md markdown into a JSON string) rather than a fully-structured tool→markdown compiler in Go. Matches the `skill_draft` payload the editor/save endpoint already consume; the per-tool `{input, output, examples}` requirement stays satisfied because the emitted `skill_md` still carries the mandated `## Tool:` sections. A structured compiler would be a much larger, drift-prone change — out of scope for part 2.
- **Message delivered at completion, not token-streamed.** Streaming raw JSON tokens into the chat bubble would show a half-formed object. A content-free `progress` event keeps the SSE connection warm and drives a "Designing your skill…" affordance; `message` + `skill_draft` arrive at `done`.
- **Graceful fallback.** `parseSkillEnvelope` falls back to legacy fence extraction if a model ignores the JSON instruction, so an un-migrated model never silently loses the draft.
- **Brace-aware JSON isolation.** `extractJSONObject` scans by brace depth while skipping string literals, so a `}` inside the embedded SKILL.md (very likely in a tool's Output JSON schema) doesn't terminate the object early. Also tolerates a ```` ```json ```` wrapper or surrounding prose.

## Forge-correctness preserved

Every runtime rule the prompt already got right is retained and test-pinned: `$1` input (`INPUT="${1:-}"`), structured JSON script output, `## Tool:` sections with Input/Output/Examples, safety constraints, `set -euo pipefail`, python-via-bins, and edit-mode `## Tool:` name preservation (#193).

## Tests

- `skill_envelope_test.go`: interviewing (skill:null) / draft / fenced-JSON / legacy-fence fallback / brace-in-string / no-object.
- `skill_builder_prompt_test.go`: new structured-output + edit-mode-shape assertions; existing convergence / install-recipe / correctness assertions still green.

## Docs

`docs/ui/skill-builder-llm.md`: new "Structured output" section; corrected a stale "three essentials" (part 1 made it four).

## Acceptance criteria (#252)

- [x] Structured `{message, skill}` envelope; handler consumes it instead of fence-parsing
- [x] `bins` install recipes (shipped in part 1 / #258)
- [x] Per-tool `{input, output, examples}` retained in compiled `## Tool:` sections
- [x] All Forge-correctness rules retained
- [x] Docs updated
- [ ] Multi-turn "drafts without looping" integration test — convergence rules are prompt-pinned; a live multi-turn harness is follow-up

## Stacking

Based on `feat/skill-builder-convergence` (#258) since both touch the prompt. Rebase to `main` once #258 merges.