### PR TITLE
feat(security): platform guardrails overlay + remove unused DB mode (#284)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -27,9 +27,8 @@ order: 3
 | `FORGE_CORS_ORIGINS` | Comma-separated CORS allowed origins for A2A server |
 | `FORGE_AUTH_URL` | External auth provider URL for token validation |
 | `FORGE_AUTH_ORG_ID` | Organization ID sent to external auth provider |
-| `FORGE_GUARDRAILS_DB` | MongoDB URI for DB-backed guardrails config + audit |
-| `FORGE_AGENT_ID` | Agent identifier for DB guardrails (falls back to `agent_id` in YAML) |
-| `FORGE_ORG_ID` | Organization identifier for DB guardrails |
+| `FORGE_AGENT_ID` | Agent identifier for audit entity identity (falls back to `agent_id` in YAML) |
+| `FORGE_ORG_ID` | Organization identifier for tenancy stamping / audit |
 | `FORGE_PASSPHRASE` | Passphrase for encrypted secrets file |
 
 ## Audit

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -108,7 +108,7 @@ Emits land as:
 }
 ```
 
-**1:1 join with the guardrails library's MongoDB audit.** When `FORGE_GUARDRAILS_DB` is set, the library writes its own audit records into a `GuardrailAuditEvent` collection in MongoDB carrying the same `entity_id` + `entity_type` columns. The values are sourced from the same env vars / forge.yaml so consumers reading both streams can join `forge.entity_id == library.entity_id AND forge.entity_type == library.entity_type` without translation. Forge only runs `entity_type: "agent"` today; the library supports `agent` / `workflow` / `assistant` as future-compatible values.
+**Entity identity.** Each event carries `entity_id` + `entity_type`, sourced from `FORGE_AGENT_ID` / `cfg.AgentID` at startup. These match the field names + values the guardrails library uses (`EntityType` constants: `agent` / `workflow` / `assistant`). Forge only runs `entity_type: "agent"` today; the other values are future-compatible.
 
 Entity identity has no per-request override — agent identity is fixed at process startup. The tenancy layer above (`org_id` / `workspace_id`) covers the multi-tenant routing case.
 

--- a/docs/security/guardrails.md
+++ b/docs/security/guardrails.md
@@ -4,36 +4,27 @@ description: "Configurable content filtering, PII detection, and jailbreak prote
 order: 7
 ---
 
-The guardrail engine validates inbound and outbound messages against configurable policy rules using the [`github.com/initializ/guardrails`](https://github.com/initializ/guardrails) library (pinned at `v0.12.0` in `forge-cli/go.mod`). Both the file-mode `guardrails.json` schema and the MongoDB-mode `AgentConfig` documents share the same shape — `models.StructuredGuardrails` from that library's [`models/config.go`](https://github.com/initializ/guardrails/blob/v0.12.0/models/config.go). The library's `models` package is the authoritative type definition; this page mirrors it for the fields most operators reach for, but field-level additions in newer library versions will surface there first.
+The guardrail engine validates inbound and outbound messages against configurable policy rules using the [`github.com/initializ/guardrails`](https://github.com/initializ/guardrails) library (pinned at `v0.12.0` in `forge-cli/go.mod`). The agent's config is a `guardrails.json` file whose shape is `models.StructuredGuardrails` from that library's [`models/config.go`](https://github.com/initializ/guardrails/blob/v0.12.0/models/config.go). The library's `models` package is the authoritative type definition; this page mirrors it for the fields most operators reach for, but field-level additions in newer library versions will surface there first.
 
 ## Architecture
 
-Guardrails are implemented as a `GuardrailChecker` interface in forge-core, with the concrete engine in forge-cli wrapping the external guardrails library. Two operational modes are supported:
-
-| Mode | Config Source | Use Case |
-|------|--------------|----------|
-| **File mode** (default) | `guardrails.json` in project root | Local development, standalone deployments |
-| **DB mode** | MongoDB (`AgentConfig` collection) | Platform deployments with centralized config + audit |
+Guardrails are implemented as a `GuardrailChecker` interface in forge-core, with the concrete engine in forge-cli wrapping the external guardrails library. The agent authors a `guardrails.json`; a platform operator can further **tighten** it with an overlay (never loosen). See [Platform guardrails overlay](#platform-guardrails-overlay).
 
 ### Source precedence
 
-`BuildGuardrailChecker` (`forge-cli/runtime/guardrails_loader.go`) resolves the active config in this exact order at every `forge run`. The first row whose trigger matches is the one that loads — there is no merging across rows.
+`BuildGuardrailChecker` (`forge-cli/runtime/guardrails_loader.go`) resolves the effective config at every `forge run`:
 
-| # | Trigger | Outcome | What happens to lower-priority sources |
-|---|---|---|---|
-| 1 | `FORGE_GUARDRAILS_DB` set **and** MongoDB connect + ping succeed | **DB mode** — config loaded per-request from the `AgentConfig` collection in the `Initializ` database, keyed by `(FORGE_AGENT_ID, FORGE_ORG_ID)`. Audit records written back to MongoDB (`EnableAudit: true`). | `guardrails.json` is ignored at runtime even if present in the image. |
-| 2 | `FORGE_GUARDRAILS_DB` set **but** connect or ping fails (3-second timeout) | Default: warns `failed to connect guardrails DB, falling back to file` and continues to row 3. With `FORGE_GUARDRAILS_DB_REQUIRED=true`: logs an Error and returns a non-nil startup error — the agent refuses to serve. See [Fail-loud mode](#fail-loud-mode). | Falls through (default) / no fallback (REQUIRED). |
-| 3 | `guardrails.json` exists at `<workDir>/<cfg.GuardrailsPath \|\| "guardrails.json">` and parses | **File mode** — config is the parsed `StructuredGuardrails`. | Built-in defaults discarded. |
-| 4 | File missing, unreadable, or invalid JSON | **Built-in defaults** — bundled PII (email/phone/SSN/credit-card) + jailbreak/prompt-injection/command-injection detection + 11 secret-pattern regexes (see [Default Secret Patterns](#default-secret-patterns)). | N/A — this is the floor. |
-| 5 | Engine construction itself errors (after picking 3 or 4) | Warns `failed to create file guardrail engine, using noop` and installs a `NoopGuardrailChecker`. | No checks run; messages pass through unmodified. |
+| # | Trigger | Outcome |
+|---|---|---|
+| 1 | `guardrails.json` exists at `<workDir>/<cfg.GuardrailsPath \|\| "guardrails.json">` and parses | Config is the parsed `StructuredGuardrails`. |
+| 2 | File missing, unreadable, or invalid JSON | **Built-in defaults** — bundled PII (email/phone/SSN/credit-card) + jailbreak/prompt-injection/command-injection detection + 11 secret-pattern regexes (see [Default Secret Patterns](#default-secret-patterns)). This is the floor. |
+| 3 | (always, after 1 or 2) **Platform guardrails overlay** is merged over the result — see [Platform guardrails overlay](#platform-guardrails-overlay). It can only tighten. |
+| 4 | Engine construction itself errors | Warns `failed to create file guardrail engine, using noop` and installs a `NoopGuardrailChecker` — no checks run, messages pass through unmodified. |
 
-Notable consequences of the order:
+Notable:
 
-- **MongoDB mode bypasses `guardrails.json` entirely** — the file still gets baked into `/app/guardrails.json` by the build, but the runner never opens it when `FORGE_GUARDRAILS_DB` is set. You can flip an agent between modes at runtime by setting / unsetting the env var without rebuilding.
-- **DB failure is non-fatal by default.** A misconfigured URI or transient network issue drops to file mode with a warning, not a hard exit. Set `FORGE_GUARDRAILS_DB_REQUIRED=true` to flip this — recommended for production. See [Fail-loud mode](#fail-loud-mode).
-- **DB mode requires `FORGE_ORG_ID`** to scope the `AgentConfig` lookup. Forgetting to set it usually surfaces as the library returning no config and decisions defaulting through; check that org ID is populated alongside the URI.
-- **`cfg.GuardrailsPath`** in `forge.yaml` overrides the default `"guardrails.json"` filename for file mode only — it has no effect in DB mode.
-- **Audit sinks differ.** DB mode writes via the library's `EnableAudit` path into MongoDB. File mode emits Forge's normal `guardrail_check` audit events through the configured audit sinks (see [Audit Events](#audit-events)).
+- **`cfg.GuardrailsPath`** in `forge.yaml` overrides the default `"guardrails.json"` filename.
+- The engine emits Forge's normal `guardrail_check` audit events through the configured audit sinks (see [Audit Events](#audit-events)).
 
 ## Built-in Evaluators
 
@@ -345,80 +336,61 @@ See [Gate Configuration](#gate-configuration) above. Field types are all `bool` 
 
 - The `forge init` template generates a `guardrails.json` containing only the `pii`, `security`, `customRules`, and `gateConfig` blocks. The other blocks (`moderation`, `urlFilter`, `approvalGates`, `nsfwText`, `hallucination`, `skillConstraints`) are not bootstrapped but are accepted at runtime — add them by hand if you need them.
 - All blocks are pointer-typed in the library struct. Omitting a key in JSON is equivalent to disabling that evaluator; setting an empty object `{}` with `enabled: false` is functionally the same but uses one extra parse cycle.
-- camelCase JSON keys are the contract — the BSON tags happen to be identical so a `StructuredGuardrails` document round-trips between MongoDB and `guardrails.json` without translation.
+- camelCase JSON keys are the contract — they match the library's struct tags exactly.
 - For evaluator semantics, regex flag handling, and the full action vocabulary, see the library's [`models/config.go`](https://github.com/initializ/guardrails/blob/v0.12.0/models/config.go).
 
-## DB Mode (Platform Deployments)
+## Platform guardrails overlay
 
-When `FORGE_GUARDRAILS_DB` is set to a MongoDB connection URI, the engine loads guardrails config from the `AgentConfig` collection and enables audit logging.
+A platform operator can **further restrict** an agent's `guardrails.json` without editing it — the same one-way ratchet the [platform policy](platform-policy.md) applies to tools / egress / models / channels. The overlay can force detections and gates on, raise actions, lower thresholds, and add rules; it can **never loosen** what the agent declared.
 
-```bash
-export FORGE_GUARDRAILS_DB="mongodb://localhost:27017"
-export FORGE_AGENT_ID="my-agent"
-export FORGE_ORG_ID="my-org"
-forge run
+The overlay is authored inside the platform `policy.yaml` under a `guardrails:` key, using the **same schema** as `guardrails.json` (the camelCase `StructuredGuardrails` fields), just in YAML:
+
+```yaml
+# policy.yaml (system / user / workspace layer — see platform-policy.md)
+denied_tools:
+  - http_request
+guardrails:
+  gateConfig:
+    outputGate: true          # force the output gate on
+  security:
+    commandInjection:
+      enabled: true
+      confidenceThreshold: 15  # lower = more sensitive
+      action: block            # raise warn/mask -> block
+  customRules:
+    rules:
+      - id: platform_secret
+        name: Internal token
+        type: regex
+        constraint: hard
+        pattern: "intz-[a-f0-9]{16}"
+        action: block
 ```
 
-The library queries `AgentConfig` with `{agent_id, org_id}` to load the `StructuredGuardrails` config.
+It is loaded from all three policy layers (system → user → workspace) and folded together most-restrictively, then merged over the agent config.
 
-| Environment Variable | Default | Description |
-|---|---|---|
-| `FORGE_GUARDRAILS_DB` | unset | MongoDB connection URI. Setting this activates DB mode. |
-| `FORGE_GUARDRAILS_DB_REQUIRED` | `false` | When `true`, an unreachable DB at startup makes the agent refuse to serve instead of silently downgrading. **Recommended for production.** See [Fail-loud mode](#fail-loud-mode). |
-| `FORGE_AGENT_ID` | from `forge.yaml` `agent_id` | Agent identifier the library uses to look up the `AgentConfig` document. |
-| `FORGE_ORG_ID` | unset | Organization identifier scoping the lookup. |
+### Merge semantics (tighten only)
 
-### Why DB mode is strictly more dangerous than file mode
-
-This is the most common operator footgun in the guardrails subsystem and deserves an explicit callout.
-
-The runtime selection is mutually exclusive (see the [resolution ladder](#source-precedence) above) — there is no merging. When `FORGE_GUARDRAILS_DB` is set:
-
-- The operator's MongoDB `AgentConfig` document is the **only** source of policy.
-- The built-in `DefaultStructuredGuardrails` (11 vendor-secret patterns, PII config, jailbreak / prompt-injection / command-injection thresholds) is **NOT** applied. It is only a fallback in file mode when `guardrails.json` is absent.
-- Any `guardrails.json` checked into the repo is **silently ignored** at runtime. Repo readers see the file and assume it's active; it isn't.
-
-The consequence: a DB-mode deploy with an empty or incomplete `AgentConfig` document is **strictly less protective** than a file-mode deploy with no file at all. A clean default deploy gets the built-in baseline; a DB-mode deploy that forgot to seed PII detection or didn't load the secret-pattern rules has no baseline at all.
-
-Operators MUST seed `AgentConfig` with the equivalent of `DefaultStructuredGuardrails`. Forge ships a CLI helper that produces ready-to-pipe JSON:
-
-```bash
-forge guardrails seed-defaults > defaults.json
-# load into MongoDB, e.g.:
-mongoimport --uri "$FORGE_GUARDRAILS_DB" \
-  --db Initializ --collection AgentConfig \
-  --file <(jq --arg id "$FORGE_AGENT_ID" '. + {agent_id:$id}' defaults.json)
-```
-
-After seeding, validate coverage:
-
-```bash
-forge guardrails validate-db
-```
-
-The validator connects to `FORGE_GUARDRAILS_DB`, fetches the agent's document, and reports on baseline coverage. Warnings surface when fewer than 5 secret-pattern rules are present, PII config is missing, or core gates are disabled — the common signs of an incomplete seed. Exits non-zero when no document exists at all, so CI / deployment hooks can fail the rollout.
-
-### Fail-loud mode
-
-When DB mode is security-critical (the platform deploy default), set `FORGE_GUARDRAILS_DB_REQUIRED=true`. The agent's startup behavior on an unreachable Mongo flips:
-
-| `FORGE_GUARDRAILS_DB_REQUIRED` | DB unreachable at startup |
+| Field | Rule |
 |---|---|
-| unset / `false` | Logs a warning, falls through to file mode (current default — back-compat). |
-| `true` | Logs an error, returns a non-nil error from runner startup, the agent process exits non-zero. |
+| `gateConfig.*` | boolean OR — a gate can be forced on, never off |
+| detections (`pii`, `security.*`, `nsfwText`, `moderation`, `hallucination`) | force-enable; take the **most-severe action** (`warn` < `mask` < `block`); take the **lower** (stricter) threshold |
+| `customRules.rules`, `security.customPatterns`, hard/soft constraints | **union** — platform rules are added; agent rules are never removed |
+| `urlFilter` | **union** denylist; **intersect** allowlist; force-enable |
+| `approvalGates` | **union** |
+| `skillConstraints` | **union** `blockedSkills`; **intersect** `allowedSkills` |
 
-The fail-loud posture matches the FWS-7 audit-sink and security-policy expectations: a misconfigured Mongo URI or a transient Mongo outage at startup MUST NOT silently downgrade protection. Platform deployments running guardrails under DB mode should set this in the deployment manifest by default; one-off `FORGE_GUARDRAILS_DB=mongodb://...` dev usage without the flag keeps the warn-and-fallback behavior.
+Every tightening the overlay applies is logged at startup (`guardrails: platform overlay tightened agent guardrails`) with the changed fields and the contributing layer, so operators can see exactly what the overlay changed. A malformed overlay (or an unknown field — strict parsing) fails loudly rather than silently dropping intended tightening.
 
-A startup warning also fires (exactly once) when both `FORGE_GUARDRAILS_DB` is set AND a `guardrails.json` is present in the workdir, pointing at the specific file being ignored. Remove the file or unset the env var to avoid drift.
+### `seed-defaults` helper
 
-### Helper subcommands
+`forge guardrails seed-defaults` prints `DefaultStructuredGuardrails` as JSON to scaffold a `guardrails.json`:
 
-| Command | Purpose |
-|---|---|
-| `forge guardrails seed-defaults` | Print `DefaultStructuredGuardrails` as JSON suitable for MongoDB seeding. Round-trips through `models.StructuredGuardrails` so the output is library-consumable verbatim. |
-| `forge guardrails validate-db` | Connect to `FORGE_GUARDRAILS_DB`, fetch the agent's `AgentConfig`, and report on baseline coverage (PII config, security thresholds, secret-pattern rule count, gate enablement). Exits non-zero on missing document. |
+```bash
+forge guardrails seed-defaults > guardrails.json
+```
 
-Both commands honor the `FORGE_GUARDRAILS_DB` / `FORGE_AGENT_ID` env vars and accept `--mongo-uri` / `--agent-id` flag overrides for ad-hoc invocations.
+The output round-trips through `models.StructuredGuardrails` and covers the 11 vendor-secret patterns, PII config, and jailbreak / prompt-injection / command-injection thresholds.
 
 ## Runtime
 
@@ -654,13 +626,8 @@ agent ever see PII?" should treat a `decision=blocked` row as the
 only one that can carry plain-text PII through the stream, and gate
 their export pipeline accordingly.
 
-### Mode-specific behavior
-
-- **File mode** — every event flows through the Forge audit pipeline.
-- **DB mode** — the guardrails library also writes audit records to
-  MongoDB when `EnableAudit` is set. Forge still emits the
-  `guardrail_check` event on its own audit sinks so SIEM consumers
-  reading the export socket see parity regardless of mode.
+Every guardrail decision flows through the Forge audit pipeline as a
+`guardrail_check` event on the configured audit sinks.
 
 See [Security Overview](overview.md) for the full security architecture
 and [Audit Logging](audit-logging.md) for the sink stack and schema

--- a/docs/security/tenancy.md
+++ b/docs/security/tenancy.md
@@ -33,7 +33,7 @@ Each field is resolved independently. A request that overrides only `X-Forge-Org
 
 Entity identity has **no per-request header layer** — entity is fixed at process startup. If a deployment needs per-request entity routing, the tenancy layer above already covers that (an agent serving multiple workspaces). Agent identity is the process, by definition.
 
-`entity_type` and `entity_id` match the field names + values the guardrails library writes to its MongoDB `GuardrailAuditEvent` collection (see `EntityType` constants: `agent` / `workflow` / `assistant`). When `FORGE_GUARDRAILS_DB` is set, both streams carry the same `(entity_id, entity_type)` pair and consumers join them 1:1 without translation. Forge only runs agents today, so the value is always `"agent"`; future entity types are an additive value change, not a schema change.
+`entity_type` and `entity_id` match the field names + values the guardrails library uses (see `EntityType` constants: `agent` / `workflow` / `assistant`). Forge only runs agents today, so the value is always `"agent"`; future entity types are an additive value change, not a schema change.
 
 ## Static tenancy (one agent per workspace)
 

--- a/forge-cli/cmd/guardrails.go
+++ b/forge-cli/cmd/guardrails.go
@@ -1,341 +1,60 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/initializ/forge/forge-cli/runtime"
 )
 
-// guardrailsCmd groups the operator-facing commands for the
-// MongoDB-backed guardrails subsystem. The runtime selection between
-// DB mode and file mode is documented in docs/security/guardrails.md;
-// these subcommands help operators seed a fresh AgentConfig and
-// validate an existing one. Issue #166.
+// guardrailsCmd groups the operator-facing guardrails helpers. Guardrails
+// run from the agent's guardrails.json (falling back to the built-in
+// DefaultStructuredGuardrails when the file is absent), optionally tightened
+// by the platform guardrails overlay in policy.yaml (#284). See
+// docs/security/guardrails.md.
 var guardrailsCmd = &cobra.Command{
 	Use:   "guardrails",
-	Short: "Manage guardrails configuration (DB mode operator helpers)",
-	Long: `Operator helpers for the MongoDB-backed guardrails subsystem.
+	Short: "Manage guardrails configuration",
+	Long: `Operator helpers for the agent's guardrails.
 
-Forge can run guardrails in two mutually-exclusive modes:
-
-  - File mode (default): reads guardrails.json from the agent's
-    workdir; falls back to built-in DefaultStructuredGuardrails when
-    the file is absent.
-  - DB mode (FORGE_GUARDRAILS_DB set): loads AgentConfig from
-    MongoDB. The library reads the document on every gate call.
-
-In DB mode the operator's MongoDB seed is the ONLY source of policy —
-the built-in DefaultStructuredGuardrails is NOT applied. An incomplete
-seed (missing PII config, no secret-pattern rules, no jailbreak
-threshold) leaves the agent strictly less protected than a file-mode
-deploy with no file at all. These subcommands help operators avoid
-that footgun.
+Guardrails are read from guardrails.json in the agent's workdir; when the
+file is absent the built-in DefaultStructuredGuardrails apply. A platform
+operator can further RESTRICT them (never loosen) via the guardrails: overlay
+in the platform policy.yaml — see docs/security/platform-policy.md and #284.
 
 See docs/security/guardrails.md for the full resolution ladder.`,
 }
 
 var guardrailsSeedDefaultsCmd = &cobra.Command{
 	Use:   "seed-defaults",
-	Short: "Print DefaultStructuredGuardrails as JSON suitable for MongoDB seeding",
+	Short: "Print DefaultStructuredGuardrails as JSON to scaffold a guardrails.json",
 	Long: `Print the built-in DefaultStructuredGuardrails as pretty-printed JSON.
 
-The output matches the library's models.StructuredGuardrails schema
-and is suitable for loading directly into MongoDB as the agent's
-AgentConfig.structured_guardrails document. Pipe to a file and edit
-before seeding if you want to tweak thresholds or add rules.
+The output matches the guardrails.json schema (models.StructuredGuardrails)
+and is a ready baseline to drop into an agent's workdir. Pipe to a file and
+edit before use if you want to tweak thresholds or add rules.
 
-  forge guardrails seed-defaults > agent-config.json
+  forge guardrails seed-defaults > guardrails.json
 
-The built-in defaults cover 11 vendor-secret patterns (Anthropic /
-OpenAI / GitHub / AWS / Slack / Telegram tokens, private-key PEM
-blocks), four PII categories (email / phone / SSN / credit card), and
-jailbreak / prompt-injection / command-injection thresholds. DB-mode
-deploys SHOULD use this as their seed baseline; an empty AgentConfig
-document is strictly less protected than file mode with no file.`,
+The built-in defaults cover 11 vendor-secret patterns (Anthropic / OpenAI /
+GitHub / AWS / Slack / Telegram tokens, private-key PEM blocks), four PII
+categories (email / phone / SSN / credit card), and jailbreak /
+prompt-injection / command-injection thresholds.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		sg := runtime.DefaultStructuredGuardrails()
 		out, err := json.MarshalIndent(sg, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshaling defaults: %w", err)
 		}
-		// Trailing newline so shell redirection produces a
-		// well-formed file. cobra writes to OutOrStdout so tests
-		// can capture stdout via SetOut.
+		// Trailing newline so shell redirection produces a well-formed
+		// file. cobra writes to OutOrStdout so tests can capture stdout.
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 		return nil
 	},
 }
 
-// guardrailsValidateDBOpts holds the resolved connection settings for
-// `forge guardrails validate-db`. Defaults pulled from env so a CI
-// run with the deployment env set "just works."
-type guardrailsValidateDBOpts struct {
-	mongoURI  string
-	agentID   string
-	dbName    string
-	colName   string
-	timeoutMs int
-}
-
-var validateDBOpts guardrailsValidateDBOpts
-
-var guardrailsValidateDBCmd = &cobra.Command{
-	Use:   "validate-db",
-	Short: "Connect to FORGE_GUARDRAILS_DB and report on the agent's seeded config",
-	Long: `Connect to MongoDB and inspect the agent's AgentConfig document.
-
-Reports on baseline coverage:
-  - PII config present and enabled
-  - JailbreakDetection / PromptInjection / CommandInjection thresholds
-  - Number of custom secret-pattern rules
-  - Gate config (input / output / tool_call gates enabled)
-
-Warns when coverage is below the built-in defaults (the threshold for
-"reasonably configured" is fewer than 5 secret-pattern rules, missing
-PII config, or missing jailbreak detection — these are common signs
-of an incomplete or stale seed).
-
-Connection settings default to env:
-  --mongo-uri  $FORGE_GUARDRAILS_DB
-  --agent-id   $FORGE_AGENT_ID
-  --db         Initializ
-  --collection AgentConfig
-
-Exits with status 1 when the agent has no document at all (the most
-common deploy error) so CI / deployment hooks can fail the rollout.`,
-	RunE: runGuardrailsValidateDB,
-}
-
 func init() {
 	guardrailsCmd.AddCommand(guardrailsSeedDefaultsCmd)
-	guardrailsCmd.AddCommand(guardrailsValidateDBCmd)
-	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.mongoURI, "mongo-uri", "",
-		"MongoDB URI (default: $FORGE_GUARDRAILS_DB)")
-	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.agentID, "agent-id", "",
-		"agent_id to look up (default: $FORGE_AGENT_ID)")
-	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.dbName, "db", "Initializ",
-		"MongoDB database name")
-	guardrailsValidateDBCmd.Flags().StringVar(&validateDBOpts.colName, "collection", "AgentConfig",
-		"AgentConfig collection name")
-	guardrailsValidateDBCmd.Flags().IntVar(&validateDBOpts.timeoutMs, "timeout-ms", 5000,
-		"connect timeout in milliseconds")
-}
-
-// runGuardrailsValidateDB is the validate-db handler. Returning an
-// error from RunE makes cobra exit non-zero; the CI signal is the
-// whole point of the command.
-func runGuardrailsValidateDB(cmd *cobra.Command, _ []string) error {
-	uri := validateDBOpts.mongoURI
-	if uri == "" {
-		uri = os.Getenv(runtime.EnvGuardrailsDB)
-	}
-	if uri == "" {
-		return errors.New("no MongoDB URI: pass --mongo-uri or set FORGE_GUARDRAILS_DB")
-	}
-	agentID := validateDBOpts.agentID
-	if agentID == "" {
-		agentID = os.Getenv("FORGE_AGENT_ID")
-	}
-	if agentID == "" {
-		return errors.New("no agent_id: pass --agent-id or set FORGE_AGENT_ID")
-	}
-
-	timeout := time.Duration(validateDBOpts.timeoutMs) * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
-	if err != nil {
-		return fmt.Errorf("mongo connect: %w", err)
-	}
-	defer func() { _ = client.Disconnect(context.Background()) }()
-
-	if err := client.Ping(ctx, nil); err != nil {
-		return fmt.Errorf("mongo ping: %w", err)
-	}
-
-	col := client.Database(validateDBOpts.dbName).Collection(validateDBOpts.colName)
-	var doc bson.M
-	if err := col.FindOne(ctx, bson.M{"agent_id": agentID}).Decode(&doc); err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return fmt.Errorf("no AgentConfig document for agent_id=%q in %s.%s; seed it via `forge guardrails seed-defaults | mongoimport`",
-				agentID, validateDBOpts.dbName, validateDBOpts.colName)
-		}
-		return fmt.Errorf("fetching AgentConfig: %w", err)
-	}
-
-	report := scoreAgentConfig(doc)
-	out := cmd.OutOrStdout()
-	_, _ = fmt.Fprintf(out, "AgentConfig for %q in %s.%s\n", agentID, validateDBOpts.dbName, validateDBOpts.colName)
-	for _, line := range report.lines {
-		_, _ = fmt.Fprintln(out, "  "+line)
-	}
-	if len(report.warnings) > 0 {
-		_, _ = fmt.Fprintln(out, "\nWARNINGS:")
-		for _, w := range report.warnings {
-			_, _ = fmt.Fprintln(out, "  - "+w)
-		}
-		_, _ = fmt.Fprintln(out, "\nReseed with `forge guardrails seed-defaults` to restore baseline coverage.")
-	} else {
-		_, _ = fmt.Fprintln(out, "\nOK — baseline coverage matches DefaultStructuredGuardrails.")
-	}
-	return nil
-}
-
-// agentConfigReport summarizes a validate-db inspection in a form
-// the test can assert on cleanly. Lines are the human-readable
-// summary; warnings are the actionable below-baseline findings.
-type agentConfigReport struct {
-	lines    []string
-	warnings []string
-}
-
-// scoreAgentConfig walks the BSON document and reports coverage. The
-// "fewer than 5 secret rules / missing PII / missing jailbreak"
-// threshold is the issue #166 baseline — anything below that is
-// strictly less protective than the built-in defaults and the
-// operator probably didn't intend it.
-//
-// Forgiving on shape: missing nested objects are reported as missing
-// (not an error). The library's struct tags use camelCase, but
-// historical seeds in the wild may use snake_case (older library
-// versions or hand-written seeds based on docs). lookupMap accepts
-// either spelling so the validator works against both shapes.
-func scoreAgentConfig(doc bson.M) agentConfigReport {
-	r := agentConfigReport{}
-
-	// Custom rules — secret-pattern coverage.
-	rules := extractCustomRules(doc)
-	r.lines = append(r.lines, fmt.Sprintf("custom_rules: %d rule(s)", len(rules)))
-	secretRules := 0
-	for _, name := range rules {
-		// Same convention DefaultStructuredGuardrails uses.
-		if len(name) >= 6 && name[:6] == "secret" {
-			secretRules++
-		}
-	}
-	r.lines = append(r.lines, fmt.Sprintf("secret_pattern_rules: %d (default seed ships 11)", secretRules))
-	if secretRules < 5 {
-		r.warnings = append(r.warnings,
-			fmt.Sprintf("fewer than 5 secret-pattern rules (%d found) — vendor token leakage in outbound responses likely unmasked", secretRules))
-	}
-
-	// PII config.
-	if pii, ok := lookupMap(doc, "pii"); ok {
-		enabled, _ := pii["enabled"].(bool)
-		r.lines = append(r.lines, fmt.Sprintf("pii.enabled: %v", enabled))
-		if !enabled {
-			r.warnings = append(r.warnings, "PII config present but disabled — email / phone / SSN / credit card in prompts will not be masked")
-		}
-	} else {
-		r.lines = append(r.lines, "pii: <missing>")
-		r.warnings = append(r.warnings, "no PII config — PII in prompts will not be masked")
-	}
-
-	// Security thresholds. Walk both camelCase (library struct
-	// tags) and snake_case (legacy seeds).
-	if sec, ok := lookupMap(doc, "security"); ok {
-		for _, names := range [][]string{
-			{"jailbreakDetection", "jailbreak_detection"},
-			{"promptInjection", "prompt_injection"},
-			{"commandInjection", "command_injection"},
-		} {
-			label := names[1]
-			t, ok := lookupMap(sec, names...)
-			if ok {
-				enabled, _ := t["enabled"].(bool)
-				r.lines = append(r.lines, fmt.Sprintf("security.%s.enabled: %v", label, enabled))
-				if !enabled {
-					r.warnings = append(r.warnings, fmt.Sprintf("security.%s present but disabled", label))
-				}
-			} else {
-				r.lines = append(r.lines, fmt.Sprintf("security.%s: <missing>", label))
-				r.warnings = append(r.warnings, fmt.Sprintf("security.%s missing — this attack class is not screened", label))
-			}
-		}
-	} else {
-		r.lines = append(r.lines, "security: <missing>")
-		r.warnings = append(r.warnings,
-			"no security config — jailbreak / prompt-injection / command-injection detection is OFF")
-	}
-
-	// Gate config.
-	if gc, ok := lookupMap(doc, "gateConfig", "gate_config"); ok {
-		input, _ := lookupBool(gc, "inputGate", "input_gate")
-		output, _ := lookupBool(gc, "outputGate", "output_gate")
-		toolCall, _ := lookupBool(gc, "toolCallGate", "tool_call_gate")
-		r.lines = append(r.lines, fmt.Sprintf("gates: input=%v output=%v tool_call=%v", input, output, toolCall))
-		if !input || !output || !toolCall {
-			r.warnings = append(r.warnings,
-				"one or more core gates disabled (input / output / tool_call) — partial enforcement")
-		}
-	} else {
-		r.lines = append(r.lines, "gate_config: <missing>")
-		r.warnings = append(r.warnings, "no gate_config — falling back to library defaults")
-	}
-
-	return r
-}
-
-// extractCustomRules pulls the rule ids out of the
-// `customRules.rules` array (with snake_case fallback), defensive
-// against shape drift. Returns empty when the path is absent or any
-// node along the way is the wrong type.
-func extractCustomRules(doc bson.M) []string {
-	cr, ok := lookupMap(doc, "customRules", "custom_rules")
-	if !ok {
-		return nil
-	}
-	rawRules, ok := cr["rules"].(bson.A)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(rawRules))
-	for _, r := range rawRules {
-		rule, ok := r.(bson.M)
-		if !ok {
-			continue
-		}
-		if id, ok := rule["id"].(string); ok {
-			out = append(out, id)
-			continue
-		}
-		if name, ok := rule["name"].(string); ok {
-			out = append(out, name)
-		}
-	}
-	return out
-}
-
-// lookupMap returns the first BSON map child of doc that matches one
-// of the supplied keys. Used to tolerate both camelCase (library
-// struct tags) and snake_case (older seed conventions) without
-// duplicating each lookup.
-func lookupMap(doc bson.M, keys ...string) (bson.M, bool) {
-	for _, k := range keys {
-		if v, ok := doc[k].(bson.M); ok {
-			return v, true
-		}
-	}
-	return nil, false
-}
-
-// lookupBool is the bool-leaf counterpart of lookupMap.
-func lookupBool(doc bson.M, keys ...string) (bool, bool) {
-	for _, k := range keys {
-		if v, ok := doc[k].(bool); ok {
-			return v, true
-		}
-	}
-	return false, false
 }

--- a/forge-cli/cmd/guardrails_test.go
+++ b/forge-cli/cmd/guardrails_test.go
@@ -7,14 +7,12 @@ import (
 	"testing"
 
 	"github.com/initializ/guardrails/models"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel is the
-// canary the issue calls out: pipe `forge guardrails seed-defaults`
-// into a JSON consumer, and the JSON MUST unmarshal into the
-// library's models.StructuredGuardrails. If we ever drift from the
-// library schema this test fails in red. Verification step 4 of #166.
+// TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel is the canary:
+// pipe `forge guardrails seed-defaults` into a JSON consumer, and the JSON
+// MUST unmarshal into the library's models.StructuredGuardrails. If we ever
+// drift from the library schema this test fails in red.
 func TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := guardrailsSeedDefaultsCmd
@@ -24,9 +22,8 @@ func TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel(t *testing.T) {
 	}
 	out := buf.String()
 	// Library JSON tags are camelCase (customRules, jailbreakDetection,
-	// promptInjection, …). The round-trip assertion below is the
-	// strict invariant; this substring check is just a fast canary
-	// against a totally-empty marshal.
+	// promptInjection, …). This substring check is a fast canary against a
+	// totally-empty marshal; the round-trip below is the strict invariant.
 	if !strings.Contains(out, "customRules") {
 		t.Errorf("seed-defaults output missing customRules section; got:\n%s", out)
 	}
@@ -36,183 +33,15 @@ func TestGuardrailsSeedDefaults_RoundTripsThroughLibraryModel(t *testing.T) {
 		t.Fatalf("seed-defaults output does not round-trip through models.StructuredGuardrails: %v\noutput:\n%s",
 			err, out)
 	}
-	// Sanity: the defaults must carry the canonical baseline. Below
-	// 5 secret-pattern rules would mean the upstream defaults
-	// regressed and the issue #166 baseline check would break too.
+	// Sanity: the defaults must carry the canonical baseline.
 	if sg.CustomRules == nil || len(sg.CustomRules.Rules) < 5 {
-		t.Errorf("seed-defaults dropped below baseline rule count; got %d", func() int {
-			if sg.CustomRules == nil {
-				return 0
-			}
-			return len(sg.CustomRules.Rules)
-		}())
+		n := 0
+		if sg.CustomRules != nil {
+			n = len(sg.CustomRules.Rules)
+		}
+		t.Errorf("seed-defaults dropped below baseline rule count; got %d", n)
 	}
 	if sg.PII == nil || !sg.PII.Enabled {
 		t.Errorf("seed-defaults missing or-disabled PII config: %+v", sg.PII)
-	}
-}
-
-// TestScoreAgentConfig_FullDefaultsHaveNoWarnings is the inverse-side
-// test: a doc constructed from DefaultStructuredGuardrails (via the
-// seed-defaults JSON round-tripped through BSON) must produce zero
-// warnings from scoreAgentConfig. If a future schema drift means the
-// validate-db pass starts flagging the canonical seed, this test
-// catches it before operators see false positives.
-//
-// Uses the camelCase key shape that matches the library struct tags
-// (what production MongoDB documents actually carry). The
-// snake_case fallback is exercised by TestScoreAgentConfig_SnakeCaseCompat
-// below.
-func TestScoreAgentConfig_FullDefaultsHaveNoWarnings(t *testing.T) {
-	doc := bson.M{
-		"customRules": bson.M{
-			"rules": bson.A{
-				bson.M{"id": "secret_anthropic", "name": "Anthropic API Key"},
-				bson.M{"id": "secret_openai", "name": "OpenAI"},
-				bson.M{"id": "secret_github_pat", "name": "GitHub PAT"},
-				bson.M{"id": "secret_aws", "name": "AWS Access Key"},
-				bson.M{"id": "secret_slack_bot", "name": "Slack Bot Token"},
-				bson.M{"id": "secret_private_key", "name": "Private Key"},
-			},
-		},
-		"pii": bson.M{"enabled": true},
-		"security": bson.M{
-			"jailbreakDetection": bson.M{"enabled": true},
-			"promptInjection":    bson.M{"enabled": true},
-			"commandInjection":   bson.M{"enabled": true},
-		},
-		"gateConfig": bson.M{
-			"inputGate":    true,
-			"outputGate":   true,
-			"toolCallGate": true,
-		},
-	}
-	r := scoreAgentConfig(doc)
-	if len(r.warnings) != 0 {
-		t.Errorf("full-defaults doc produced warnings: %v", r.warnings)
-	}
-}
-
-// TestScoreAgentConfig_SnakeCaseCompat confirms the validator also
-// accepts the snake_case spelling — legacy seeds and hand-written
-// configs based on old docs use that convention. Same input as the
-// camelCase case above, no warnings expected.
-func TestScoreAgentConfig_SnakeCaseCompat(t *testing.T) {
-	doc := bson.M{
-		"custom_rules": bson.M{
-			"rules": bson.A{
-				bson.M{"id": "secret_a"}, bson.M{"id": "secret_b"},
-				bson.M{"id": "secret_c"}, bson.M{"id": "secret_d"},
-				bson.M{"id": "secret_e"},
-			},
-		},
-		"pii": bson.M{"enabled": true},
-		"security": bson.M{
-			"jailbreak_detection": bson.M{"enabled": true},
-			"prompt_injection":    bson.M{"enabled": true},
-			"command_injection":   bson.M{"enabled": true},
-		},
-		"gate_config": bson.M{
-			"input_gate":     true,
-			"output_gate":    true,
-			"tool_call_gate": true,
-		},
-	}
-	r := scoreAgentConfig(doc)
-	if len(r.warnings) != 0 {
-		t.Errorf("snake_case-shaped doc produced warnings: %v", r.warnings)
-	}
-}
-
-// TestScoreAgentConfig_EmptyDocFlagsEverything is the operator-error
-// canary: an empty AgentConfig document (or one missing all the
-// baseline blocks) must flag every coverage gap the issue documents.
-// This is the most common deploy error — a developer creates an
-// AgentConfig with just an agent_id field and assumes the library
-// applies defaults. It doesn't.
-func TestScoreAgentConfig_EmptyDocFlagsEverything(t *testing.T) {
-	r := scoreAgentConfig(bson.M{})
-	wantWarns := []string{
-		"fewer than 5 secret-pattern rules",
-		"no PII config",
-		"no security config",
-		"no gate_config",
-	}
-	for _, want := range wantWarns {
-		found := false
-		for _, w := range r.warnings {
-			if strings.Contains(w, want) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected warning containing %q; got warnings=%v", want, r.warnings)
-		}
-	}
-}
-
-// TestScoreAgentConfig_FewerThan5SecretRulesWarns pins the explicit
-// threshold the issue calls out: a doc with 4 secret-pattern rules
-// (one below baseline) MUST warn about secret-pattern coverage, but
-// nothing else if PII / security / gates are otherwise healthy.
-func TestScoreAgentConfig_FewerThan5SecretRulesWarns(t *testing.T) {
-	doc := bson.M{
-		"customRules": bson.M{
-			"rules": bson.A{
-				bson.M{"id": "secret_one"},
-				bson.M{"id": "secret_two"},
-				bson.M{"id": "secret_three"},
-				bson.M{"id": "secret_four"},
-			},
-		},
-		"pii": bson.M{"enabled": true},
-		"security": bson.M{
-			"jailbreakDetection": bson.M{"enabled": true},
-			"promptInjection":    bson.M{"enabled": true},
-			"commandInjection":   bson.M{"enabled": true},
-		},
-		"gateConfig": bson.M{
-			"inputGate":    true,
-			"outputGate":   true,
-			"toolCallGate": true,
-		},
-	}
-	r := scoreAgentConfig(doc)
-	if len(r.warnings) != 1 {
-		t.Errorf("expected exactly 1 warning (secret-pattern coverage); got %d: %v",
-			len(r.warnings), r.warnings)
-	}
-	if len(r.warnings) > 0 && !strings.Contains(r.warnings[0], "secret-pattern") {
-		t.Errorf("warning should be about secret-pattern coverage; got %q", r.warnings[0])
-	}
-}
-
-// TestExtractCustomRules_DefensiveOnShape walks the BSON-shape edge
-// cases scoreAgentConfig must survive: missing custom_rules,
-// custom_rules present but rules array wrong type, individual rule
-// entries missing id, etc. The function MUST never panic and MUST
-// fall back to an empty result so the warning surfaces correctly.
-func TestExtractCustomRules_DefensiveOnShape(t *testing.T) {
-	cases := []struct {
-		name string
-		doc  bson.M
-		want int
-	}{
-		{"absent customRules", bson.M{}, 0},
-		{"customRules not a map", bson.M{"customRules": "string"}, 0},
-		{"rules not an array", bson.M{"customRules": bson.M{"rules": "oops"}}, 0},
-		{"rule missing id", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{}}}}, 0},
-		{"rule has id camelCase", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{"id": "secret_x"}}}}, 1},
-		{"rule has id snake_case fallback", bson.M{"custom_rules": bson.M{"rules": bson.A{bson.M{"id": "secret_x"}}}}, 1},
-		{"rule has name fallback", bson.M{"customRules": bson.M{"rules": bson.A{bson.M{"name": "X"}}}}, 1},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := extractCustomRules(c.doc)
-			if len(got) != c.want {
-				t.Errorf("extractCustomRules(%+v) = %v, want length %d", c.doc, got, c.want)
-			}
-		})
 	}
 }

--- a/forge-cli/go.mod
+++ b/forge-cli/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/initializ/forge/forge-ui v0.0.0
 	github.com/initializ/guardrails v0.12.0
 	github.com/spf13/cobra v1.10.2
-	go.mongodb.org/mongo-driver v1.17.7
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
@@ -52,6 +51,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gowebpki/jcs v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/initializ/ctxzip v0.1.2 // indirect
@@ -83,6 +83,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.etcd.io/bbolt v1.5.0 // indirect
+	go.mongodb.org/mongo-driver v1.17.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect

--- a/forge-cli/go.sum
+++ b/forge-cli/go.sum
@@ -73,6 +73,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -146,6 +148,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/forge-cli/runtime/guardrails_engine.go
+++ b/forge-cli/runtime/guardrails_engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/initializ/guardrails"
 	"github.com/initializ/guardrails/models"
@@ -12,8 +11,6 @@ import (
 	"github.com/initializ/forge/forge-core/a2a"
 	"github.com/initializ/forge/forge-core/observability"
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // Result-string constants for the guardrail_check audit event. Operators
@@ -30,9 +27,9 @@ const (
 )
 
 // LibraryGuardrailEngine implements coreruntime.GuardrailChecker using
-// the github.com/initializ/guardrails library. It supports two modes:
-//   - File mode: uses StructuredGuardrails loaded from guardrails.json
-//   - DB mode: loads config from MongoDB (set via FORGE_GUARDRAILS_DB env)
+// the github.com/initializ/guardrails library. Config is a
+// StructuredGuardrails loaded from guardrails.json (optionally tightened by
+// the platform guardrails overlay — see #284).
 //
 // On every mask / block / warn decision the engine emits a
 // guardrail_check audit event through auditLogger (when wired). The
@@ -44,7 +41,6 @@ type LibraryGuardrailEngine struct {
 	manager       *guardrails.GuardrailManager
 	structured    *models.StructuredGuardrails
 	enforce       bool
-	useDB         bool
 	agentID       string
 	orgID         string
 	configVersion int64
@@ -71,48 +67,6 @@ func NewFileGuardrailEngine(sg *models.StructuredGuardrails, enforce bool, logge
 		structured: sg,
 		enforce:    enforce,
 		logger:     logger,
-	}, nil
-}
-
-// NewDBGuardrailEngine creates a guardrail engine backed by MongoDB.
-// Config is loaded from the AgentConfig collection; audit logging is enabled.
-//
-// Connect timeout is 3s. Long enough to absorb DNS jitter and a slow
-// TLS handshake on a healthy cluster, short enough that a
-// misconfigured URI or a downed Mongo surfaces during startup rather
-// than holding up the agent process. Issue #166: shorter timeout
-// also makes the fail-loud REQUIRED-mode path surface in seconds,
-// not tens of seconds.
-func NewDBGuardrailEngine(mongoURI, agentID, orgID string, enforce bool, logger coreruntime.Logger) (*LibraryGuardrailEngine, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
-	if err != nil {
-		return nil, fmt.Errorf("connecting to guardrails DB: %w", err)
-	}
-
-	// Verify connectivity
-	if err := client.Ping(ctx, nil); err != nil {
-		return nil, fmt.Errorf("pinging guardrails DB: %w", err)
-	}
-
-	mgr, err := guardrails.NewGuardrailManager(guardrails.Config{
-		MongoClient:  client,
-		DatabaseName: "Initializ",
-		EnableAudit:  true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating guardrail manager with DB: %w", err)
-	}
-
-	return &LibraryGuardrailEngine{
-		manager: mgr,
-		enforce: enforce,
-		useDB:   true,
-		agentID: agentID,
-		orgID:   orgID,
-		logger:  logger,
 	}, nil
 }
 
@@ -144,12 +98,9 @@ func (e *LibraryGuardrailEngine) WithTracing(cfg observability.TracingConfig) *L
 	return e
 }
 
-// structuredIfFileMode returns the StructuredGuardrails pointer only in file
-// mode. In DB mode the library loads config from MongoDB automatically.
-func (e *LibraryGuardrailEngine) structuredIfFileMode() *models.StructuredGuardrails {
-	if e.useDB {
-		return nil
-	}
+// structuredConfig returns the StructuredGuardrails the library evaluates
+// each gate against.
+func (e *LibraryGuardrailEngine) structuredConfig() *models.StructuredGuardrails {
 	return e.structured
 }
 
@@ -184,7 +135,7 @@ func (e *LibraryGuardrailEngine) CheckInbound(ctx context.Context, msg *a2a.Mess
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 	})
 	if err != nil {
@@ -279,7 +230,7 @@ func (e *LibraryGuardrailEngine) checkOneOutboundPart(ctx context.Context, msg *
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 	})
 	if err != nil {
@@ -337,7 +288,7 @@ func (e *LibraryGuardrailEngine) CheckToolCall(ctx context.Context, toolName, ar
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 	})
 	if err != nil {
@@ -402,7 +353,7 @@ func (e *LibraryGuardrailEngine) CheckToolOutput(ctx context.Context, toolName, 
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 		Metadata:             map[string]interface{}{"tool_name": toolName},
 	})
@@ -467,7 +418,7 @@ func (e *LibraryGuardrailEngine) CheckContext(ctx context.Context, content strin
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 	})
 	if err != nil {
@@ -527,7 +478,7 @@ func (e *LibraryGuardrailEngine) CheckStream(ctx context.Context, chunk string) 
 		EntityID:             e.agentID,
 		OrgID:                e.orgID,
 		EntityType:           guardrails.EntityTypeAgent,
-		StructuredGuardrails: e.structuredIfFileMode(),
+		StructuredGuardrails: e.structuredConfig(),
 		ConfigVersion:        e.configVersion,
 	})
 	if err != nil {

--- a/forge-cli/runtime/guardrails_loader.go
+++ b/forge-cli/runtime/guardrails_loader.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"sync"
 
 	"github.com/initializ/guardrails/models"
 
@@ -15,31 +13,6 @@ import (
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
 	"github.com/initializ/forge/forge-core/types"
 )
-
-// Environment variable names for guardrails resolution hardening
-// (issue #166). Mirrors the FORGE_* convention used elsewhere in the
-// security subsystem.
-const (
-	// EnvGuardrailsDB is the existing MongoDB URI selector that
-	// activates DB mode. Documented here for grep-ability — the
-	// loader still reads the raw string at the FORGE_GUARDRAILS_DB
-	// callsite below.
-	EnvGuardrailsDB = "FORGE_GUARDRAILS_DB"
-	// EnvGuardrailsDBRequired flips the silent-fallback to a
-	// startup-time abort when DB mode is selected but Mongo is
-	// unreachable. Off by default (back-compat); platform deploys
-	// that consider DB mode security-critical should set this to
-	// fail loud instead of quietly downgrading to file mode or
-	// defaults.
-	EnvGuardrailsDBRequired = "FORGE_GUARDRAILS_DB_REQUIRED"
-)
-
-// dbFileExclusivityOnce guards the one-shot startup warning emitted
-// when both FORGE_GUARDRAILS_DB and a guardrails.json are present.
-// Package-scoped so the warning fires exactly once per process even
-// if BuildGuardrailChecker is called multiple times (it isn't in
-// production, but tests do). Reset in tests via resetDBFileWarning.
-var dbFileExclusivityOnce sync.Once
 
 // LoadPolicyScaffold reads policy-scaffold.json from the output directory.
 // Returns nil (no error) if the file does not exist.
@@ -66,8 +39,10 @@ func DefaultPolicyScaffold() *agentspec.PolicyScaffold {
 	return &agentspec.PolicyScaffold{}
 }
 
-// BuildGuardrailChecker creates the guardrail engine based on configuration.
-// Priority: FORGE_GUARDRAILS_DB env → guardrails.json file → defaults.
+// BuildGuardrailChecker creates the guardrail engine from guardrails.json
+// (or the built-in defaults when no file is present), then applies the
+// platform guardrails overlay (#284) so an operator can further restrict
+// the agent's guardrails without editing the agent's file.
 //
 // auditLogger and auditCfg are wired into the resulting engine so every
 // mask/block/warn decision emits a guardrail_check event through the
@@ -78,19 +53,8 @@ func DefaultPolicyScaffold() *agentspec.PolicyScaffold {
 // When auditLogger is nil the engine is silent on the audit pipeline
 // (used by tests).
 //
-// Issue #166: the function now returns an error rather than always
-// falling back to a noop checker. The non-nil-error paths are:
-//
-//   - FORGE_GUARDRAILS_DB is set, FORGE_GUARDRAILS_DB_REQUIRED is
-//     truthy, AND the Mongo connect fails. Without REQUIRED the
-//     loader still warns and falls through to file mode for
-//     back-compat (the platform deploy should set REQUIRED so a
-//     misconfigured Mongo URI fails loud at startup instead of
-//     silently downgrading to a less-protective posture).
-//
-// Other failure paths (file-engine construction error, etc.) continue
-// to log and return a NoopGuardrailChecker — they're rare and the
-// recovery path is well-understood.
+// A file-engine construction error logs and returns a
+// NoopGuardrailChecker — rare, and the recovery path is well-understood.
 func BuildGuardrailChecker(
 	cfg *types.ForgeConfig,
 	workDir string,
@@ -108,56 +72,7 @@ func BuildGuardrailChecker(
 		return e
 	}
 
-	// One-shot exclusivity warning: when DB mode is selected AND a
-	// guardrails.json sits in the workdir, the file is silently
-	// ignored. Repo readers see a file checked in and assume it's
-	// active; in DB-mode deploys it's dead config that drifts. Issue
-	// #166. Fires through the ops logger (not the audit stream — this
-	// is a config-shape warning, not an audited event), exactly once
-	// per process via dbFileExclusivityOnce.
-	mongoURI := os.Getenv(EnvGuardrailsDB)
-	if mongoURI != "" {
-		if filePath, ok := guardrailsFilePathIfPresent(cfg, workDir); ok {
-			dbFileExclusivityOnce.Do(func() {
-				logger.Warn("guardrails: DB mode active but guardrails.json also present — the file is IGNORED. DB and file are mutually exclusive. Remove the file or unset FORGE_GUARDRAILS_DB to avoid drift.", map[string]any{
-					"file": filePath,
-				})
-			})
-		}
-	}
-
-	// DB mode: connect to MongoDB for config + audit
-	if mongoURI != "" {
-		agentID := os.Getenv("FORGE_AGENT_ID")
-		if agentID == "" && cfg != nil {
-			agentID = cfg.AgentID
-		}
-		orgID := os.Getenv("FORGE_ORG_ID")
-		engine, err := NewDBGuardrailEngine(mongoURI, agentID, orgID, enforce, logger)
-		if err == nil {
-			logger.Info("guardrails: using MongoDB-backed config", map[string]any{
-				"agent_id": agentID,
-			})
-			return attach(engine), nil
-		}
-		// FAIL-LOUD path. When REQUIRED is set, the agent refuses
-		// to serve rather than quietly downgrade. Platform deploys
-		// running guardrails under DB mode should set this in the
-		// deployment manifest so a misconfigured URI or a
-		// transient Mongo outage doesn't silently downgrade
-		// protection.
-		if dbModeRequired() {
-			logger.Error("guardrails: DB mode required (FORGE_GUARDRAILS_DB_REQUIRED=true) but DB unreachable; refusing to start", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, fmt.Errorf("guardrails DB required but unreachable: %w", err)
-		}
-		logger.Warn("failed to connect guardrails DB, falling back to file", map[string]any{
-			"error": err.Error(),
-		})
-	}
-
-	// File mode: load from guardrails.json
+	// Load the agent's guardrails.json (or the built-in defaults).
 	sg := LoadGuardrailsJSON(cfg, workDir)
 	if sg == nil {
 		sg = DefaultStructuredGuardrails()
@@ -178,39 +93,6 @@ func BuildGuardrailChecker(
 		return &coreruntime.NoopGuardrailChecker{}, nil
 	}
 	return attach(engine), nil
-}
-
-// dbModeRequired reads FORGE_GUARDRAILS_DB_REQUIRED and returns true
-// when the operator has opted into fail-loud behavior. Parse failure
-// or empty value yields false (back-compat) — same forgiving posture
-// as the other guardrails env vars.
-func dbModeRequired() bool {
-	v := os.Getenv(EnvGuardrailsDBRequired)
-	if v == "" {
-		return false
-	}
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		return false
-	}
-	return b
-}
-
-// guardrailsFilePathIfPresent returns the resolved guardrails.json
-// path (relative to workDir, honoring cfg.GuardrailsPath) and a bool
-// reporting whether the file actually exists on disk. Used by the
-// exclusivity warning to give the operator an actionable message
-// pointing at the specific file that's being ignored.
-func guardrailsFilePathIfPresent(cfg *types.ForgeConfig, workDir string) (string, bool) {
-	filename := "guardrails.json"
-	if cfg != nil && cfg.GuardrailsPath != "" {
-		filename = cfg.GuardrailsPath
-	}
-	path := filepath.Join(workDir, filename)
-	if _, err := os.Stat(path); err == nil {
-		return path, true
-	}
-	return path, false
 }
 
 // LoadGuardrailsJSON reads guardrails.json from the project directory.

--- a/forge-cli/runtime/guardrails_loader.go
+++ b/forge-cli/runtime/guardrails_loader.go
@@ -163,6 +163,13 @@ func BuildGuardrailChecker(
 		sg = DefaultStructuredGuardrails()
 	}
 
+	// Platform guardrails overlay (#284): a workspace/user/system operator
+	// can FURTHER RESTRICT the agent's guardrails — force detections/gates
+	// on, raise actions, lower thresholds, union rule/denylist/blocked-skill
+	// sets. It can never loosen. Applied to whichever config we resolved
+	// (file or defaults) so the tightening is universal.
+	sg = applyPlatformGuardrailsOverlay(sg, logger)
+
 	engine, err := NewFileGuardrailEngine(sg, enforce, logger)
 	if err != nil {
 		logger.Warn("failed to create file guardrail engine, using noop", map[string]any{

--- a/forge-cli/runtime/guardrails_loader.go
+++ b/forge-cli/runtime/guardrails_loader.go
@@ -82,8 +82,12 @@ func BuildGuardrailChecker(
 	// can FURTHER RESTRICT the agent's guardrails — force detections/gates
 	// on, raise actions, lower thresholds, union rule/denylist/blocked-skill
 	// sets. It can never loosen. Applied to whichever config we resolved
-	// (file or defaults) so the tightening is universal.
-	sg = applyPlatformGuardrailsOverlay(sg, logger)
+	// (file or defaults) so the tightening is universal. Fail-closed: a
+	// malformed overlay aborts startup rather than dropping the mandate.
+	sg, err := applyPlatformGuardrailsOverlay(sg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("platform guardrails overlay: %w", err)
+	}
 
 	engine, err := NewFileGuardrailEngine(sg, enforce, logger)
 	if err != nil {

--- a/forge-cli/runtime/guardrails_loader_test.go
+++ b/forge-cli/runtime/guardrails_loader_test.go
@@ -4,25 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/initializ/forge/forge-core/observability"
-	"github.com/initializ/forge/forge-core/types"
 )
 
-// resetDBFileWarning lets a test re-arm the one-shot exclusivity
-// warning between assertions. Lives only in _test.go so production
-// callers can't accidentally rearm it. Issue #166.
-func resetDBFileWarning() {
-	dbFileExclusivityOnce = sync.Once{}
-}
-
-// captureLogger records the highest-severity message emitted plus
-// every Warn/Error line so tests can assert what surfaced through
-// the ops logger (NOT the audit stream — the exclusivity warning
-// and the fail-loud abort both go through Logger, never the
-// AuditLogger).
+// captureLogger records everything emitted through the ops logger so tests
+// can assert what surfaced (e.g. the platform-overlay tightening line).
 type captureLogger struct {
 	infos  []string
 	warns  []string
@@ -34,194 +22,54 @@ func (l *captureLogger) Info(msg string, _ map[string]any)  { l.infos = append(l
 func (l *captureLogger) Warn(msg string, _ map[string]any)  { l.warns = append(l.warns, msg) }
 func (l *captureLogger) Error(msg string, _ map[string]any) { l.errors = append(l.errors, msg) }
 
-// TestBuildGuardrailChecker_DBRequired_FailsLoudOnUnreachable is the
-// core issue #166 invariant: with FORGE_GUARDRAILS_DB pointing at an
-// unreachable host AND FORGE_GUARDRAILS_DB_REQUIRED=true, startup
-// MUST return a non-nil error rather than quietly downgrading to
-// file mode or defaults. The runner propagates the error so the
-// agent process exits non-zero and the platform deploy can surface
-// the failure.
-func TestBuildGuardrailChecker_DBRequired_FailsLoudOnUnreachable(t *testing.T) {
-	resetDBFileWarning()
-	// 127.0.0.1:1 is reliably unreachable on test hosts.
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-	t.Setenv(EnvGuardrailsDBRequired, "true")
-
-	logger := &captureLogger{}
-	checker, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-
-	if err == nil {
-		t.Fatalf("expected error in REQUIRED mode with unreachable DB; got checker=%v", checker)
-	}
-	if checker != nil {
-		t.Errorf("REQUIRED-mode failure must return nil checker; got %T", checker)
-	}
-	if !strings.Contains(err.Error(), "DB required but unreachable") {
-		t.Errorf("error must mention REQUIRED-mode; got %q", err.Error())
-	}
-	// Logger should carry an Error line (not just Warn) so platform
-	// ops can grep for the specific failure mode.
-	if len(logger.errors) == 0 {
-		t.Errorf("expected an Error log line in REQUIRED-mode failure; got warns=%v", logger.warns)
-	}
+func isolateLayers(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)                                                 // isolate the user policy layer
+	t.Setenv("FORGE_SYSTEM_POLICY", filepath.Join(dir, "no-system.yaml")) // isolate the system layer
+	t.Setenv("FORGE_PLATFORM_POLICY", "")                                 // no workspace policy unless a test sets it
+	return dir
 }
 
-// TestBuildGuardrailChecker_DBUnreachable_FallsBackByDefault pins
-// the back-compat path: with DB set but REQUIRED unset, an
-// unreachable DB still warn-and-falls-back to file mode. Operators
-// who deliberately want the safer fail-loud posture set REQUIRED.
-func TestBuildGuardrailChecker_DBUnreachable_FallsBackByDefault(t *testing.T) {
-	resetDBFileWarning()
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-	// REQUIRED deliberately unset.
+// TestBuildGuardrailChecker_AppliesPlatformOverlay wires a workspace
+// policy.yaml with a guardrails overlay and confirms the build logs that the
+// overlay tightened the agent guardrails (#284).
+func TestBuildGuardrailChecker_AppliesPlatformOverlay(t *testing.T) {
+	dir := isolateLayers(t)
+	if err := os.WriteFile(filepath.Join(dir, "guardrails.json"), []byte(`{
+		"gateConfig": {"outputGate": false}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policyPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(`
+guardrails:
+  gateConfig:
+    outputGate: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FORGE_PLATFORM_POLICY", policyPath)
 
 	logger := &captureLogger{}
-	checker, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
+	checker, err := BuildGuardrailChecker(nil, dir, false, logger, nil,
 		GuardrailAuditConfig{}, observability.TracingConfig{})
 	if err != nil {
-		t.Fatalf("default (non-REQUIRED) path must not error on DB unreachable; got %v", err)
+		t.Fatalf("overlay build errored: %v", err)
 	}
 	if checker == nil {
-		t.Errorf("default path must return a non-nil fallback checker")
+		t.Fatal("expected a non-nil checker")
 	}
-	// At least one Warn should describe the fallback. Tests are
-	// loose on the exact message wording so a future log tweak
-	// doesn't break the invariant.
-	foundWarn := false
-	for _, w := range logger.warns {
-		if strings.Contains(w, "guardrails") || strings.Contains(w, "fall") {
-			foundWarn = true
+	if !anyContains(logger.infos, "platform overlay tightened") {
+		t.Errorf("expected a tightening log line; got infos=%v", logger.infos)
+	}
+}
+
+func anyContains(lines []string, substr string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, substr) {
+			return true
 		}
 	}
-	if !foundWarn {
-		t.Errorf("expected a fallback warning; got warns=%v", logger.warns)
-	}
-}
-
-// TestBuildGuardrailChecker_DBRequiredAcceptsForgivingParse confirms
-// the env-parse posture matches the rest of the FORGE_* env layer:
-// garbage values fall back to "not set" (safe default — same as
-// AuditPayloadCaptureFromEnv). A typo in FORGE_GUARDRAILS_DB_REQUIRED
-// doesn't accidentally enable fail-loud mode in deployments that
-// didn't intend to opt in.
-func TestBuildGuardrailChecker_DBRequiredAcceptsForgivingParse(t *testing.T) {
-	resetDBFileWarning()
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-	t.Setenv(EnvGuardrailsDBRequired, "not-a-bool")
-
-	logger := &captureLogger{}
-	_, err := BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	if err != nil {
-		t.Errorf("malformed REQUIRED must not flip fail-loud; got err=%v", err)
-	}
-}
-
-// TestBuildGuardrailChecker_DBAndFile_WarnsOnce is the Part 3
-// invariant: when an operator has BOTH FORGE_GUARDRAILS_DB set AND a
-// guardrails.json checked into the workdir, the file is silently
-// ignored today — repo readers see it and assume it's active. The
-// one-shot warning makes the dead-config drift visible without
-// spamming the log on every BuildGuardrailChecker call.
-func TestBuildGuardrailChecker_DBAndFile_WarnsOnce(t *testing.T) {
-	resetDBFileWarning()
-	wd := t.TempDir()
-	guardrailsPath := filepath.Join(wd, "guardrails.json")
-	if err := os.WriteFile(guardrailsPath, []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-
-	logger := &captureLogger{}
-	// First call — warning should fire.
-	_, _ = BuildGuardrailChecker(nil, wd, false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	exclusivityWarns := countWarnsContaining(logger.warns, "DB and file are mutually exclusive")
-	if exclusivityWarns != 1 {
-		t.Errorf("expected exactly 1 exclusivity warning on first build; got %d (warns=%v)",
-			exclusivityWarns, logger.warns)
-	}
-
-	// Second call — warning must NOT re-fire. One-shot semantics so
-	// the message doesn't spam ops logs in tests that build the
-	// checker repeatedly or in any code path that ever calls
-	// BuildGuardrailChecker more than once.
-	logger2 := &captureLogger{}
-	_, _ = BuildGuardrailChecker(nil, wd, false, logger2, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	if countWarnsContaining(logger2.warns, "DB and file are mutually exclusive") != 0 {
-		t.Errorf("exclusivity warning re-fired on second build; got warns=%v", logger2.warns)
-	}
-}
-
-// TestBuildGuardrailChecker_DBOnly_NoFile_NoExclusivityWarn confirms
-// the warning ONLY fires when both are present. A clean DB-mode
-// deploy with no leftover guardrails.json must not see a spurious
-// "file is ignored" line.
-func TestBuildGuardrailChecker_DBOnly_NoFile_NoExclusivityWarn(t *testing.T) {
-	resetDBFileWarning()
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-
-	logger := &captureLogger{}
-	_, _ = BuildGuardrailChecker(nil, t.TempDir(), false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 0 {
-		t.Errorf("exclusivity warning fired without guardrails.json; got warns=%v", logger.warns)
-	}
-}
-
-// TestBuildGuardrailChecker_FileOnly_NoWarn confirms the file-only
-// path is unchanged — no DB env, no exclusivity warning.
-func TestBuildGuardrailChecker_FileOnly_NoWarn(t *testing.T) {
-	resetDBFileWarning()
-	wd := t.TempDir()
-	if err := os.WriteFile(filepath.Join(wd, "guardrails.json"), []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// FORGE_GUARDRAILS_DB deliberately unset via Setenv("").
-	t.Setenv(EnvGuardrailsDB, "")
-
-	logger := &captureLogger{}
-	_, _ = BuildGuardrailChecker(nil, wd, false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 0 {
-		t.Errorf("exclusivity warning fired in file-only mode; got warns=%v", logger.warns)
-	}
-}
-
-// TestBuildGuardrailChecker_HonorsCustomGuardrailsPath confirms the
-// exclusivity check resolves cfg.GuardrailsPath, not just the
-// default `guardrails.json` filename. Operators who renamed the
-// file via forge.yaml must still see the warning when it conflicts
-// with DB mode.
-func TestBuildGuardrailChecker_HonorsCustomGuardrailsPath(t *testing.T) {
-	resetDBFileWarning()
-	wd := t.TempDir()
-	customPath := "policies/custom-guardrails.json"
-	if err := os.MkdirAll(filepath.Join(wd, "policies"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(wd, customPath), []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv(EnvGuardrailsDB, "mongodb://127.0.0.1:1/forbidden")
-
-	cfg := &types.ForgeConfig{GuardrailsPath: customPath}
-	logger := &captureLogger{}
-	_, _ = BuildGuardrailChecker(cfg, wd, false, logger, nil,
-		GuardrailAuditConfig{}, observability.TracingConfig{})
-	if countWarnsContaining(logger.warns, "DB and file are mutually exclusive") != 1 {
-		t.Errorf("expected exclusivity warning for custom GuardrailsPath; got warns=%v", logger.warns)
-	}
-}
-
-func countWarnsContaining(warns []string, substr string) int {
-	n := 0
-	for _, w := range warns {
-		if strings.Contains(w, substr) {
-			n++
-		}
-	}
-	return n
+	return false
 }

--- a/forge-cli/runtime/guardrails_loader_test.go
+++ b/forge-cli/runtime/guardrails_loader_test.go
@@ -65,6 +65,76 @@ guardrails:
 	}
 }
 
+// TestBuildGuardrailChecker_MalformedOverlay_FailsClosed pins finding #1
+// from the #285 review: a typo'd `guardrails:` block (rejected by strict
+// decode) must ABORT startup, not silently drop the operator's mandate.
+func TestBuildGuardrailChecker_MalformedOverlay_FailsClosed(t *testing.T) {
+	dir := isolateLayers(t)
+	policyPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(`
+guardrails:
+  gateConfig:
+    outptGate: true
+`), 0o600); err != nil { // typo: outptGate
+		t.Fatal(err)
+	}
+	t.Setenv("FORGE_PLATFORM_POLICY", policyPath)
+
+	logger := &captureLogger{}
+	checker, err := BuildGuardrailChecker(nil, dir, false, logger, nil,
+		GuardrailAuditConfig{}, observability.TracingConfig{})
+	if err == nil {
+		t.Fatalf("expected a startup error on malformed overlay; got checker=%v", checker)
+	}
+	if checker != nil {
+		t.Errorf("fail-closed must return a nil checker; got %T", checker)
+	}
+	if len(logger.errors) == 0 {
+		t.Errorf("expected an Error log line; got infos=%v warns=%v", logger.infos, logger.warns)
+	}
+}
+
+// TestLoadPlatformGuardrailsOverlay_FoldsUserAndWorkspace confirms multiple
+// layers combine (user ~/.forge/policy.yaml + workspace FORGE_PLATFORM_POLICY).
+func TestLoadPlatformGuardrailsOverlay_FoldsUserAndWorkspace(t *testing.T) {
+	dir := isolateLayers(t)
+
+	userDir := filepath.Join(dir, ".forge")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "policy.yaml"), []byte(`
+guardrails:
+  gateConfig:
+    inputGate: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wsPath := filepath.Join(dir, "ws-policy.yaml")
+	if err := os.WriteFile(wsPath, []byte(`
+guardrails:
+  gateConfig:
+    outputGate: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FORGE_PLATFORM_POLICY", wsPath)
+
+	overlay, sources, err := LoadPlatformGuardrailsOverlay()
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if overlay == nil || overlay.GateConfig == nil {
+		t.Fatal("expected a folded overlay with gateConfig")
+	}
+	if !overlay.GateConfig.InputGate || !overlay.GateConfig.OutputGate {
+		t.Errorf("both layers should contribute gates; got %+v", overlay.GateConfig)
+	}
+	if len(sources) != 2 {
+		t.Errorf("expected 2 contributing layers, got %v", sources)
+	}
+}
+
 func anyContains(lines []string, substr string) bool {
 	for _, l := range lines {
 		if strings.Contains(l, substr) {

--- a/forge-cli/runtime/guardrails_merge.go
+++ b/forge-cli/runtime/guardrails_merge.go
@@ -38,12 +38,20 @@ var actionSeverity = map[string]int{
 // moreSevereAction returns whichever action is stricter. When only one is
 // set, that one wins. Never returns a less-severe action than `agent`, which
 // is what enforces the never-loosen invariant for actions.
+//
+// If the agent's action is UNRECOGNIZED (severity 0 — e.g. a newer library
+// added a stricter action string this build doesn't know), the agent's
+// action is kept: we can't prove the platform's is stricter, and replacing
+// an unknown-but-possibly-stricter action would risk a loosen.
 func moreSevereAction(agent, platform string) string {
 	if platform == "" {
 		return agent
 	}
 	if agent == "" {
 		return platform
+	}
+	if actionSeverity[agent] == 0 {
+		return agent // unknown agent action — never downgrade it
 	}
 	if actionSeverity[platform] > actionSeverity[agent] {
 		return platform
@@ -52,9 +60,14 @@ func moreSevereAction(agent, platform string) string {
 }
 
 // stricterThreshold returns the more-sensitive (LOWER) of two confidence
-// thresholds, treating a non-positive value as "unset". A detector fires
-// when confidence >= threshold, so a lower threshold fires more often =
-// stricter. The platform can lower a threshold but never raise it.
+// thresholds. A detector fires when confidence >= threshold, so a lower
+// threshold fires more often = stricter; the platform can lower a threshold
+// but never raise it.
+//
+// A non-positive value is treated as a SENTINEL for "unset", not a real
+// threshold — so a platform `0` cannot lower an agent's `50`. An agent that
+// genuinely wants maximum sensitivity should enable the detector with a
+// small positive threshold rather than relying on `0`.
 func stricterThreshold(agent, platform float64) float64 {
 	switch {
 	case platform <= 0:
@@ -81,6 +94,10 @@ func MergeGuardrails(agent, platform *models.StructuredGuardrails) (*models.Stru
 	if platform == nil {
 		return result, nil
 	}
+	// Deep-copy the overlay too, so appended rules / patterns / categories in
+	// the result never share inner slices with the caller's platform input
+	// (exact "never aliases inputs" contract).
+	platform = cloneGuardrails(platform)
 	var tt []GuardrailTightening
 	add := func(field, change string) { tt = append(tt, GuardrailTightening{Field: field, Change: change}) }
 
@@ -140,8 +157,14 @@ func mergePII(agent, platform *models.PIIConfig, add func(string, string)) *mode
 			agent.Categories[name] = pc
 			continue
 		}
+		if pc.Enabled && !ac.Enabled {
+			add("pii.categories."+name+".enabled", "enabled")
+		}
+		if na := moreSevereAction(ac.Action, pc.Action); na != ac.Action {
+			add("pii.categories."+name+".action", ac.Action+" -> "+na)
+			ac.Action = na
+		}
 		ac.Enabled = ac.Enabled || pc.Enabled
-		ac.Action = moreSevereAction(ac.Action, pc.Action)
 		agent.Categories[name] = ac
 	}
 	return agent
@@ -155,7 +178,10 @@ func mergeModeration(agent, platform *models.ModerationConfig, add func(string, 
 		add("moderation.enabled", "enabled")
 	}
 	agent.Enabled = agent.Enabled || platform.Enabled
-	agent.Action = moreSevereAction(agent.Action, platform.Action)
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("moderation.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
 	if agent.Categories == nil {
 		agent.Categories = map[string]models.ModerationCategoryConfig{}
 	}
@@ -166,9 +192,18 @@ func mergeModeration(agent, platform *models.ModerationConfig, add func(string, 
 			add("moderation.categories."+name, "added")
 			continue
 		}
+		if pc.Enabled && !ac.Enabled {
+			add("moderation.categories."+name+".enabled", "enabled")
+		}
+		if na := moreSevereAction(ac.Action, pc.Action); na != ac.Action {
+			add("moderation.categories."+name+".action", ac.Action+" -> "+na)
+			ac.Action = na
+		}
+		if nt := stricterThreshold(ac.Threshold, pc.Threshold); nt != ac.Threshold {
+			add("moderation.categories."+name+".threshold", fmt.Sprintf("%g -> %g", ac.Threshold, nt))
+			ac.Threshold = nt
+		}
 		ac.Enabled = ac.Enabled || pc.Enabled
-		ac.Action = moreSevereAction(ac.Action, pc.Action)
-		ac.Threshold = stricterThreshold(ac.Threshold, pc.Threshold)
 		agent.Categories[name] = ac
 	}
 	return agent
@@ -234,7 +269,10 @@ func mergeURLFilter(agent, platform *models.URLFilterConfig, add func(string, st
 		add("urlFilter.enabled", "enabled")
 	}
 	agent.Enabled = agent.Enabled || platform.Enabled
-	agent.Action = moreSevereAction(agent.Action, platform.Action)
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("urlFilter.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
 
 	if n := unionInto(&agent.Denylist, platform.Denylist); n > 0 {
 		add("urlFilter.denylist", fmt.Sprintf("+%d domain(s)", n))
@@ -242,6 +280,12 @@ func mergeURLFilter(agent, platform *models.URLFilterConfig, add func(string, st
 	// Allowlist intersection tightens (fewer URLs pass). Only intersect when
 	// the platform actually declares an allowlist — an empty platform
 	// allowlist means "no opinion", not "deny everything".
+	//
+	// CAVEAT (#287): when agent and platform allowlists are DISJOINT the
+	// intersection is empty-but-non-nil. Whether the guardrails library reads
+	// that as "deny all" (correct ratchet) or "no filtering" (a loosen) under
+	// the active Mode is unverified. Until #287 pins it, operators should
+	// ensure overlapping allowlists.
 	if len(platform.Allowlist) > 0 && len(agent.Allowlist) > 0 {
 		before := len(agent.Allowlist)
 		agent.Allowlist = intersectStrings(agent.Allowlist, platform.Allowlist)
@@ -255,7 +299,10 @@ func mergeURLFilter(agent, platform *models.URLFilterConfig, add func(string, st
 	// When both lists are populated, "both" mode is the only one that
 	// enforces the union of constraints.
 	if len(agent.Allowlist) > 0 && len(agent.Denylist) > 0 {
-		agent.Mode = "both"
+		if agent.Mode != "both" {
+			add("urlFilter.mode", agent.Mode+" -> both")
+			agent.Mode = "both"
+		}
 	} else if agent.Mode == "" {
 		agent.Mode = platform.Mode
 	}
@@ -325,7 +372,10 @@ func mergeNSFW(agent, platform *models.NSFWTextConfig, add func(string, string))
 		add("nsfwText.enabled", "enabled")
 	}
 	agent.Enabled = agent.Enabled || platform.Enabled
-	agent.ConfidenceThreshold = stricterThreshold(agent.ConfidenceThreshold, platform.ConfidenceThreshold)
+	if nt := stricterThreshold(agent.ConfidenceThreshold, platform.ConfidenceThreshold); nt != agent.ConfidenceThreshold {
+		add("nsfwText.confidenceThreshold", fmt.Sprintf("%g -> %g", agent.ConfidenceThreshold, nt))
+		agent.ConfidenceThreshold = nt
+	}
 	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
 		add("nsfwText.action", agent.Action+" -> "+na)
 		agent.Action = na
@@ -352,7 +402,8 @@ func mergeHallucination(agent, platform *models.HallucinationConfig, add func(st
 		add("hallucination.minSourceCount", fmt.Sprintf("%d -> %d", agent.MinSourceCount, platform.MinSourceCount))
 		agent.MinSourceCount = platform.MinSourceCount
 	}
-	if agent.Mode == "" {
+	if agent.Mode == "" && platform.Mode != "" {
+		add("hallucination.mode", "set "+platform.Mode)
 		agent.Mode = platform.Mode
 	}
 	return agent
@@ -366,7 +417,10 @@ func mergeSkillConstraints(agent, platform *models.SkillConstraintsConfig, add f
 		add("skillConstraints.enabled", "enabled")
 	}
 	agent.Enabled = agent.Enabled || platform.Enabled
-	agent.Action = moreSevereAction(agent.Action, platform.Action)
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("skillConstraints.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
 	if n := unionInto(&agent.BlockedSkills, platform.BlockedSkills); n > 0 {
 		add("skillConstraints.blockedSkills", fmt.Sprintf("+%d", n))
 	}

--- a/forge-cli/runtime/guardrails_merge.go
+++ b/forge-cli/runtime/guardrails_merge.go
@@ -1,0 +1,459 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/initializ/guardrails/models"
+)
+
+// GuardrailTightening records one place where the platform overlay made an
+// agent's guardrails STRICTER. Emitted for audit so an operator can see
+// exactly what a layer changed (mirrors the violation attribution in
+// forge-core/security/platform_policy_enforce.go).
+type GuardrailTightening struct {
+	// Field is the dotted path into StructuredGuardrails, e.g.
+	// "security.commandInjection.action" or "gateConfig.outputGate".
+	Field string
+	// Change is a short human-readable before→after, e.g. "warn -> block"
+	// or "enabled" or "+2 rules".
+	Change string
+}
+
+// actionSeverity orders the redaction/enforcement actions from least to
+// most restrictive. "Most severe wins" during a merge, so the platform can
+// raise warn→mask→block but never lower it. Unknown actions rank 0 so an
+// unrecognized platform action never silently downgrades a known agent one.
+var actionSeverity = map[string]int{
+	"warn":                   1,
+	"flag":                   1,
+	"mask":                   2,
+	"redact":                 2,
+	"replace":                2,
+	"block":                  3,
+	"require_human_approval": 4,
+}
+
+// moreSevereAction returns whichever action is stricter. When only one is
+// set, that one wins. Never returns a less-severe action than `agent`, which
+// is what enforces the never-loosen invariant for actions.
+func moreSevereAction(agent, platform string) string {
+	if platform == "" {
+		return agent
+	}
+	if agent == "" {
+		return platform
+	}
+	if actionSeverity[platform] > actionSeverity[agent] {
+		return platform
+	}
+	return agent
+}
+
+// stricterThreshold returns the more-sensitive (LOWER) of two confidence
+// thresholds, treating a non-positive value as "unset". A detector fires
+// when confidence >= threshold, so a lower threshold fires more often =
+// stricter. The platform can lower a threshold but never raise it.
+func stricterThreshold(agent, platform float64) float64 {
+	switch {
+	case platform <= 0:
+		return agent
+	case agent <= 0:
+		return platform
+	case platform < agent:
+		return platform
+	default:
+		return agent
+	}
+}
+
+// MergeGuardrails returns the agent's guardrails tightened by the platform
+// overlay — a one-way ratchet: the platform can force detections/gates ON,
+// raise actions, lower thresholds, and union rule/denylist/blocked-skill
+// sets, but can NEVER loosen anything the agent declared. An absent platform
+// section leaves the agent's setting untouched.
+//
+// The returned value is a deep copy — neither input is mutated. The second
+// return is the list of tightenings the platform applied, for audit.
+func MergeGuardrails(agent, platform *models.StructuredGuardrails) (*models.StructuredGuardrails, []GuardrailTightening) {
+	result := cloneGuardrails(agent)
+	if platform == nil {
+		return result, nil
+	}
+	var tt []GuardrailTightening
+	add := func(field, change string) { tt = append(tt, GuardrailTightening{Field: field, Change: change}) }
+
+	if platform.PII != nil {
+		result.PII = mergePII(result.PII, platform.PII, add)
+	}
+	if platform.Moderation != nil {
+		result.Moderation = mergeModeration(result.Moderation, platform.Moderation, add)
+	}
+	if platform.Security != nil {
+		result.Security = mergeSecurity(result.Security, platform.Security, add)
+	}
+	if platform.URLFilter != nil {
+		result.URLFilter = mergeURLFilter(result.URLFilter, platform.URLFilter, add)
+	}
+	if platform.CustomRules != nil {
+		result.CustomRules = mergeCustomRules(result.CustomRules, platform.CustomRules, add)
+	}
+	if len(platform.ApprovalGates) > 0 {
+		result.ApprovalGates = mergeApprovalGates(result.ApprovalGates, platform.ApprovalGates, add)
+	}
+	if platform.NSFWText != nil {
+		result.NSFWText = mergeNSFW(result.NSFWText, platform.NSFWText, add)
+	}
+	if platform.Hallucination != nil {
+		result.Hallucination = mergeHallucination(result.Hallucination, platform.Hallucination, add)
+	}
+	if platform.SkillConstraints != nil {
+		result.SkillConstraints = mergeSkillConstraints(result.SkillConstraints, platform.SkillConstraints, add)
+	}
+	if platform.GateConfig != nil {
+		result.GateConfig = mergeGateConfig(result.GateConfig, platform.GateConfig, add)
+	}
+
+	return result, tt
+}
+
+func mergePII(agent, platform *models.PIIConfig, add func(string, string)) *models.PIIConfig {
+	if agent == nil {
+		agent = &models.PIIConfig{Categories: map[string]models.PIICategoryConfig{}}
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("pii.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("pii.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
+	if agent.Categories == nil {
+		agent.Categories = map[string]models.PIICategoryConfig{}
+	}
+	for name, pc := range platform.Categories {
+		ac, ok := agent.Categories[name]
+		if !ok {
+			add("pii.categories."+name, "added")
+			agent.Categories[name] = pc
+			continue
+		}
+		ac.Enabled = ac.Enabled || pc.Enabled
+		ac.Action = moreSevereAction(ac.Action, pc.Action)
+		agent.Categories[name] = ac
+	}
+	return agent
+}
+
+func mergeModeration(agent, platform *models.ModerationConfig, add func(string, string)) *models.ModerationConfig {
+	if agent == nil {
+		agent = &models.ModerationConfig{Categories: map[string]models.ModerationCategoryConfig{}}
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("moderation.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	agent.Action = moreSevereAction(agent.Action, platform.Action)
+	if agent.Categories == nil {
+		agent.Categories = map[string]models.ModerationCategoryConfig{}
+	}
+	for name, pc := range platform.Categories {
+		ac, ok := agent.Categories[name]
+		if !ok {
+			agent.Categories[name] = pc
+			add("moderation.categories."+name, "added")
+			continue
+		}
+		ac.Enabled = ac.Enabled || pc.Enabled
+		ac.Action = moreSevereAction(ac.Action, pc.Action)
+		ac.Threshold = stricterThreshold(ac.Threshold, pc.Threshold)
+		agent.Categories[name] = ac
+	}
+	return agent
+}
+
+func mergeSecurity(agent, platform *models.SecurityConfig, add func(string, string)) *models.SecurityConfig {
+	if agent == nil {
+		agent = &models.SecurityConfig{}
+	}
+	agent.JailbreakDetection = mergeThreshold("security.jailbreakDetection", agent.JailbreakDetection, platform.JailbreakDetection, add)
+	agent.PromptInjection = mergeThreshold("security.promptInjection", agent.PromptInjection, platform.PromptInjection, add)
+	agent.SQLInjection = mergeThreshold("security.sqlInjection", agent.SQLInjection, platform.SQLInjection, add)
+	agent.CommandInjection = mergeThreshold("security.commandInjection", agent.CommandInjection, platform.CommandInjection, add)
+
+	if len(platform.CustomPatterns) > 0 {
+		before := len(agent.CustomPatterns)
+		seen := map[string]struct{}{}
+		for _, p := range agent.CustomPatterns {
+			seen[p.Name+"|"+p.Pattern] = struct{}{}
+		}
+		for _, p := range platform.CustomPatterns {
+			if _, dup := seen[p.Name+"|"+p.Pattern]; dup {
+				continue
+			}
+			agent.CustomPatterns = append(agent.CustomPatterns, p)
+		}
+		if n := len(agent.CustomPatterns) - before; n > 0 {
+			add("security.customPatterns", fmt.Sprintf("+%d pattern(s)", n))
+		}
+	}
+	return agent
+}
+
+func mergeThreshold(field string, agent, platform *models.ThresholdConfig, add func(string, string)) *models.ThresholdConfig {
+	if platform == nil {
+		return agent
+	}
+	if agent == nil {
+		add(field, "added")
+		cp := *platform
+		return &cp
+	}
+	if platform.Enabled && !agent.Enabled {
+		add(field+".enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	if nt := stricterThreshold(agent.ConfidenceThreshold, platform.ConfidenceThreshold); nt != agent.ConfidenceThreshold {
+		add(field+".confidenceThreshold", fmt.Sprintf("%g -> %g", agent.ConfidenceThreshold, nt))
+		agent.ConfidenceThreshold = nt
+	}
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add(field+".action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
+	return agent
+}
+
+func mergeURLFilter(agent, platform *models.URLFilterConfig, add func(string, string)) *models.URLFilterConfig {
+	if agent == nil {
+		agent = &models.URLFilterConfig{}
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("urlFilter.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	agent.Action = moreSevereAction(agent.Action, platform.Action)
+
+	if n := unionInto(&agent.Denylist, platform.Denylist); n > 0 {
+		add("urlFilter.denylist", fmt.Sprintf("+%d domain(s)", n))
+	}
+	// Allowlist intersection tightens (fewer URLs pass). Only intersect when
+	// the platform actually declares an allowlist — an empty platform
+	// allowlist means "no opinion", not "deny everything".
+	if len(platform.Allowlist) > 0 && len(agent.Allowlist) > 0 {
+		before := len(agent.Allowlist)
+		agent.Allowlist = intersectStrings(agent.Allowlist, platform.Allowlist)
+		if before != len(agent.Allowlist) {
+			add("urlFilter.allowlist", fmt.Sprintf("%d -> %d (intersect)", before, len(agent.Allowlist)))
+		}
+	} else if len(platform.Allowlist) > 0 && len(agent.Allowlist) == 0 {
+		agent.Allowlist = append([]string(nil), platform.Allowlist...)
+		add("urlFilter.allowlist", fmt.Sprintf("set %d (platform)", len(agent.Allowlist)))
+	}
+	// When both lists are populated, "both" mode is the only one that
+	// enforces the union of constraints.
+	if len(agent.Allowlist) > 0 && len(agent.Denylist) > 0 {
+		agent.Mode = "both"
+	} else if agent.Mode == "" {
+		agent.Mode = platform.Mode
+	}
+	return agent
+}
+
+func mergeCustomRules(agent, platform *models.CustomRulesConfig, add func(string, string)) *models.CustomRulesConfig {
+	if agent == nil {
+		agent = &models.CustomRulesConfig{}
+	}
+	if n := unionInto(&agent.HardConstraints, platform.HardConstraints); n > 0 {
+		add("customRules.hardConstraints", fmt.Sprintf("+%d", n))
+	}
+	if n := unionInto(&agent.SoftConstraints, platform.SoftConstraints); n > 0 {
+		add("customRules.softConstraints", fmt.Sprintf("+%d", n))
+	}
+	if len(platform.Rules) > 0 {
+		seen := map[string]struct{}{}
+		for _, r := range agent.Rules {
+			seen[r.ID] = struct{}{}
+		}
+		before := len(agent.Rules)
+		for _, r := range platform.Rules {
+			if r.ID != "" {
+				if _, dup := seen[r.ID]; dup {
+					continue
+				}
+				seen[r.ID] = struct{}{}
+			}
+			agent.Rules = append(agent.Rules, r)
+		}
+		if n := len(agent.Rules) - before; n > 0 {
+			add("customRules.rules", fmt.Sprintf("+%d rule(s)", n))
+		}
+	}
+	return agent
+}
+
+func mergeApprovalGates(agent, platform []models.ApprovalCondition, add func(string, string)) []models.ApprovalCondition {
+	seen := map[string]struct{}{}
+	for _, c := range agent {
+		seen[c.ID] = struct{}{}
+	}
+	before := len(agent)
+	for _, c := range platform {
+		if c.ID != "" {
+			if _, dup := seen[c.ID]; dup {
+				continue
+			}
+			seen[c.ID] = struct{}{}
+		}
+		agent = append(agent, c)
+	}
+	if n := len(agent) - before; n > 0 {
+		add("approvalGates", fmt.Sprintf("+%d condition(s)", n))
+	}
+	return agent
+}
+
+func mergeNSFW(agent, platform *models.NSFWTextConfig, add func(string, string)) *models.NSFWTextConfig {
+	if agent == nil {
+		add("nsfwText", "added")
+		cp := *platform
+		return &cp
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("nsfwText.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	agent.ConfidenceThreshold = stricterThreshold(agent.ConfidenceThreshold, platform.ConfidenceThreshold)
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("nsfwText.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
+	return agent
+}
+
+func mergeHallucination(agent, platform *models.HallucinationConfig, add func(string, string)) *models.HallucinationConfig {
+	if agent == nil {
+		add("hallucination", "added")
+		cp := *platform
+		return &cp
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("hallucination.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	if na := moreSevereAction(agent.Action, platform.Action); na != agent.Action {
+		add("hallucination.action", agent.Action+" -> "+na)
+		agent.Action = na
+	}
+	// More required sources = stricter.
+	if platform.MinSourceCount > agent.MinSourceCount {
+		add("hallucination.minSourceCount", fmt.Sprintf("%d -> %d", agent.MinSourceCount, platform.MinSourceCount))
+		agent.MinSourceCount = platform.MinSourceCount
+	}
+	if agent.Mode == "" {
+		agent.Mode = platform.Mode
+	}
+	return agent
+}
+
+func mergeSkillConstraints(agent, platform *models.SkillConstraintsConfig, add func(string, string)) *models.SkillConstraintsConfig {
+	if agent == nil {
+		agent = &models.SkillConstraintsConfig{}
+	}
+	if platform.Enabled && !agent.Enabled {
+		add("skillConstraints.enabled", "enabled")
+	}
+	agent.Enabled = agent.Enabled || platform.Enabled
+	agent.Action = moreSevereAction(agent.Action, platform.Action)
+	if n := unionInto(&agent.BlockedSkills, platform.BlockedSkills); n > 0 {
+		add("skillConstraints.blockedSkills", fmt.Sprintf("+%d", n))
+	}
+	if len(platform.AllowedSkills) > 0 && len(agent.AllowedSkills) > 0 {
+		before := len(agent.AllowedSkills)
+		agent.AllowedSkills = intersectStrings(agent.AllowedSkills, platform.AllowedSkills)
+		if before != len(agent.AllowedSkills) {
+			add("skillConstraints.allowedSkills", fmt.Sprintf("%d -> %d (intersect)", before, len(agent.AllowedSkills)))
+		}
+	} else if len(platform.AllowedSkills) > 0 {
+		agent.AllowedSkills = append([]string(nil), platform.AllowedSkills...)
+		add("skillConstraints.allowedSkills", fmt.Sprintf("set %d (platform)", len(agent.AllowedSkills)))
+	}
+	return agent
+}
+
+func mergeGateConfig(agent, platform *models.GateConfig, add func(string, string)) *models.GateConfig {
+	if agent == nil {
+		agent = &models.GateConfig{}
+	}
+	forceOn := func(name string, a *bool, p bool) {
+		if p && !*a {
+			add("gateConfig."+name, "enabled")
+			*a = true
+		}
+	}
+	forceOn("inputGate", &agent.InputGate, platform.InputGate)
+	forceOn("contextGate", &agent.ContextGate, platform.ContextGate)
+	forceOn("toolCallGate", &agent.ToolCallGate, platform.ToolCallGate)
+	forceOn("outputGate", &agent.OutputGate, platform.OutputGate)
+	forceOn("streamGate", &agent.StreamGate, platform.StreamGate)
+	return agent
+}
+
+// unionInto appends every element of add[] not already present in *dst,
+// preserving order, and returns how many were added.
+func unionInto(dst *[]string, add []string) int {
+	seen := map[string]struct{}{}
+	for _, s := range *dst {
+		seen[s] = struct{}{}
+	}
+	n := 0
+	for _, s := range add {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		*dst = append(*dst, s)
+		n++
+	}
+	return n
+}
+
+// intersectStrings returns the elements present in BOTH a and b, in a's
+// order. Used for allowlist intersection (fewer entries = stricter).
+func intersectStrings(a, b []string) []string {
+	inB := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		inB[s] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, s := range a {
+		if _, ok := inB[s]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// cloneGuardrails deep-copies via JSON round-trip so the merge never mutates
+// the caller's inputs. Returns a fresh empty config when g is nil.
+func cloneGuardrails(g *models.StructuredGuardrails) *models.StructuredGuardrails {
+	if g == nil {
+		return &models.StructuredGuardrails{}
+	}
+	data, err := json.Marshal(g)
+	if err != nil {
+		return &models.StructuredGuardrails{}
+	}
+	var out models.StructuredGuardrails
+	if err := json.Unmarshal(data, &out); err != nil {
+		return &models.StructuredGuardrails{}
+	}
+	return &out
+}
+
+// sortTightenings orders tightenings by Field for stable audit output.
+func sortTightenings(tt []GuardrailTightening) {
+	sort.Slice(tt, func(i, j int) bool { return tt[i].Field < tt[j].Field })
+}

--- a/forge-cli/runtime/guardrails_merge_test.go
+++ b/forge-cli/runtime/guardrails_merge_test.go
@@ -1,0 +1,178 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/initializ/guardrails/models"
+)
+
+func thr(enabled bool, threshold float64, action string) *models.ThresholdConfig {
+	return &models.ThresholdConfig{Enabled: enabled, ConfidenceThreshold: threshold, Action: action}
+}
+
+// TestMerge_NilPlatform — a nil overlay returns a clone of the agent with no
+// tightenings, and does not alias the input.
+func TestMerge_NilPlatform(t *testing.T) {
+	agent := &models.StructuredGuardrails{GateConfig: &models.GateConfig{OutputGate: true}}
+	got, tt := MergeGuardrails(agent, nil)
+	if len(tt) != 0 {
+		t.Errorf("nil platform should tighten nothing, got %v", tt)
+	}
+	if got == agent {
+		t.Error("result must be a copy, not the same pointer")
+	}
+	if got.GateConfig == agent.GateConfig {
+		t.Error("nested GateConfig must be a copy, not aliased")
+	}
+}
+
+// TestMerge_GateForceOn — platform can force a gate ON but never OFF.
+func TestMerge_GateForceOn(t *testing.T) {
+	agent := &models.StructuredGuardrails{GateConfig: &models.GateConfig{InputGate: true, OutputGate: false}}
+	platform := &models.StructuredGuardrails{GateConfig: &models.GateConfig{OutputGate: true, InputGate: false}}
+	got, tt := MergeGuardrails(agent, platform)
+	if !got.GateConfig.OutputGate {
+		t.Error("platform should force outputGate ON")
+	}
+	if !got.GateConfig.InputGate {
+		t.Error("platform must NOT turn agent's inputGate OFF (never loosen)")
+	}
+	if len(tt) != 1 || tt[0].Field != "gateConfig.outputGate" {
+		t.Errorf("expected one tightening on outputGate, got %v", tt)
+	}
+}
+
+// TestMerge_ActionSeverity — most-severe action wins; a weaker platform
+// action does not downgrade the agent's.
+func TestMerge_ActionSeverity(t *testing.T) {
+	agent := &models.StructuredGuardrails{Security: &models.SecurityConfig{CommandInjection: thr(true, 40, "warn")}}
+	platform := &models.StructuredGuardrails{Security: &models.SecurityConfig{CommandInjection: thr(true, 40, "block")}}
+	got, _ := MergeGuardrails(agent, platform)
+	if got.Security.CommandInjection.Action != "block" {
+		t.Errorf("expected action raised to block, got %q", got.Security.CommandInjection.Action)
+	}
+
+	// Reverse: platform weaker than agent must not loosen.
+	agent2 := &models.StructuredGuardrails{Security: &models.SecurityConfig{CommandInjection: thr(true, 40, "block")}}
+	platform2 := &models.StructuredGuardrails{Security: &models.SecurityConfig{CommandInjection: thr(true, 40, "warn")}}
+	got2, tt2 := MergeGuardrails(agent2, platform2)
+	if got2.Security.CommandInjection.Action != "block" {
+		t.Errorf("weaker platform action must not loosen agent; got %q", got2.Security.CommandInjection.Action)
+	}
+	if len(tt2) != 0 {
+		t.Errorf("no tightening expected when platform is weaker, got %v", tt2)
+	}
+}
+
+// TestMerge_ThresholdStricter — lower (more sensitive) threshold wins; a
+// higher platform threshold does not raise the agent's.
+func TestMerge_ThresholdStricter(t *testing.T) {
+	agent := &models.StructuredGuardrails{Security: &models.SecurityConfig{PromptInjection: thr(true, 50, "block")}}
+	platform := &models.StructuredGuardrails{Security: &models.SecurityConfig{PromptInjection: thr(true, 30, "block")}}
+	got, _ := MergeGuardrails(agent, platform)
+	if got.Security.PromptInjection.ConfidenceThreshold != 30 {
+		t.Errorf("expected threshold lowered to 30, got %g", got.Security.PromptInjection.ConfidenceThreshold)
+	}
+
+	platform2 := &models.StructuredGuardrails{Security: &models.SecurityConfig{PromptInjection: thr(true, 80, "block")}}
+	got2, _ := MergeGuardrails(agent, platform2)
+	if got2.Security.PromptInjection.ConfidenceThreshold != 50 {
+		t.Errorf("higher platform threshold must not loosen; expected 50, got %g", got2.Security.PromptInjection.ConfidenceThreshold)
+	}
+}
+
+// TestMerge_DetectionEnable — platform force-enables a detection the agent
+// left off, and can add one the agent omitted entirely.
+func TestMerge_DetectionEnable(t *testing.T) {
+	agent := &models.StructuredGuardrails{Security: &models.SecurityConfig{CommandInjection: thr(false, 40, "warn")}}
+	platform := &models.StructuredGuardrails{Security: &models.SecurityConfig{
+		CommandInjection: thr(true, 40, "warn"),
+		SQLInjection:     thr(true, 20, "block"), // agent had none
+	}}
+	got, _ := MergeGuardrails(agent, platform)
+	if !got.Security.CommandInjection.Enabled {
+		t.Error("platform should force commandInjection enabled")
+	}
+	if got.Security.SQLInjection == nil || !got.Security.SQLInjection.Enabled {
+		t.Error("platform should add the sqlInjection detector the agent omitted")
+	}
+}
+
+// TestMerge_CustomRulesUnion — platform rules are added; duplicates by ID
+// are not; agent rules are never removed.
+func TestMerge_CustomRulesUnion(t *testing.T) {
+	agent := &models.StructuredGuardrails{CustomRules: &models.CustomRulesConfig{
+		Rules: []models.CustomRule{{ID: "a", Action: "mask"}},
+	}}
+	platform := &models.StructuredGuardrails{CustomRules: &models.CustomRulesConfig{
+		Rules: []models.CustomRule{{ID: "a", Action: "block"}, {ID: "b", Action: "block"}},
+	}}
+	got, _ := MergeGuardrails(agent, platform)
+	if len(got.CustomRules.Rules) != 2 {
+		t.Fatalf("expected union of 2 rules (dedupe id 'a'), got %d", len(got.CustomRules.Rules))
+	}
+	if got.CustomRules.Rules[0].ID != "a" || got.CustomRules.Rules[0].Action != "mask" {
+		t.Error("agent's rule 'a' must be preserved unchanged (union does not overwrite)")
+	}
+}
+
+// TestMerge_URLFilter — denylist unions, allowlist intersects.
+func TestMerge_URLFilter(t *testing.T) {
+	agent := &models.StructuredGuardrails{URLFilter: &models.URLFilterConfig{
+		Enabled: true, Allowlist: []string{"a.com", "b.com"}, Denylist: []string{"x.com"},
+	}}
+	platform := &models.StructuredGuardrails{URLFilter: &models.URLFilterConfig{
+		Allowlist: []string{"b.com", "c.com"}, Denylist: []string{"y.com"},
+	}}
+	got, _ := MergeGuardrails(agent, platform)
+	if len(got.URLFilter.Denylist) != 2 {
+		t.Errorf("denylist should union to 2, got %v", got.URLFilter.Denylist)
+	}
+	if len(got.URLFilter.Allowlist) != 1 || got.URLFilter.Allowlist[0] != "b.com" {
+		t.Errorf("allowlist should intersect to [b.com], got %v", got.URLFilter.Allowlist)
+	}
+}
+
+// TestMerge_SkillConstraints — blocked unions, allowed intersects.
+func TestMerge_SkillConstraints(t *testing.T) {
+	agent := &models.StructuredGuardrails{SkillConstraints: &models.SkillConstraintsConfig{
+		Enabled: true, AllowedSkills: []string{"s1", "s2"}, BlockedSkills: []string{"bad1"},
+	}}
+	platform := &models.StructuredGuardrails{SkillConstraints: &models.SkillConstraintsConfig{
+		AllowedSkills: []string{"s2", "s3"}, BlockedSkills: []string{"bad2"},
+	}}
+	got, _ := MergeGuardrails(agent, platform)
+	if len(got.SkillConstraints.BlockedSkills) != 2 {
+		t.Errorf("blocked should union to 2, got %v", got.SkillConstraints.BlockedSkills)
+	}
+	if len(got.SkillConstraints.AllowedSkills) != 1 || got.SkillConstraints.AllowedSkills[0] != "s2" {
+		t.Errorf("allowed should intersect to [s2], got %v", got.SkillConstraints.AllowedSkills)
+	}
+}
+
+// TestMerge_NeverLoosen_InputUnmutated — a fully-weaker overlay changes
+// nothing, and the agent input is never mutated by the merge.
+func TestMerge_NeverLoosen_InputUnmutated(t *testing.T) {
+	agent := &models.StructuredGuardrails{
+		GateConfig: &models.GateConfig{InputGate: true, OutputGate: true, ToolCallGate: true},
+		Security:   &models.SecurityConfig{CommandInjection: thr(true, 20, "block")},
+		PII:        &models.PIIConfig{Enabled: true, Action: "block"},
+	}
+	platform := &models.StructuredGuardrails{
+		GateConfig: &models.GateConfig{}, // all false
+		Security:   &models.SecurityConfig{CommandInjection: thr(false, 90, "warn")},
+		PII:        &models.PIIConfig{Enabled: false, Action: "warn"},
+	}
+	got, tt := MergeGuardrails(agent, platform)
+	if len(tt) != 0 {
+		t.Errorf("weaker overlay must tighten nothing, got %v", tt)
+	}
+	// Agent still strict.
+	if !got.GateConfig.OutputGate || got.Security.CommandInjection.Action != "block" || got.PII.Action != "block" {
+		t.Error("agent settings must be preserved against a weaker overlay")
+	}
+	// Input untouched.
+	if agent.PII.Action != "block" || agent.Security.CommandInjection.ConfidenceThreshold != 20 {
+		t.Error("MergeGuardrails must not mutate the agent input")
+	}
+}

--- a/forge-cli/runtime/guardrails_merge_test.go
+++ b/forge-cli/runtime/guardrails_merge_test.go
@@ -1,10 +1,54 @@
 package runtime
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/initializ/guardrails/models"
 )
+
+// TestMerge_EveryChangeIsRecorded pins review finding #3: whenever the
+// overlay actually changes the effective config, at least one tightening is
+// recorded — so the "tightened nothing" log can never be misleading. Covers
+// the sections that were previously mutated silently (moderation, pii
+// categories, nsfw threshold, urlFilter action, skillConstraints action).
+func TestMerge_EveryChangeIsRecorded(t *testing.T) {
+	cases := map[string]struct{ agent, platform *models.StructuredGuardrails }{
+		"moderation.action": {
+			agent:    &models.StructuredGuardrails{Moderation: &models.ModerationConfig{Enabled: true, Action: "warn"}},
+			platform: &models.StructuredGuardrails{Moderation: &models.ModerationConfig{Enabled: true, Action: "block"}},
+		},
+		"pii.category": {
+			agent: &models.StructuredGuardrails{PII: &models.PIIConfig{Enabled: true, Action: "mask",
+				Categories: map[string]models.PIICategoryConfig{"email": {Enabled: false, Action: "warn"}}}},
+			platform: &models.StructuredGuardrails{PII: &models.PIIConfig{Enabled: true, Action: "mask",
+				Categories: map[string]models.PIICategoryConfig{"email": {Enabled: true, Action: "block"}}}},
+		},
+		"nsfw.threshold": {
+			agent:    &models.StructuredGuardrails{NSFWText: &models.NSFWTextConfig{Enabled: true, ConfidenceThreshold: 0.8, Action: "block"}},
+			platform: &models.StructuredGuardrails{NSFWText: &models.NSFWTextConfig{Enabled: true, ConfidenceThreshold: 0.3, Action: "block"}},
+		},
+		"urlFilter.action": {
+			agent:    &models.StructuredGuardrails{URLFilter: &models.URLFilterConfig{Enabled: true, Action: "warn", Denylist: []string{"x.com"}}},
+			platform: &models.StructuredGuardrails{URLFilter: &models.URLFilterConfig{Action: "block"}},
+		},
+		"skillConstraints.action": {
+			agent:    &models.StructuredGuardrails{SkillConstraints: &models.SkillConstraintsConfig{Enabled: true, Action: "warn"}},
+			platform: &models.StructuredGuardrails{SkillConstraints: &models.SkillConstraintsConfig{Action: "block"}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			effective, tt := MergeGuardrails(tc.agent, tc.platform)
+			if reflect.DeepEqual(tc.agent, effective) {
+				t.Skip("overlay produced no change for this case")
+			}
+			if len(tt) == 0 {
+				t.Errorf("effective config changed but no tightening was recorded (misleading audit log)")
+			}
+		})
+	}
+}
 
 func thr(enabled bool, threshold float64, action string) *models.ThresholdConfig {
 	return &models.ThresholdConfig{Enabled: enabled, ConfidenceThreshold: threshold, Action: action}

--- a/forge-cli/runtime/guardrails_overlay.go
+++ b/forge-cli/runtime/guardrails_overlay.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/initializ/guardrails/models"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	"github.com/initializ/forge/forge-core/security"
+)
+
+// LoadPlatformGuardrailsOverlay reads the `guardrails:` overlay from every
+// platform-policy layer (system → user → workspace, the same layers the
+// capability policy uses) and folds them into a single most-restrictive
+// overlay.
+//
+// The overlay is authored in the YAML policy.yaml using the SAME schema as
+// the agent's guardrails.json (guardrails.StructuredGuardrails, camelCase
+// field names). forge-core carries it as a raw YAML subtree; here we bridge
+// each layer YAML→JSON→typed struct and union them via MergeGuardrails.
+//
+// Returns (nil, nil, nil) when no layer declares a guardrails overlay — the
+// common case, where the agent's guardrails.json stands alone. A malformed
+// overlay (or a policy layer that won't parse) is a hard error, matching the
+// fail-loud posture of the capability-policy loader.
+func LoadPlatformGuardrailsOverlay() (*models.StructuredGuardrails, []string, error) {
+	layers, err := security.LoadAllPolicyLayers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var combined *models.StructuredGuardrails
+	var sources []string
+	for i := range layers {
+		raw := layers[i].Policy.Guardrails
+		if len(raw) == 0 {
+			continue
+		}
+		ov, err := overlayFromRawYAML(raw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing %s-layer guardrails overlay (%s): %w",
+				layers[i].Source, layers[i].Path, err)
+		}
+		// Fold onto the accumulator. MergeGuardrails is a most-restrictive
+		// union, so layer order doesn't affect the combined result.
+		combined, _ = MergeGuardrails(combined, ov)
+		sources = append(sources, layers[i].Source)
+	}
+	if combined == nil {
+		return nil, nil, nil
+	}
+	return combined, sources, nil
+}
+
+// overlayFromRawYAML bridges the raw YAML subtree (already decoded to
+// map[string]any by the YAML policy loader) into the typed
+// StructuredGuardrails: marshal the map to JSON, then strictly unmarshal
+// into the struct. Strict unmarshal (DisallowUnknownFields) preserves the
+// "operator typos fail loudly" posture of the capability-policy loader — a
+// mistyped `comandInjection:` is rejected rather than silently ignored.
+func overlayFromRawYAML(raw map[string]any) (*models.StructuredGuardrails, error) {
+	j, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("re-encoding overlay: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.DisallowUnknownFields()
+	var sg models.StructuredGuardrails
+	if err := dec.Decode(&sg); err != nil {
+		return nil, fmt.Errorf("unknown or malformed guardrails field: %w", err)
+	}
+	return &sg, nil
+}
+
+// applyPlatformGuardrailsOverlay merges the platform overlay (if any) over
+// the agent's guardrails and logs every tightening for audit visibility.
+// Returns the effective guardrails to hand to the engine. On a malformed
+// overlay it logs and returns the agent's guardrails unchanged — the overlay
+// is additive protection; a broken overlay must not crash an otherwise-valid
+// agent, but the operator is told loudly.
+func applyPlatformGuardrailsOverlay(agent *models.StructuredGuardrails, logger coreruntime.Logger) *models.StructuredGuardrails {
+	overlay, sources, err := LoadPlatformGuardrailsOverlay()
+	if err != nil {
+		logger.Error("guardrails: platform overlay failed to load; agent guardrails used unchanged", map[string]any{
+			"error": err.Error(),
+		})
+		return agent
+	}
+	if overlay == nil {
+		return agent
+	}
+
+	effective, tightenings := MergeGuardrails(agent, overlay)
+	sortTightenings(tightenings)
+
+	if len(tightenings) == 0 {
+		logger.Info("guardrails: platform overlay loaded but tightened nothing (agent already at least as strict)", map[string]any{
+			"layers": sources,
+		})
+		return effective
+	}
+
+	changes := make([]string, 0, len(tightenings))
+	for _, t := range tightenings {
+		changes = append(changes, t.Field+": "+t.Change)
+	}
+	logger.Info("guardrails: platform overlay tightened agent guardrails", map[string]any{
+		"layers":  sources,
+		"changes": changes,
+	})
+	return effective
+}

--- a/forge-cli/runtime/guardrails_overlay.go
+++ b/forge-cli/runtime/guardrails_overlay.go
@@ -44,7 +44,9 @@ func LoadPlatformGuardrailsOverlay() (*models.StructuredGuardrails, []string, er
 				layers[i].Source, layers[i].Path, err)
 		}
 		// Fold onto the accumulator. MergeGuardrails is a most-restrictive
-		// union, so layer order doesn't affect the combined result.
+		// union; the effective strictness is order-independent, though a few
+		// first-writer-wins fallbacks (urlFilter/hallucination Mode when
+		// unset, rule-ID dedupe) resolve to whichever layer set them first.
 		combined, _ = MergeGuardrails(combined, ov)
 		sources = append(sources, layers[i].Source)
 	}
@@ -75,21 +77,27 @@ func overlayFromRawYAML(raw map[string]any) (*models.StructuredGuardrails, error
 }
 
 // applyPlatformGuardrailsOverlay merges the platform overlay (if any) over
-// the agent's guardrails and logs every tightening for audit visibility.
-// Returns the effective guardrails to hand to the engine. On a malformed
-// overlay it logs and returns the agent's guardrails unchanged — the overlay
-// is additive protection; a broken overlay must not crash an otherwise-valid
-// agent, but the operator is told loudly.
-func applyPlatformGuardrailsOverlay(agent *models.StructuredGuardrails, logger coreruntime.Logger) *models.StructuredGuardrails {
+// the agent's guardrails and logs every tightening for visibility. Returns
+// the effective guardrails to hand to the engine.
+//
+// FAIL-CLOSED: a malformed overlay is a hard error, not a warning. A platform
+// guardrails overlay is an operator mandate in the same class as the egress /
+// tool / model denies enforced by platform_policy_enforce.go — those refuse
+// to start on conflict, and a typo'd `guardrails:` block that strict-decoding
+// rejects must likewise abort rather than silently drop the intended
+// tightening (which would start the agent LESS protected than the operator
+// mandated). The caller (BuildGuardrailChecker) propagates the error so the
+// runner exits non-zero.
+func applyPlatformGuardrailsOverlay(agent *models.StructuredGuardrails, logger coreruntime.Logger) (*models.StructuredGuardrails, error) {
 	overlay, sources, err := LoadPlatformGuardrailsOverlay()
 	if err != nil {
-		logger.Error("guardrails: platform overlay failed to load; agent guardrails used unchanged", map[string]any{
+		logger.Error("guardrails: platform overlay failed to load; refusing to start", map[string]any{
 			"error": err.Error(),
 		})
-		return agent
+		return nil, err
 	}
 	if overlay == nil {
-		return agent
+		return agent, nil
 	}
 
 	effective, tightenings := MergeGuardrails(agent, overlay)
@@ -99,7 +107,7 @@ func applyPlatformGuardrailsOverlay(agent *models.StructuredGuardrails, logger c
 		logger.Info("guardrails: platform overlay loaded but tightened nothing (agent already at least as strict)", map[string]any{
 			"layers": sources,
 		})
-		return effective
+		return effective, nil
 	}
 
 	changes := make([]string, 0, len(tightenings))
@@ -110,5 +118,5 @@ func applyPlatformGuardrailsOverlay(agent *models.StructuredGuardrails, logger c
 		"layers":  sources,
 		"changes": changes,
 	})
-	return effective
+	return effective, nil
 }

--- a/forge-cli/runtime/guardrails_overlay_test.go
+++ b/forge-cli/runtime/guardrails_overlay_test.go
@@ -1,0 +1,152 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/initializ/guardrails/models"
+
+	"github.com/initializ/forge/forge-core/security"
+)
+
+// TestOverlayFromRawYAML_Bridge verifies the YAML→JSON→struct bridge maps
+// the camelCase guardrails schema authored in policy.yaml onto the typed
+// StructuredGuardrails correctly (the core YAML-vs-JSON concern).
+func TestOverlayFromRawYAML_Bridge(t *testing.T) {
+	policyYAML := []byte(`
+denied_tools:
+  - http_request
+guardrails:
+  gateConfig:
+    outputGate: true
+  security:
+    commandInjection:
+      enabled: true
+      confidenceThreshold: 20
+      action: block
+  customRules:
+    rules:
+      - id: platform_secret
+        name: Internal token
+        type: regex
+        constraint: hard
+        pattern: "intz-[a-f0-9]{16}"
+        action: block
+`)
+	pol, err := security.ParsePlatformPolicy(policyYAML)
+	if err != nil {
+		t.Fatalf("policy parse failed: %v", err)
+	}
+	if len(pol.Guardrails) == 0 {
+		t.Fatal("guardrails block did not parse into PlatformPolicy.Guardrails")
+	}
+
+	ov, err := overlayFromRawYAML(pol.Guardrails)
+	if err != nil {
+		t.Fatalf("bridge failed: %v", err)
+	}
+	if ov.GateConfig == nil || !ov.GateConfig.OutputGate {
+		t.Error("gateConfig.outputGate did not bridge")
+	}
+	if ov.Security == nil || ov.Security.CommandInjection == nil {
+		t.Fatal("security.commandInjection did not bridge")
+	}
+	if ov.Security.CommandInjection.ConfidenceThreshold != 20 {
+		t.Errorf("confidenceThreshold bridged wrong: %g", ov.Security.CommandInjection.ConfidenceThreshold)
+	}
+	if ov.Security.CommandInjection.Action != "block" {
+		t.Errorf("action bridged wrong: %q", ov.Security.CommandInjection.Action)
+	}
+	if ov.CustomRules == nil || len(ov.CustomRules.Rules) != 1 || ov.CustomRules.Rules[0].ID != "platform_secret" {
+		t.Errorf("customRules did not bridge: %+v", ov.CustomRules)
+	}
+}
+
+// TestOverlayFromRawYAML_StrictUnknownField ensures an operator typo in the
+// guardrails block fails loudly (parity with the strict policy loader).
+func TestOverlayFromRawYAML_StrictUnknownField(t *testing.T) {
+	pol, err := security.ParsePlatformPolicy([]byte(`
+guardrails:
+  gateConfig:
+    outptGate: true
+`)) // typo: outptGate
+	if err != nil {
+		t.Fatalf("policy parse failed: %v", err)
+	}
+	if _, err := overlayFromRawYAML(pol.Guardrails); err == nil {
+		t.Error("expected strict bridge to reject the unknown field 'outptGate'")
+	}
+}
+
+// TestLoadPlatformGuardrailsOverlay_Workspace loads a workspace-layer
+// policy.yaml (via FORGE_PLATFORM_POLICY) carrying a guardrails overlay and
+// checks it merges over an agent config. HOME + FORGE_SYSTEM_POLICY are
+// redirected so the system/user layers don't leak from the host.
+func TestLoadPlatformGuardrailsOverlay_Workspace(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)                                                 // isolate user layer (~/.forge)
+	t.Setenv("FORGE_SYSTEM_POLICY", filepath.Join(dir, "no-system.yaml")) // isolate system layer
+
+	policyPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(`
+guardrails:
+  gateConfig:
+    outputGate: true
+  security:
+    commandInjection:
+      enabled: true
+      confidenceThreshold: 15
+      action: block
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FORGE_PLATFORM_POLICY", policyPath)
+
+	overlay, sources, err := LoadPlatformGuardrailsOverlay()
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if overlay == nil {
+		t.Fatal("expected an overlay from the workspace policy")
+	}
+	if len(sources) != 1 || sources[0] != security.LayerWorkspace {
+		t.Errorf("expected workspace source, got %v", sources)
+	}
+
+	// Agent that is weaker than the overlay: gate off, command injection warn.
+	agent := &models.StructuredGuardrails{
+		GateConfig: &models.GateConfig{OutputGate: false},
+		Security:   &models.SecurityConfig{CommandInjection: thr(true, 50, "warn")},
+	}
+	effective, tt := MergeGuardrails(agent, overlay)
+	if !effective.GateConfig.OutputGate {
+		t.Error("overlay should have forced outputGate on")
+	}
+	if effective.Security.CommandInjection.Action != "block" {
+		t.Error("overlay should have raised commandInjection action to block")
+	}
+	if effective.Security.CommandInjection.ConfidenceThreshold != 15 {
+		t.Error("overlay should have lowered the threshold to 15")
+	}
+	if len(tt) == 0 {
+		t.Error("expected recorded tightenings")
+	}
+}
+
+// TestLoadPlatformGuardrailsOverlay_None returns nil when no layer declares
+// a guardrails overlay.
+func TestLoadPlatformGuardrailsOverlay_None(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("FORGE_SYSTEM_POLICY", filepath.Join(dir, "no-system.yaml"))
+	t.Setenv("FORGE_PLATFORM_POLICY", "") // no workspace policy
+
+	overlay, _, err := LoadPlatformGuardrailsOverlay()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overlay != nil {
+		t.Errorf("expected nil overlay when no layer declares one, got %+v", overlay)
+	}
+}

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -401,10 +401,9 @@ type AuditEvent struct {
 	//
 	// Field names + values match the guardrails library's BasePayload
 	// vocabulary (EntityID, EntityType — "agent" / "workflow" /
-	// "assistant"), so the Forge NDJSON stream and the library's
-	// MongoDB GuardrailAuditEvent collection share columns 1:1 and
-	// can be joined without a translation table. EntityType is
-	// hardcoded to "agent" today since Forge only runs agents;
+	// "assistant") so the Forge NDJSON stream lines up with the
+	// library's own vocabulary without a translation table. EntityType
+	// is hardcoded to "agent" today since Forge only runs agents;
 	// future entity types are an additive value change, not a schema
 	// change.
 	//
@@ -509,10 +508,9 @@ type AuditLogger struct {
 	// Static entity stamp, installed once at agent startup via
 	// WithEntity(). Populated from FORGE_AGENT_ID / cfg.AgentID
 	// in the CLI runner with entityType hardcoded to "agent".
-	// Every emit stamps these so SIEM consumers can join the Forge
-	// NDJSON stream against the guardrails library's MongoDB
-	// GuardrailAuditEvent collection on (entity_id, entity_type)
-	// without translation. See issue #164.
+	// Every emit stamps these so SIEM consumers have a stable
+	// (entity_id, entity_type) identity on each Forge NDJSON event.
+	// See issue #164.
 	tenantEntityID   string
 	tenantEntityType string
 }

--- a/forge-core/security/platform_policy.go
+++ b/forge-core/security/platform_policy.go
@@ -74,6 +74,22 @@ type PlatformPolicy struct {
 	// injection. Not consumed by the runtime in v1; the field is on
 	// the schema so operators write one policy document, not two.
 	DeniedChannels []string `yaml:"denied_channels,omitempty" json:"denied_channels,omitempty"`
+
+	// Guardrails is the platform guardrails OVERLAY (#284) — a
+	// most-restrictive layer merged over the agent's guardrails.json. It
+	// uses the exact same schema as guardrails.json
+	// (guardrails.StructuredGuardrails: pii / security / customRules /
+	// gateConfig / …), authored here in YAML with the same camelCase
+	// field names.
+	//
+	// It is held as a raw subtree (map[string]any) rather than the typed
+	// struct so forge-core stays free of a dependency on the external
+	// guardrails module — forge-cli bridges this YAML subtree into the
+	// typed StructuredGuardrails (YAML → JSON → struct) and applies the
+	// one-way tighten merge. The platform can only tighten (force
+	// detections/gates on, raise actions, lower thresholds, union
+	// rule/denylist/blocked-skill sets); it can never loosen.
+	Guardrails map[string]any `yaml:"guardrails,omitempty" json:"guardrails,omitempty"`
 }
 
 // ModelMatcher identifies one forbidden model. Both fields are
@@ -102,7 +118,8 @@ func (p PlatformPolicy) IsZero() bool {
 		len(p.ForbiddenModels) == 0 &&
 		p.MaxEgressAllowlistSize == 0 &&
 		p.MaxToolCount == 0 &&
-		len(p.DeniedChannels) == 0
+		len(p.DeniedChannels) == 0 &&
+		len(p.Guardrails) == 0
 }
 
 // LoadPlatformPolicy reads + parses a platform policy file from disk.


### PR DESCRIPTION
Closes #284.

## Part 1 — Platform guardrails overlay

Let a platform operator **further restrict** an agent's `guardrails.json` — the same one-way ratchet the capability policy applies to tools/egress/models/channels. The platform can force detections/gates on, raise actions, lower thresholds, and union rule/denylist/blocked-skill sets; it can **never loosen**.

**Authoring (YAML → JSON, per review feedback):** the overlay lives in the platform `policy.yaml` under a `guardrails:` key, using the **same schema** as `guardrails.json` (camelCase `StructuredGuardrails` fields) — just YAML instead of JSON:

```yaml
guardrails:
  gateConfig: { outputGate: true }
  security:
    commandInjection: { enabled: true, confidenceThreshold: 15, action: block }
```

forge-core carries it as a raw `map[string]any` (so it stays free of the guardrails module); forge-cli bridges YAML→JSON→typed `StructuredGuardrails` (**strict**, so operator typos fail loudly) and applies the tighten-only merge.

**Merge semantics** (`MergeGuardrails`, pure + deep-copies, never mutates inputs):

| Field | Rule |
|---|---|
| `gateConfig.*` | boolean OR (force on, never off) |
| detections (pii/security/nsfw/moderation/hallucination) | force-enable; most-severe action (warn<mask<block); lower threshold wins |
| rules / customPatterns / hard-soft constraints | union |
| `urlFilter` | union denylist, intersect allowlist, force-enable |
| `approvalGates` | union |
| `skillConstraints` | union blocked, intersect allowed |

Loaded from all three policy layers (system→user→workspace), folded most-restrictively, applied in `BuildGuardrailChecker` with every tightening logged (field + layer) for audit.

## Part 2 — Remove the unused DB-mode construct

`FORGE_GUARDRAILS_DB` (MongoDB) was never adopted and is the wrong model for platform control (wholesale replacement, not a merge). Removed `NewDBGuardrailEngine`, the DB branch + env vars + fail-loud + exclusivity warning, `forge guardrails validate-db` and its Mongo helpers (kept `seed-defaults`, repurposed to scaffold a `guardrails.json`), and all DB tests.

`go mod tidy` drops `go.mongodb.org/mongo-driver` from forge-cli's **direct** deps — no package imports it now. (It remains an *indirect* graph entry pulled by the guardrails library's own go.mod, so it isn't fully eliminated from the module graph; the issue's "entirely" was optimistic.)

## Design note

`MergeGuardrails` lives in `forge-cli/runtime` (not `forge-core/security` as the issue suggested) because all guardrails code + the `models` import already live there; putting it in forge-core would add a new `forge-core → guardrails` dependency edge for no benefit. forge-core only gains a raw-subtree `Guardrails` field on `PlatformPolicy`.

## Tests
- Merge ratchet per field + **never-loosen invariant** + input-not-mutated.
- YAML→struct bridge; strict unknown-field rejection; end-to-end workspace-layer overlay load; overlay applied in `BuildGuardrailChecker`.
- Build/vet/test/lint green across forge-core/security + forge-cli runtime + cmd.

## Docs
Rewrote `docs/security/guardrails.md`: removed the DB-mode / fail-loud / validate-db sections and the two-mode framing; documented the platform overlay + merge semantics.