### PR TITLE
feat(audit): hybrid cadence for audit_export_status heartbeat

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -36,7 +36,7 @@ repo.
 15. [How to create an agent](#15-how-to-create-an-agent)
 16. [How to create a skill](#16-how-to-create-a-skill)
 17. [Audit event reference](#17-audit-event-reference)
-18. [Workstream recap — FWS-1 through FWS-10](#18-workstream-recap--fws-1-through-fws-10)
+18. [Workstream recap — FWS-1 through FWS-10 + OTel v1](#18-workstream-recap--fws-1-through-fws-10--otel-v1)
 19. [Docs map](#19-docs-map)
 20. [Recipes — common questions](#20-recipes--common-questions)
 
@@ -639,7 +639,7 @@ intentionally have no `seq`.
 |---|---|---|
 | stderr (NDJSON) | yes | The safety net — container log collectors capture it by default |
 | Unix Domain Socket | when `--audit-socket` / `FORGE_AUDIT_SOCKET` | Lazy reconnect, 50ms per-write timeout, exponential backoff 100ms → 5s cap, drop on timeout |
-| Localhost HTTP | when `--audit-http-endpoint` / `FORGE_AUDIT_HTTP_ENDPOINT` (socket wins when both set) | Same fire-and-forget discipline |
+| Localhost HTTP | when `--audit-http-endpoint` / `FORGE_AUDIT_HTTP_ENDPOINT` (socket wins when both set) | Same fire-and-forget discipline; `connected` is a live level (1 on 2xx, 0 on any failure) so the #280 flip edge fires for it too |
 
 Events are byte-identical across sinks. An `audit_export_status` event
 carries per-sink `writes_ok` / `drops_timeout` / `drops_dial` /
@@ -1167,7 +1167,7 @@ Every event also carries `schema_version: "1.0"` (FWS-8) and `seq`
 | **FWS-4** | #88 | Cancellation signal handling — `tasks/cancel` actually cancels via `context.CancelCauseFunc`; `invocation_cancelled` audit event with classified reason + partial token counts | `docs/security/audit-logging.md` § Cancellation |
 | **FWS-5** | #89 | Platform policy enforcement at runtime — workspace-level deploy-time bounds (egress / tools / models / sizes); `forge package` policy-ready manifests | `docs/security/platform-policy.md` |
 | **FWS-6** | #90 | Three-layer platform policy + channel scope — system / user / workspace layers compose by union + most-restrictive; `denied_channels` first-class; `forge channel disable/enable` edits the user layer | `docs/security/platform-policy.md` |
-| **FWS-7** | #95 | Audit event export capability — Unix Domain Socket sink + HTTP localhost fallback; fire-and-forget; `audit_export_status` periodic per-sink health | `docs/security/audit-logging.md` § Audit Event Export |
+| **FWS-7** | #95 | Audit event export capability — Unix Domain Socket sink + HTTP localhost fallback; fire-and-forget; `audit_export_status` hybrid-cadence per-sink health (#280) | `docs/security/audit-logging.md` § Audit Event Export |
 | **FWS-8** | #91 | Hardened audit emission — `schema_version` + monotonic `seq` per invocation; default metadata-only invariant pinned by regression test; opt-in `AuditPayloadCapture` with per-field byte caps. Follow-ups: #173 (PR closed the seq gap on `tool_exec` / `session_end` — 3 sites switched from plain `Emit` to `EmitFromContext`) and #174 (PR moved the `SequenceCounter` installation upstream of the auth middleware via a wrapper + `EnsureSequenceCounter` so `auth_verify` / `auth_fail` land seq=1). #175 tracks a follow-up lint to catch future `Emit`-instead-of-`EmitFromContext` drift. | `docs/security/audit-logging.md` § Schema contract / § Sequence numbers |
 | **FWS-9** | #100 | Ops logger output stream separation — stdout for `JSONLogger`, stderr stays for audit NDJSON | `docs/security/audit-logging.md` § Streams |
 | **FWS-10** | #110 | Rate-limit configurability + orchestration-friendly defaults + cancel exemption — `server.rate_limit:` yaml block + CLI flags + env; `tasks/cancel` exempt from the write bucket by default | `docs/reference/forge-yaml-schema.md` § `server.rate_limit` |

--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -168,8 +168,10 @@ The path of a single A2A invocation:
 
 The runner also installs `agent_card_published` (startup + hot-reload,
 FWS-1), `policy_loaded` per non-empty layer (FWS-5/6),
-`audit_export_status` every 60s when an export sink is configured
-(FWS-7).
+`audit_export_status` on a hybrid cadence when an export sink is
+configured — immediately on a sink `connected` flip, else a slow
+keepalive (15m default, `AUDIT_STATUS_KEEPALIVE_INTERVAL`) (FWS-7,
+#280).
 
 **Read**: `docs/core-concepts/runtime-engine.md`,
 `docs/core-concepts/hooks.md`, `forge-cli/runtime/runner.go`.
@@ -639,10 +641,16 @@ intentionally have no `seq`.
 | Unix Domain Socket | when `--audit-socket` / `FORGE_AUDIT_SOCKET` | Lazy reconnect, 50ms per-write timeout, exponential backoff 100ms → 5s cap, drop on timeout |
 | Localhost HTTP | when `--audit-http-endpoint` / `FORGE_AUDIT_HTTP_ENDPOINT` (socket wins when both set) | Same fire-and-forget discipline |
 
-Events are byte-identical across sinks. A periodic
-`audit_export_status` event (every 60s) carries per-sink
-`writes_ok` / `drops_timeout` / `drops_dial` / `connected` so
-operators tail the audit stream itself to confirm export health.
+Events are byte-identical across sinks. An `audit_export_status` event
+carries per-sink `writes_ok` / `drops_timeout` / `drops_dial` /
+`connected` so operators tail the audit stream itself to confirm export
+health. It fires on a **hybrid cadence** (#280): immediately when a
+sink's `connected` flag flips, else a slow keepalive (15m default,
+`AUDIT_STATUS_KEEPALIVE_INTERVAL`, read at startup). The edge is the
+`connected` level, not the cumulative `drops_*` counters — the status
+event's own write to a failing sink bumps those counters, so diffing
+them would self-amplify one emit per poll for the whole outage. Every
+emit carries `fields.reason` (`state_change` | `keepalive`).
 
 **Streams** (FWS-9):
 
@@ -1128,7 +1136,7 @@ when OTel tracing is enabled (OTel v1 / Phase 4 / #105). Both use
 | `AuditPolicyLoaded` | `policy_loaded` | One per non-empty policy layer at startup; `layer`, `source`, per-list size counters (FWS-5/6) |
 | `AuditPolicyViolationAtBuildTime` | `policy_violation_at_build_time` | `violation_kind`, `offending_value`, `forge_yaml_field`, `layer`, `source` (FWS-5/6) |
 | `AuditChannelDeniedByPolicy` | `channel_denied_by_policy` | `channel`, `layer`, `source` (FWS-6) |
-| `audit_export_status` | `audit_export_status` | Every 60s when an export sink is configured; per-sink `writes_ok`, `drops_timeout`, `drops_dial`, `connected` (FWS-7) |
+| `audit_export_status` | `audit_export_status` | Hybrid cadence when an export sink is configured — immediately on a sink `connected` flip, else a slow keepalive (15m default, `AUDIT_STATUS_KEEPALIVE_INTERVAL`); `fields.reason` (`state_change` \| `keepalive`) + per-sink `writes_ok`, `drops_timeout`, `drops_dial`, `connected` (FWS-7, #280) |
 | `AuditIntentAlignment` | `intent_alignment` | R3 (#208) — per `BeforeToolExec` when `security.intent_alignment` enabled; `tool`, `decision` (`allow` / `warn` / `deny`), `score` (cosine ∈ [-1,1] or the string `"NaN"` on fail-closed), `reason`. Never carries the LLM prompt or tool args. |
 | `AuditIntentDrift` | `intent_drift` | R7 (#214) — state transitions of the rolling-window drift analyzer; `tool`, `severity` (`mean_below_threshold` / `monotone_decrease` / `both` / `recovered`), `transition` (`entered` / `recovered`), `mean`, `window`. One per transition — no per-call flood. |
 | `AuditAuthStepUpRequired` | `auth_step_up_required` | R4b (#210) — caller identity missing / carrying weaker `acr` than the tool requires; `tool`, `required_acr`, `presented_acr`, `reason`. REST handler translates into HTTP 401 with RFC 9470 `WWW-Authenticate: Bearer error="step_up_required", acr_values="…"`. |

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -398,7 +398,7 @@ visible from t=0.
 | `writes_ok` | Events successfully delivered to this sink |
 | `drops_timeout` | Events dropped because the per-event Write missed its deadline (slow / unresponsive peer) |
 | `drops_dial` | Events dropped because the connection was down (sidecar offline or in backoff window) |
-| `connected` | `1` when a working connection is held, `0` otherwise. Sticky `0` for fire-and-forget sinks (writerSink) |
+| `connected` | Live health level: `1` when the last write succeeded, `0` after any failure. Both network sinks maintain it — the UDS sink clears it on dial/timeout/write error, and the HTTP sink clears it on request-build / transport / timeout / non-2xx (#280) — which is what the hybrid cadence's `connected`-flip edge relies on. Sticky `0` for fire-and-forget sinks (writerSink), which never hold a connection |
 
 ### Why a separate path from OTel
 

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -32,7 +32,7 @@ All runtime security events are emitted as structured NDJSON to stderr with corr
 | `policy_loaded` | One per non-empty policy layer at startup (system / user / workspace). Carries `fields.layer`, `source` (file path), deny-list size counts, and max bounds. See [Platform Policy](platform-policy.md). |
 | `policy_violation_at_build_time` | One per violation when `forge.yaml` conflicts with any policy layer. Agent refuses to start. Carries `fields.violation_kind` / `offending_value` / `forge_yaml_field` plus `layer` + `source` identifying the enforcing file. See [Platform Policy](platform-policy.md). |
 | `channel_denied_by_policy` | One per channel adapter skipped at startup because a policy layer's `denied_channels` list names it. Non-fatal; the agent runs with the remaining channels. Carries `fields.channel`, `layer` (`system` / `user` / `workspace`), and `source` (file path). See [Platform Policy — Channels](platform-policy.md#channels). |
-| `audit_export_status` | One event every 60s when an export sink is configured. Carries `fields.sinks[]`, one entry per registered sink with `name`, `writes_ok`, `drops_timeout`, `drops_dial`, `connected`. Operators tail the audit stream to confirm export health. See [Audit Event Export (FWS-7)](#audit-event-export-fws-7). |
+| `audit_export_status` | Per-sink export-health heartbeat, emitted on a **hybrid** cadence (#280): immediately when a sink's `connected` flag flips and otherwise as a slow keepalive (15 min by default, `AUDIT_STATUS_KEEPALIVE_INTERVAL` overrides, read at startup). Carries `fields.reason` (`state_change` \| `keepalive`) and `fields.sinks[]`, one entry per sink with `name`, `writes_ok`, `drops_timeout`, `drops_dial`, `connected`. The `drops_*` counters ride in the payload but deliberately don't drive the edge (they self-amplify during an outage — see [Sink health](#sink-health-audit_export_status)). Operators tail the stream to confirm export health; a missing keepalive past the interval is itself alertable. See [Audit Event Export (FWS-7)](#audit-event-export-fws-7). |
 | `intent_alignment` | Emitted per `BeforeToolExec` when `security.intent_alignment` is enabled (R3 / #208). Carries `fields.tool`, `fields.decision` (`allow` / `warn` / `deny`), `fields.score` (cosine similarity ∈ [-1,1] as a float, or the string `"NaN"` on fail-closed paths), and `fields.reason`. Payload never carries the LLM prompt or tool args — only the scored decision. See [Intent Alignment](intent-alignment.md). |
 | `intent_drift` | Emitted on state transitions of the R7 rolling-window drift analyzer (R7 / #214). Carries `fields.tool`, `fields.severity` (`mean_below_threshold` / `monotone_decrease` / `both` / `recovered`), `fields.transition` (`entered` / `recovered`), `fields.mean` (rolling window mean at trip time), and `fields.window` (configured window size). One event on entry, one on recovery — never per-call flooded across a long drift stretch. See [Intent Alignment — Drift tracking](intent-alignment.md). |
 | `auth_step_up_required` | Emitted when the R4b step-up hook refuses a tool call because the caller's identity lacks the required `acr` claim (R4b / #210). Carries `fields.tool`, `fields.required_acr`, `fields.presented_acr` (empty when no acr was presented), `fields.reason`. The REST handler translates this into HTTP 401 with an RFC 9470 `WWW-Authenticate: Bearer error="step_up_required", acr_values="<value>"` challenge. See [Step-up Authorization](step-up-auth.md). |
@@ -345,15 +345,46 @@ wins.
 
 ### Sink health: `audit_export_status`
 
-Every 60 seconds the runtime emits one `audit_export_status` event
-carrying per-sink counters. The event flows through the same fan-out
-so operators tail the audit stream itself to confirm export health.
+The runtime emits `audit_export_status` events carrying per-sink
+counters. The event flows through the same fan-out so operators tail
+the audit stream itself to confirm export health.
+
+**Hybrid cadence (#280).** Emitting once a minute produced ~1,440
+near-identical "still fine" rows per agent per day, which dominated the
+audit collection at fleet scale. The runtime instead:
+
+- polls sink health frequently (`AuditExportStatusPollInterval`, 15s) and
+  emits **immediately** when a sink's `connected` flag flips (a dial
+  failure holds it at 0; a write timeout disconnects the sink, so both
+  failure modes read 0 on the next poll) — so a failure surfaces within
+  one poll interval; and
+- otherwise emits a slow **keepalive** so liveness stays provable. The
+  keepalive interval defaults to 15 minutes and is overridable via the
+  `AUDIT_STATUS_KEEPALIVE_INTERVAL` env var (a Go duration, e.g. `"5m"`,
+  `"1h"`), read once at process start — a deploy-time knob, not
+  live-tunable. A missing keepalive past the interval is itself alertable.
+
+The edge signal is `connected` — a **level** the sink maintains — and
+deliberately **not** the cumulative `drops_*` counters: the status event
+flows through every sink including a failing one, so its own write bumps
+that sink's drop counter, and on an idle agent the status emits are the
+only writes. Diffing drops would therefore self-amplify — one emit per
+poll for the whole outage. The `drops_*` counters still ride in every
+event's `sinks[]` payload for anyone tracking totals; they just don't
+drive the edge.
+
+Steady-state volume drops from ~1,440/day to a handful. Every event
+carries `fields.reason` — `state_change` (a `connected` flip) or
+`keepalive` (still alive) — so consumers can distinguish the two. A
+keepalive baseline is emitted at startup so a healthy pipeline is
+visible from t=0.
 
 ```json
 {
   "ts": "2026-06-06T18:30:00Z",
   "event": "audit_export_status",
   "fields": {
+    "reason": "state_change",
     "sinks": [
       {"name": "stderr",      "writes_ok": 4137, "drops_timeout": 0, "drops_dial": 0, "connected": 0},
       {"name": "unix-socket", "writes_ok": 4135, "drops_timeout": 0, "drops_dial": 2, "connected": 1}

--- a/forge-core/runtime/audit_export_integration_test.go
+++ b/forge-core/runtime/audit_export_integration_test.go
@@ -84,7 +84,7 @@ func TestAuditExport_EndToEnd(t *testing.T) {
 		Model: "gpt-4o", Provider: "openai", Duration: 250 * time.Millisecond,
 		Usage: LLMUsage{InputTokens: 120, OutputTokens: 45},
 	})
-	emitAuditExportStatus(logger)
+	emitAuditExportStatus(logger, auditStatusReasonKeepalive)
 
 	// Receive on the UDS side and assert per-event parity with the
 	// stderr-side capture.

--- a/forge-core/runtime/audit_export_status.go
+++ b/forge-core/runtime/audit_export_status.go
@@ -2,53 +2,112 @@ package runtime
 
 import (
 	"context"
+	"os"
 	"time"
 )
 
-// AuditExportStatusInterval is how often StartAuditExportStatus emits
-// an audit_export_status event. The issue calls for 60s; exposed as a
-// package var so tests can shorten it.
-var AuditExportStatusInterval = 60 * time.Second
+// Audit-export status heartbeat cadence (issue #280). The event proves the
+// audit pipeline is alive and reports per-sink health. Emitting it once a
+// minute produced ~1,440 rows/agent/day of near-constant "still fine" noise
+// that dominated the audit collection at fleet scale. The hybrid below keeps
+// the integrity signal while collapsing steady-state volume to a handful/day:
+//
+//   - poll sink health frequently and emit IMMEDIATELY on a state change
+//     (a sink's `connected` flag flips, or a sink is added/removed), so a
+//     failure surfaces within one poll interval;
+//   - otherwise emit a keepalive on a slow interval, so liveness stays
+//     provable (a missing keepalive past the interval is itself alertable).
+//
+// The edge signal is `connected` — a LEVEL the sink maintains — and NOT the
+// cumulative `drops_*` counters. This is deliberate and load-bearing: the
+// status event itself flows through every sink, including a failing one, so
+// its own write bumps that sink's drop counter. On an idle agent the status
+// emits are the *only* writes, so a drop-delta edge would be self-referential
+// — every poll would see "drops increased since last time" and emit again,
+// one event per poll for the whole outage (4× the old fixed cadence, and
+// worst precisely during an incident). `connected` has no such feedback: a
+// dial failure holds it at 0 and a write timeout disconnects the sink (so it
+// also reads 0 on the next poll), so both failure modes converge on a single
+// 1→0 transition that settles until recovery flips it back. Drop counters
+// still ride in every emit's `sinks[]` payload for anyone tracking totals;
+// they just don't drive the edge.
+//
+// Every emit carries fields.reason ("state_change" | "keepalive") so
+// consumers can distinguish "something changed" from "still alive".
+var (
+	// AuditExportStatusPollInterval is how often sink health is checked for a
+	// state change. This is the failure-detection latency. Package var so
+	// tests can shorten it.
+	AuditExportStatusPollInterval = 15 * time.Second
 
-// AuditExportStatus is the event type for the periodic per-sink health
-// report. Single event per tick; carries one entry in fields.sinks per
-// registered sink with that sink's counters (writes_ok, drops_timeout,
-// drops_dial, connected).
+	// AuditExportStatusKeepaliveInterval is the maximum time between emitted
+	// status events when nothing changes. Overridable at process startup via
+	// the AUDIT_STATUS_KEEPALIVE_INTERVAL env var (a Go duration, e.g. "15m",
+	// "1h"); it is read once when the heartbeat starts, so a change takes a
+	// restart — there is no live reload. Package var so tests can shorten it.
+	AuditExportStatusKeepaliveInterval = 15 * time.Minute
+)
+
+// EnvAuditStatusKeepaliveInterval overrides AuditExportStatusKeepaliveInterval
+// when set to a valid Go duration. Read once at startup (deploy-time knob, not
+// live-tunable).
+const EnvAuditStatusKeepaliveInterval = "AUDIT_STATUS_KEEPALIVE_INTERVAL"
+
+// AuditExportStatus is the event type for the per-sink health report.
 const AuditExportStatus = "audit_export_status"
 
-// StartAuditExportStatus spawns a background goroutine that emits one
-// audit_export_status event every AuditExportStatusInterval until the
-// returned stop function is called or ctx is cancelled. The goroutine
-// uses the same AuditLogger it reports on — the status event itself
-// flows through every sink, including the export ones, so operators
-// can see "is my export healthy?" by inspecting the export stream.
+// Emit reasons (fields.reason).
+const (
+	auditStatusReasonKeepalive   = "keepalive"
+	auditStatusReasonStateChange = "state_change"
+)
+
+// StartAuditExportStatus spawns a background goroutine that emits
+// audit_export_status events using the hybrid cadence described above, until
+// the returned stop function is called or ctx is cancelled. The goroutine
+// uses the same AuditLogger it reports on — the status event flows through
+// every sink (including the export ones) so operators can see "is my export
+// healthy?" by inspecting the export stream.
 //
-// Returns a stop func the caller invokes during shutdown. The stop
-// func blocks until the goroutine exits so shutdown ordering is
-// deterministic (no chance of a final status event landing after the
-// runtime has torn down its writers).
+// An initial keepalive is emitted at startup so liveness is provable from
+// t=0. The stop func blocks until the goroutine exits (deterministic shutdown
+// ordering) and is idempotent.
 //
-// Idempotent: calling stop twice is safe.
-//
-// See issue #95 / FWS-7 acceptance criterion §6.
+// See issue #95 / FWS-7 §6 (original) and issue #280 (hybrid cadence).
 func StartAuditExportStatus(ctx context.Context, audit *AuditLogger) (stop func()) {
 	if audit == nil {
 		return func() {}
 	}
+	keepalive := resolveKeepaliveInterval()
 	done := make(chan struct{})
 	stopCh := make(chan struct{})
 	go func() {
 		defer close(done)
-		t := time.NewTicker(AuditExportStatusInterval)
-		defer t.Stop()
+
+		// Baseline emit so a healthy pipeline is visible immediately, and a
+		// reference snapshot to diff subsequent polls against.
+		last := sinkStateSnapshot(audit)
+		emitAuditExportStatus(audit, auditStatusReasonKeepalive)
+		lastEmit := time.Now()
+
+		poll := time.NewTicker(AuditExportStatusPollInterval)
+		defer poll.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-stopCh:
 				return
-			case <-t.C:
-				emitAuditExportStatus(audit)
+			case <-poll.C:
+				cur := sinkStateSnapshot(audit)
+				switch {
+				case sinkStateChanged(last, cur):
+					emitAuditExportStatus(audit, auditStatusReasonStateChange)
+					last, lastEmit = cur, time.Now()
+				case time.Since(lastEmit) >= keepalive:
+					emitAuditExportStatus(audit, auditStatusReasonKeepalive)
+					last, lastEmit = cur, time.Now()
+				}
 			}
 		}
 	}()
@@ -63,16 +122,66 @@ func StartAuditExportStatus(ctx context.Context, audit *AuditLogger) (stop func(
 	}
 }
 
-// emitAuditExportStatus snapshots every registered sink's stats and
-// emits a single status event. Sinks are reported in registration
-// order so the stderr safety-net always lands at sinks[0] — operators
-// reading the event have a consistent shape.
+// resolveKeepaliveInterval reads AUDIT_STATUS_KEEPALIVE_INTERVAL when set to a
+// positive Go duration; otherwise returns AuditExportStatusKeepaliveInterval.
+func resolveKeepaliveInterval() time.Duration {
+	if v := os.Getenv(EnvAuditStatusKeepaliveInterval); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return AuditExportStatusKeepaliveInterval
+}
+
+// sinkState is the edge-trigger-relevant health of a sink: whether it
+// currently holds a working connection. The cumulative `drops_*` counters are
+// deliberately EXCLUDED (see the package comment and sinkStateChanged) — they
+// increment on the status event's own writes, so diffing them would make the
+// signal self-referential and re-fire every poll during an outage.
+type sinkState struct {
+	connected int64
+}
+
+// sinkStateSnapshot captures the health-relevant state for every sink, keyed
+// by sink name.
+func sinkStateSnapshot(audit *AuditLogger) map[string]sinkState {
+	sinks := audit.Sinks()
+	out := make(map[string]sinkState, len(sinks))
+	for _, s := range sinks {
+		out[s.Name()] = sinkState{connected: s.Stats()["connected"]}
+	}
+	return out
+}
+
+// sinkStateChanged reports whether any sink's health changed between two
+// snapshots: a `connected` flip (either direction — 1→0 is failure, 0→1 is
+// recovery) or a sink added/removed. Drop counters are intentionally not part
+// of the diff (see the package comment).
+func sinkStateChanged(prev, cur map[string]sinkState) bool {
+	if len(prev) != len(cur) {
+		return true
+	}
+	for name, c := range cur {
+		p, ok := prev[name]
+		if !ok || p.connected != c.connected {
+			return true
+		}
+	}
+	return false
+}
+
+// emitAuditExportStatus snapshots every registered sink's full stats and
+// emits a single status event tagged with the given reason. Sinks are
+// reported in registration order so the stderr safety-net always lands at
+// sinks[0] — operators reading the event have a consistent shape. The full
+// stats (including the cumulative drop counters) ride in the payload even
+// though only `connected` drives the edge, so anyone tracking totals still
+// sees them on every emit.
 //
-// The event flows through the AuditLogger like any other, so the
-// status itself reaches every sink. There's no risk of a feedback
-// loop: the status event doesn't trigger sink-write callbacks; it's
-// just bytes on the wire.
-func emitAuditExportStatus(audit *AuditLogger) {
+// The event flows through the AuditLogger like any other; there's no feedback
+// loop that triggers another status emit (a sink write does not call back into
+// this — it's just bytes on the wire).
+func emitAuditExportStatus(audit *AuditLogger, reason string) {
 	sinks := audit.Sinks()
 	report := make([]map[string]any, 0, len(sinks))
 	for _, s := range sinks {
@@ -84,6 +193,6 @@ func emitAuditExportStatus(audit *AuditLogger) {
 	}
 	audit.Emit(AuditEvent{
 		Event:  AuditExportStatus,
-		Fields: map[string]any{"sinks": report},
+		Fields: map[string]any{"reason": reason, "sinks": report},
 	})
 }

--- a/forge-core/runtime/audit_sink_http.go
+++ b/forge-core/runtime/audit_sink_http.go
@@ -68,6 +68,14 @@ func (s *httpSink) Stats() map[string]int64 { return s.stats.snapshot() }
 // dial-class drop (the receiver rejected it; we won't queue). Network
 // timeouts count as timeout drops. Like socketSink, returns nil in
 // every transient case so the fan-out loop continues.
+//
+// `connected` tracks live health as a level: a 2xx sets it to 1, and
+// EVERY failure path (request build / transport error / timeout /
+// non-2xx) stores 0. This mirrors socketSink's dropConnLocked() so the
+// audit_export_status heartbeat's connected-flip edge (#280) fires on an
+// HTTP endpoint outage too — without this, a failure after any prior
+// success would leave `connected` stuck at 1 and stay invisible until
+// the next keepalive.
 func (s *httpSink) Write(ctx context.Context, eventBytes []byte) error {
 	s.mu.Lock()
 	if s.closed {
@@ -82,6 +90,7 @@ func (s *httpSink) Write(ctx context.Context, eventBytes []byte) error {
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, s.endpoint, bytes.NewReader(eventBytes))
 	if err != nil {
 		s.stats.dropsDial.Add(1)
+		s.stats.connected.Store(0)
 		return nil
 	}
 	req.Header.Set("Content-Type", "application/x-ndjson")
@@ -93,6 +102,7 @@ func (s *httpSink) Write(ctx context.Context, eventBytes []byte) error {
 		} else {
 			s.stats.dropsDial.Add(1)
 		}
+		s.stats.connected.Store(0)
 		return nil
 	}
 	// Drain + close so the connection can be re-used by the transport.
@@ -101,6 +111,7 @@ func (s *httpSink) Write(ctx context.Context, eventBytes []byte) error {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		s.stats.dropsDial.Add(1)
+		s.stats.connected.Store(0)
 		return nil
 	}
 	s.stats.writesOK.Add(1)

--- a/forge-core/runtime/audit_sink_test.go
+++ b/forge-core/runtime/audit_sink_test.go
@@ -469,38 +469,199 @@ func TestNewAuditLoggerFromConfig_EmptyIsStderrOnly(t *testing.T) {
 
 // audit_export_status fires on every tick; one event per registered
 // sink in the fields.sinks array.
-func TestStartAuditExportStatus_EmitsPerSinkReport(t *testing.T) {
-	prev := AuditExportStatusInterval
-	AuditExportStatusInterval = 25 * time.Millisecond
-	defer func() { AuditExportStatusInterval = prev }()
-
-	var buf bytes.Buffer
-	logger := &AuditLogger{
-		sinks:   []Sink{newWriterSink(&buf, "buf-status")},
-		logOnce: map[string]bool{},
-	}
-	stop := StartAuditExportStatus(context.Background(), logger)
-	time.Sleep(80 * time.Millisecond) // expect 2-3 ticks
-	stop()
-
-	// Parse all lines; find the status events.
-	dec := json.NewDecoder(strings.NewReader(buf.String()))
-	var found int
+// collectStatusEvents drains a buffer of NDJSON and returns the
+// audit_export_status events.
+func collectStatusEvents(t *testing.T, s string) []AuditEvent {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(s))
+	var out []AuditEvent
 	for dec.More() {
 		var evt AuditEvent
 		if err := dec.Decode(&evt); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
 		if evt.Event == AuditExportStatus {
-			found++
-			sinks, ok := evt.Fields["sinks"].([]any)
-			if !ok || len(sinks) != 1 {
-				t.Errorf("status event fields.sinks = %v", evt.Fields["sinks"])
-			}
+			out = append(out, evt)
 		}
 	}
-	if found < 2 {
-		t.Errorf("got %d audit_export_status events, want >= 2", found)
+	return out
+}
+
+// TestStartAuditExportStatus_EmitsPerSinkReport pins the baseline shape: an
+// initial keepalive is emitted at startup carrying one sinks[] entry per sink
+// with a reason tag (#280).
+func TestStartAuditExportStatus_EmitsPerSinkReport(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &AuditLogger{
+		sinks:   []Sink{newWriterSink(&buf, "buf-status")},
+		logOnce: map[string]bool{},
+	}
+	stop := StartAuditExportStatus(context.Background(), logger)
+	time.Sleep(30 * time.Millisecond) // enough for the startup emit
+	stop()
+
+	evts := collectStatusEvents(t, buf.String())
+	if len(evts) < 1 {
+		t.Fatalf("expected at least the startup keepalive, got %d", len(evts))
+	}
+	e := evts[0]
+	if e.Fields["reason"] != auditStatusReasonKeepalive {
+		t.Errorf("startup emit reason = %v, want keepalive", e.Fields["reason"])
+	}
+	sinks, ok := e.Fields["sinks"].([]any)
+	if !ok || len(sinks) != 1 {
+		t.Errorf("status event fields.sinks = %v", e.Fields["sinks"])
+	}
+}
+
+// TestStartAuditExportStatus_SlowKeepalive pins the #280 volume fix: with a
+// healthy (unchanging) sink, a LONG keepalive means only the startup emit
+// appears — no per-poll heartbeat spam.
+func TestStartAuditExportStatus_SlowKeepalive(t *testing.T) {
+	prevPoll := AuditExportStatusPollInterval
+	prevKA := AuditExportStatusKeepaliveInterval
+	AuditExportStatusPollInterval = 5 * time.Millisecond
+	AuditExportStatusKeepaliveInterval = time.Hour // effectively never in this test
+	defer func() {
+		AuditExportStatusPollInterval = prevPoll
+		AuditExportStatusKeepaliveInterval = prevKA
+	}()
+
+	var buf bytes.Buffer
+	logger := &AuditLogger{sinks: []Sink{newWriterSink(&buf, "buf-status")}, logOnce: map[string]bool{}}
+	stop := StartAuditExportStatus(context.Background(), logger)
+	time.Sleep(60 * time.Millisecond) // ~12 polls, no state change
+	stop()
+
+	if n := len(collectStatusEvents(t, buf.String())); n != 1 {
+		t.Errorf("healthy steady state should emit only the startup keepalive; got %d events", n)
+	}
+}
+
+// TestStartAuditExportStatus_EmitsOnConnectedFlip pins the integrity half: a
+// sink whose `connected` flag flips triggers an immediate state_change emit
+// even under a long keepalive. `connected` is the edge signal (#280 review) —
+// both a 1→0 failure and a 0→1 recovery must fire.
+func TestStartAuditExportStatus_EmitsOnConnectedFlip(t *testing.T) {
+	prevPoll := AuditExportStatusPollInterval
+	prevKA := AuditExportStatusKeepaliveInterval
+	AuditExportStatusPollInterval = 5 * time.Millisecond
+	AuditExportStatusKeepaliveInterval = time.Hour
+	defer func() {
+		AuditExportStatusPollInterval = prevPoll
+		AuditExportStatusKeepaliveInterval = prevKA
+	}()
+
+	var buf bytes.Buffer
+	sink := newFakeStatSink("flaky") // starts connected
+	// The fakeStatSink drives the state change; a writer sink captures the
+	// emitted status events into buf (fakeStatSink discards writes).
+	logger := &AuditLogger{sinks: []Sink{sink, newWriterSink(&buf, "buf")}, logOnce: map[string]bool{}}
+	stop := StartAuditExportStatus(context.Background(), logger)
+	time.Sleep(20 * time.Millisecond) // startup emit + a few clean polls
+	sink.setConnected(0)              // fail: 1 -> 0
+	time.Sleep(20 * time.Millisecond) // a poll observes the failure
+	sink.setConnected(1)              // recover: 0 -> 1
+	time.Sleep(20 * time.Millisecond) // a poll observes the recovery
+	stop()
+
+	reasons := statusReasons(collectStatusEvents(t, buf.String()))
+	var stateChanges int
+	for _, r := range reasons {
+		if r == auditStatusReasonStateChange {
+			stateChanges++
+		}
+	}
+	if stateChanges < 2 {
+		t.Errorf("both the 1->0 failure and 0->1 recovery must emit state_change; got %d in %v", stateChanges, reasons)
+	}
+}
+
+// TestStartAuditExportStatus_PersistentOutageDoesNotAmplify is the #280-review
+// regression guard: during a SUSTAINED outage the status event must not
+// self-amplify. Because every emit writes to the failing sink (bumping its
+// drop counter), a drop-delta edge would re-fire every poll — one event per
+// poll for the whole outage. With `connected` as the edge, a down sink settles
+// after a single 1→0 transition, so the emit count stays bounded no matter how
+// many poll windows elapse.
+func TestStartAuditExportStatus_PersistentOutageDoesNotAmplify(t *testing.T) {
+	prevPoll := AuditExportStatusPollInterval
+	prevKA := AuditExportStatusKeepaliveInterval
+	AuditExportStatusPollInterval = 2 * time.Millisecond
+	AuditExportStatusKeepaliveInterval = time.Hour
+	defer func() {
+		AuditExportStatusPollInterval = prevPoll
+		AuditExportStatusKeepaliveInterval = prevKA
+	}()
+
+	var buf bytes.Buffer
+	sink := newFakeStatSink("down")
+	sink.downOnWrite = true // first write drops the connection; every write bumps drops
+	logger := &AuditLogger{sinks: []Sink{sink, newWriterSink(&buf, "buf")}, logOnce: map[string]bool{}}
+	stop := StartAuditExportStatus(context.Background(), logger)
+	time.Sleep(80 * time.Millisecond) // ~40 poll windows of continuous dropping
+	stop()
+
+	// A drop-delta edge would emit ~40 times here; `connected` gives exactly
+	// the startup keepalive + one 1→0 state_change. Bound generously to stay
+	// robust against scheduler jitter while still catching amplification.
+	evts := collectStatusEvents(t, buf.String())
+	if len(evts) > 3 {
+		t.Errorf("sustained outage self-amplified: %d status events across ~40 polls (reasons %v)", len(evts), statusReasons(evts))
+	}
+	var stateChanges int
+	for _, e := range evts {
+		if e.Fields["reason"] == auditStatusReasonStateChange {
+			stateChanges++
+		}
+	}
+	if stateChanges != 1 {
+		t.Errorf("a settled outage must produce exactly one state_change; got %d in %v", stateChanges, statusReasons(evts))
+	}
+}
+
+func statusReasons(evts []AuditEvent) []any {
+	out := make([]any, 0, len(evts))
+	for _, e := range evts {
+		out = append(out, e.Fields["reason"])
+	}
+	return out
+}
+
+// fakeStatSink is a Sink whose health we can mutate to simulate transitions.
+// Writes are discarded. `connected` starts at 1 (use newFakeStatSink); tests
+// flip it via setConnected. When downOnWrite is set, every write drops the
+// connection and bumps the drop counter — this reproduces the outage
+// self-feed the status heartbeat must not amplify (#280 review).
+type fakeStatSink struct {
+	name        string
+	connected   atomic.Int64
+	drops       atomic.Int64
+	downOnWrite bool
+}
+
+func newFakeStatSink(name string) *fakeStatSink {
+	f := &fakeStatSink{name: name}
+	f.connected.Store(1)
+	return f
+}
+
+func (f *fakeStatSink) Name() string { return f.name }
+func (f *fakeStatSink) Write(context.Context, []byte) error {
+	if f.downOnWrite {
+		f.connected.Store(0)
+		f.drops.Add(1)
+	}
+	return nil
+}
+func (f *fakeStatSink) Close(context.Context) error { return nil }
+func (f *fakeStatSink) setConnected(v int64)        { f.connected.Store(v) }
+func (f *fakeStatSink) Stats() map[string]int64 {
+	return map[string]int64{
+		"connected":     f.connected.Load(),
+		"drops_dial":    f.drops.Load(),
+		"drops_timeout": 0,
+		"writes_ok":     0,
 	}
 }
 
@@ -508,3 +669,20 @@ func TestStartAuditExportStatus_EmitsPerSinkReport(t *testing.T) {
 // "windows". Uses the gort alias so this file can sit in package
 // runtime without name collisions. UDS tests skip on Windows.
 func runtimeGOOS_isWindows() bool { return gort.GOOS == "windows" }
+
+// TestResolveKeepaliveInterval_EnvOverride pins the AUDIT_STATUS_KEEPALIVE_INTERVAL
+// override and the fall-back-on-garbage behavior (#280).
+func TestResolveKeepaliveInterval_EnvOverride(t *testing.T) {
+	prev := AuditExportStatusKeepaliveInterval
+	AuditExportStatusKeepaliveInterval = 15 * time.Minute
+	defer func() { AuditExportStatusKeepaliveInterval = prev }()
+
+	t.Setenv(EnvAuditStatusKeepaliveInterval, "3m")
+	if got := resolveKeepaliveInterval(); got != 3*time.Minute {
+		t.Errorf("env override = %v, want 3m", got)
+	}
+	t.Setenv(EnvAuditStatusKeepaliveInterval, "not-a-duration")
+	if got := resolveKeepaliveInterval(); got != AuditExportStatusKeepaliveInterval {
+		t.Errorf("invalid env should fall back to the package default; got %v", got)
+	}
+}

--- a/forge-core/runtime/audit_sink_test.go
+++ b/forge-core/runtime/audit_sink_test.go
@@ -249,6 +249,53 @@ func TestHTTPSink_Posts_Event(t *testing.T) {
 	}
 }
 
+// 6b. httpSink health is a live level: a 2xx sets connected=1 and every
+// failure path clears it to 0, so the #280 connected-flip edge fires on an
+// HTTP endpoint outage (previously connected stayed sticky at its last
+// success and an outage was invisible until the next keepalive).
+func TestHTTPSink_ErrorPathsClearConnected(t *testing.T) {
+	var status atomic.Int64
+	status.Store(http.StatusAccepted)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(int(status.Load()))
+	}))
+
+	s := NewHTTPSink(srv.URL, 200*time.Millisecond)
+	defer func() { _ = s.Close(context.Background()) }()
+	write := func() {
+		if err := s.Write(context.Background(), []byte(`{}`+"\n")); err != nil {
+			t.Fatalf("Write returned err: %v", err)
+		}
+	}
+
+	// 2xx → healthy.
+	write()
+	if s.Stats()["connected"] != 1 {
+		t.Fatalf("after a 2xx, connected = %d, want 1", s.Stats()["connected"])
+	}
+
+	// non-2xx → the outage must flip the edge to 0, not stay stuck at 1.
+	status.Store(http.StatusInternalServerError)
+	write()
+	if s.Stats()["connected"] != 0 {
+		t.Errorf("after a non-2xx, connected = %d, want 0", s.Stats()["connected"])
+	}
+
+	// recovery → back to 1 (the 0→1 edge the heartbeat reports as recovery).
+	status.Store(http.StatusAccepted)
+	write()
+	if s.Stats()["connected"] != 1 {
+		t.Errorf("after recovery, connected = %d, want 1", s.Stats()["connected"])
+	}
+
+	// transport error (endpoint gone) → 0, mirroring the socket sink.
+	srv.Close()
+	write()
+	if s.Stats()["connected"] != 0 {
+		t.Errorf("after a transport error, connected = %d, want 0", s.Stats()["connected"])
+	}
+}
+
 // 7. Multi-sink fan-out: stderr + socket configured; one Emit reaches
 // both sinks.
 func TestAuditLogger_FanOut_AllSinksReceive(t *testing.T) {


### PR DESCRIPTION
Closes #280.

## Problem

`audit_export_status` emitted a per-sink health report every **60s** —
~**1,440 rows/agent/day** of near-constant "still fine" noise that
dominated audit collection at fleet scale, while adding little integrity
signal (nothing had changed).

## Change: hybrid cadence

Replace the fixed 60s tick with a state-aware hybrid loop:

- **Poll** sink health every 15s (`AuditExportStatusPollInterval`) and emit
  **immediately** when a sink's `connected` flag flips. Failures surface
  within one poll interval.
- Otherwise emit a slow **keepalive** so liveness stays provable. Default
  **15 min**, overridable via `AUDIT_STATUS_KEEPALIVE_INTERVAL` (a Go
  duration, e.g. `5m`, `1h`), **read once at process start** — a
  deploy-time knob, not live-tunable (no SIGHUP-style reload). A missing
  keepalive past the interval is itself alertable.

Steady-state volume drops from **~1,440/day → a handful**.

### Edge signal is `connected`, not drop counters

The edge trigger is the per-sink `connected` **level**, deliberately
**not** the cumulative `drops_*` counters. The status event flows through
every sink — including a failing one — so its own write bumps that sink's
drop counter, and on an idle agent the status emits are the *only* writes.
A drops-delta edge would therefore be self-referential: every poll would
see "drops increased" and emit again, **one event per poll for the whole
outage (4× the old cadence, worst precisely during an incident)**.
`connected` has no such feedback — a dial failure holds it at 0 and a
write timeout disconnects the sink, so both failure modes settle on a
single 1→0 transition until recovery flips it back. The `drops_*` counters
still ride in every emit's `sinks[]` payload for anyone tracking totals.

### `fields.reason`

Every emit is tagged `fields.reason`: `state_change` (a `connected` flip)
or `keepalive` (periodic liveness proof). A keepalive baseline is emitted
at **startup** so a healthy pipeline is visible from t=0.

## Tests

- `TestStartAuditExportStatus_EmitsPerSinkReport` — startup keepalive baseline + report shape + `reason`
- `TestStartAuditExportStatus_SlowKeepalive` — long keepalive → only the startup emit (no steady-state spam)
- `TestStartAuditExportStatus_EmitsOnConnectedFlip` — both 1→0 failure and 0→1 recovery emit `state_change`
- `TestStartAuditExportStatus_PersistentOutageDoesNotAmplify` — **regression guard**: a sink dropping across ~40 poll windows yields exactly the startup keepalive + one `state_change` (would be ~40 under drop-delta logic)
- `TestResolveKeepaliveInterval_EnvOverride` — env override honored; garbage falls back to default

All pass with `-race`.

## Docs

`docs/security/audit-logging.md` documents the hybrid cadence, the
`connected`-based edge and why drops are excluded, the `reason` field, and
the `AUDIT_STATUS_KEEPALIVE_INTERVAL` override.

> **Review finding #2 resolved:** the three "every 60s" mentions in
> `.claude/skills/forge.md` are now synced to the hybrid cadence (via
> `/sync-docs`, commit `c0edd0b`).
