### PR TITLE
feat(channels): native Slack interactive approvals for DEFER (R4c) (#310)

### DIFF
--- a/docs/security/defer-decisions.md
+++ b/docs/security/defer-decisions.md
@@ -213,6 +213,31 @@ doesn't implement interactive approvals (`channels.ApprovalDeliverer`)
 can't be a target. Telegram / MS Teams interactive approvals are a
 follow-up (same interface).
 
+> ⚠️ **The approval authority is channel membership.** Any user who can
+> see the message and click a button resolves the deferred call. Forge
+> records **who** clicked (in the audit event) but does **not** yet check
+> that they are *authorized* to approve — so **the target channel's
+> membership IS the approval ACL.** Consequences:
+>
+> - Route approvals to a **tightly-scoped private channel**, not a broad
+>   `#oncall` that includes guests, contractors, bots, or integrations.
+> - A **compromised member account** grants approval authority over every
+>   agent action routed there — treat channel membership as a privileged
+>   grant.
+> - There is no requester≠approver (four-eyes) or per-tool approver
+>   restriction today. A per-tool, email-based approver allowlist is
+>   tracked in #313.
+>
+> **No rejection reason is captured from Slack today.** A button click
+> carries no free text, so a Slack `reject` records an empty `note`; if
+> you need a documented reason, resolve via `POST /tasks/{id}/decisions`
+> with a `note`, or wait for the follow-up that opens a reason modal.
+
+**If the target adapter isn't running**, Forge warns at startup (e.g.
+`security.defer` routes `cli_execute` to `channel:slack:…` but `slack` is
+not active — start with `--with slack`). The deferral still holds; the
+approval just won't be delivered until an approver POSTs directly.
+
 ### Custom notify path
 
 For any other target (or without the Slack adapter), wire your own:

--- a/docs/security/defer-decisions.md
+++ b/docs/security/defer-decisions.md
@@ -39,9 +39,9 @@ DEFER is **not** the right tool for:
        tools:
          cli_execute:
            to: channel:slack:#oncall
-           timeout: 10m
+           timeout: 5m     # keep <= 6m for channel-routed approvals (see the window note below)
            context_template: "Agent wants to run {tool} with args: {args}"
-       default_timeout: 10m
+       default_timeout: 5m
    ```
 
 2. **`BeforeToolExec` hook fires** on a matching tool call:
@@ -196,7 +196,7 @@ security:
     tools:
       atlassian__jira_create_issue:
         to: channel:slack:#oncall        # channel:<adapter>:<target>
-        timeout: 15m
+        timeout: 5m                       # <= 6m for channel-routed approvals (see the window note below)
         context_template: "Agent wants to run {tool} with args: {args}"
 ```
 

--- a/docs/security/defer-decisions.md
+++ b/docs/security/defer-decisions.md
@@ -200,6 +200,21 @@ security:
         context_template: "Agent wants to run {tool} with args: {args}"
 ```
 
+**The `<target>` may be a channel id (`C0123ABC5`) or a name (`#oncall`
+or `oncall`).** A name is resolved to its id via `conversations.list` and
+cached; an id is used directly. Requirements for the target channel:
+
+- **The bot must be a member** of the channel (invite it) — otherwise
+  Slack rejects the post with `not_in_channel`.
+- Resolving a **name** needs the bot's `channels:read` (public) +
+  `groups:read` (private) scopes; posting needs `chat:write`; updating the
+  message after a decision needs `chat:write` as well.
+- Name resolution **fails closed** — if the name can't be resolved (wrong
+  scope, bot not a member, no such channel) the delivery errors (logged,
+  non-fatal) rather than posting to the wrong place. If in doubt, use the
+  **channel id** directly (right-click the channel → *View channel
+  details* → the id is at the bottom).
+
 This needs **no inbound exposure to Forge**: the Slack adapter uses
 Socket Mode (outbound WebSocket), so the button click arrives over the
 agent's existing outbound connection. Under the hood the click is routed

--- a/docs/security/defer-decisions.md
+++ b/docs/security/defer-decisions.md
@@ -178,19 +178,49 @@ replace.
 Never carries token bytes or full tool inputs beyond the truncated
 context template.
 
-## Notify integration (follow-up)
+## Notify integration
 
-The `to` field is free-form for now — the runtime doesn't route it
-anywhere. Operators wire their own notify path:
+### Native Slack approvals (#310)
 
-- Poll the audit stream for `task_deferred`, forward to Slack/Teams/etc.
-- Slack Block Kit approve/reject buttons post back to
-  `/tasks/{id}/decisions` (add an auth token — the endpoint honors
-  the runner's normal auth middleware).
+When the agent runs with `--with slack` and a deferred tool's `to` is
+`channel:slack:<channel>`, Forge **delivers the approval natively**: on a
+deferral the Slack adapter posts a **Block Kit** message with **Approve /
+Reject** buttons to that channel, and a click resolves the deferral —
+the tool proceeds or fails and the message updates with the outcome +
+approver.
 
-A first-party channel adapter with approve/reject buttons is
-tracked as a follow-up; the plumbing (audit → HTTP roundtrip) is
-in place today.
+```yaml
+security:
+  defer:
+    enabled: true
+    tools:
+      atlassian__jira_create_issue:
+        to: channel:slack:#oncall        # channel:<adapter>:<target>
+        timeout: 15m
+        context_template: "Agent wants to run {tool} with args: {args}"
+```
+
+This needs **no inbound exposure to Forge**: the Slack adapter uses
+Socket Mode (outbound WebSocket), so the button click arrives over the
+agent's existing outbound connection. Under the hood the click is routed
+to the same `POST /tasks/{id}/decisions` endpoint an operator would curl.
+Delivery is **best-effort** — if Slack is unreachable the deferral still
+holds and an approver can POST the decision directly; a delivery failure
+never auto-denies.
+
+The `to` value must be `channel:<adapter>:<target>`; an adapter that
+doesn't implement interactive approvals (`channels.ApprovalDeliverer`)
+can't be a target. Telegram / MS Teams interactive approvals are a
+follow-up (same interface).
+
+### Custom notify path
+
+For any other target (or without the Slack adapter), wire your own:
+
+- Poll the audit stream for `task_deferred` (carries `task_id`, `to`,
+  `context`), forward to your tool of choice.
+- Have it POST `{decision, approver, note}` to `/tasks/{id}/decisions`
+  (add an auth token — the endpoint honors the runner's auth middleware).
 
 ## Combining with other governance controls
 

--- a/docs/security/defer-decisions.md
+++ b/docs/security/defer-decisions.md
@@ -253,6 +253,21 @@ follow-up (same interface).
 not active — start with `--with slack`). The deferral still holds; the
 approval just won't be delivered until an approver POSTs directly.
 
+> ⏱ **Approval window for channel-initiated conversations.** A conversation
+> that arrives *through* a channel adapter (Slack/Telegram → agent) is
+> served synchronously: the channel router holds the request open for
+> `channels.SyncRequestTimeout` (**6 minutes**). Because the agent loop
+> runs under that request's context, if the approval doesn't land within
+> ~6 minutes the HTTP call times out, the context is cancelled, and the
+> **deferral is abandoned** (the tool call fails; a later click gets a
+> `404`). So for channel-routed approvals, **set `timeout` ≤ 6m** — Forge
+> warns at startup if a channel target's `timeout` exceeds the sync
+> window. Direct A2A clients that hold the connection (or poll `tasks/get`)
+> aren't bound by this. The proper fix — detaching the deferred task and
+> delivering the result asynchronously so long approvals survive — is
+> tracked in #314. The session itself always resumes intact on approval
+> (the deferral is keyed on the task id, not the channel).
+
 ### Custom notify path
 
 For any other target (or without the Slack adapter), wire your own:

--- a/forge-cli/channels/router.go
+++ b/forge-cli/channels/router.go
@@ -16,6 +16,13 @@ import (
 	"github.com/initializ/forge/forge-core/channels"
 )
 
+// SyncRequestTimeout is how long the router holds a channel-initiated
+// tasks/send request open waiting for the agent's response. It is the ceiling
+// on how long a channel-initiated tool call can spend awaiting a human DEFER
+// approval before the HTTP call times out (the request context is cancelled and
+// the deferral is abandoned). See #314 for lifting this via async delivery.
+const SyncRequestTimeout = 360 * time.Second
+
 // Router forwards channel events to an A2A agent server via JSON-RPC over HTTP.
 type Router struct {
 	agentURL    string
@@ -30,7 +37,7 @@ func NewRouter(agentURL, bearerToken string) *Router {
 		agentURL:    agentURL,
 		bearerToken: bearerToken,
 		client: &http.Client{
-			Timeout: 360 * time.Second,
+			Timeout: SyncRequestTimeout,
 		},
 	}
 }

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -21,6 +22,7 @@ import (
 	corechannels "github.com/initializ/forge/forge-core/channels"
 	coreruntime "github.com/initializ/forge/forge-core/runtime"
 	"github.com/initializ/forge/forge-core/security"
+	"github.com/initializ/forge/forge-core/types"
 	"github.com/spf13/cobra"
 )
 
@@ -251,6 +253,11 @@ func runRun(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
+	// activeChannelSet is the set of adapters actually running (post policy
+	// filter). Used below to warn if a DEFER `to:` routes approvals to a
+	// channel that isn't active (#311 review / user report).
+	activeChannelSet := map[string]bool{}
+
 	// Start channel adapters if --with flag is set
 	if runWithChannels != "" {
 		registry := defaultRegistry()
@@ -302,6 +309,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 			defer plugin.Stop() //nolint:errcheck
 
 			activePlugins[name] = plugin
+			activeChannelSet[name] = true
 
 			go func() {
 				if err := plugin.Start(ctx, router.Handler()); err != nil {
@@ -330,12 +338,24 @@ func runRun(cmd *cobra.Command, args []string) error {
 			// deferred tool call's `to: channel:<adapter>:<target>` to a
 			// channel adapter that supports interactive approvals, and resolve
 			// the approver's click back to the decisions endpoint.
+			opsLog := coreruntime.NewJSONLogger(os.Stdout, false)
 			resolver := func(ctx context.Context, d corechannels.ApprovalDecision) error {
-				return postDeferDecision(ctx, agentURL, runner.AuthToken(), d)
+				if err := postDeferDecision(ctx, agentURL, runner.AuthToken(), d); err != nil {
+					opsLog.Warn("defer: recording approval decision failed", map[string]any{
+						"task_id": d.TaskID, "decision": d.Decision, "approver": d.Approver, "error": err.Error(),
+					})
+					return err
+				}
+				return nil
 			}
 			for _, plugin := range activePlugins {
 				if deliverer, ok := plugin.(corechannels.ApprovalDeliverer); ok {
 					deliverer.SetApprovalResolver(resolver)
+				}
+				// Route the adapter's ops signals (e.g. approval-handling
+				// errors) through the structured stdout stream (#311 review).
+				if la, ok := plugin.(corechannels.LoggerAware); ok {
+					la.SetLogger(opsLog)
 				}
 			}
 			runner.SetDeferralNotifier(func(ctx context.Context, to, taskID, tool, approverContext string, timeout time.Duration) error {
@@ -362,7 +382,43 @@ func runRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// #311 review / user report: warn (loudly, at startup) if a DEFER tool
+	// routes approvals to a channel adapter that isn't active — otherwise the
+	// approval is silently never delivered (the deferral still holds; an
+	// approver must POST /tasks/{id}/decisions directly). Runs regardless of
+	// --with so a missing adapter is caught even when no channel is started.
+	for _, w := range deferChannelTargetWarnings(cfg.Security.Defer, activeChannelSet) {
+		fmt.Fprintln(os.Stderr, "  Warning:    "+w)
+	}
+
 	return runner.Run(ctx)
+}
+
+// deferChannelTargetWarnings returns a warning for each DEFER tool whose `to:`
+// routes to a `channel:<adapter>:…` that is not in the active adapter set.
+// Pure + testable.
+func deferChannelTargetWarnings(deferCfg types.DeferConfig, activeChannels map[string]bool) []string {
+	if !deferCfg.Enabled {
+		return nil
+	}
+	var warns []string
+	seen := map[string]bool{}
+	for tool, tc := range deferCfg.Tools {
+		to := tc.To
+		if to == "" {
+			to = deferCfg.DefaultTo
+		}
+		adapter, _, ok := parseDeferTarget(to)
+		if !ok || activeChannels[adapter] || seen[tool] {
+			continue
+		}
+		seen[tool] = true
+		warns = append(warns, fmt.Sprintf(
+			"security.defer routes %q approvals to channel adapter %q, but it is not active — start with --with %s, or approvals must be resolved via POST /tasks/{id}/decisions",
+			tool, adapter, adapter))
+	}
+	sort.Strings(warns) // deterministic order (map iteration)
+	return warns
 }
 
 // parseDeferTarget parses a DEFER `to:` value of the form

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -390,6 +390,15 @@ func runRun(cmd *cobra.Command, args []string) error {
 	for _, w := range deferChannelTargetWarnings(cfg.Security.Defer, activeChannelSet) {
 		fmt.Fprintln(os.Stderr, "  Warning:    "+w)
 	}
+	// #311 review / #314: a channel-initiated conversation only waits
+	// channels.SyncRequestTimeout for the agent's response, so a DEFER timeout
+	// longer than that can't be honored for channel-routed approvals — the
+	// HTTP call times out and the deferral is abandoned before the approver
+	// acts. Warn so operators set a fitting timeout (real fix: async delivery,
+	// #314).
+	for _, w := range deferTimeoutWarnings(cfg.Security.Defer, channels.SyncRequestTimeout) {
+		fmt.Fprintln(os.Stderr, "  Warning:    "+w)
+	}
 
 	return runner.Run(ctx)
 }
@@ -418,6 +427,40 @@ func deferChannelTargetWarnings(deferCfg types.DeferConfig, activeChannels map[s
 			tool, adapter, adapter))
 	}
 	sort.Strings(warns) // deterministic order (map iteration)
+	return warns
+}
+
+// deferTimeoutWarnings returns a warning for each DEFER tool that routes to a
+// channel with a timeout longer than syncWait — the window a channel-initiated
+// conversation actually waits for the agent's response. Beyond it the HTTP call
+// times out and the deferral is abandoned before the approver can act (#314).
+func deferTimeoutWarnings(deferCfg types.DeferConfig, syncWait time.Duration) []string {
+	if !deferCfg.Enabled {
+		return nil
+	}
+	var warns []string
+	for tool, tc := range deferCfg.Tools {
+		to := tc.To
+		if to == "" {
+			to = deferCfg.DefaultTo
+		}
+		if _, _, ok := parseDeferTarget(to); !ok {
+			continue // only channel-routed approvals are bound by the sync wait
+		}
+		timeout := tc.Timeout
+		if timeout == 0 {
+			timeout = deferCfg.DefaultTimeout
+		}
+		if timeout == 0 {
+			timeout = 10 * time.Minute // engine default
+		}
+		if timeout > syncWait {
+			warns = append(warns, fmt.Sprintf(
+				"security.defer routes %q approvals to a channel with timeout %s, but a channel-initiated conversation only waits ~%s (the channel router HTTP timeout) — an approval that arrives later is lost and the tool call fails. Set timeout <= %s (or await the async-delivery fix, #314).",
+				tool, timeout, syncWait, syncWait))
+		}
+	}
+	sort.Strings(warns)
 	return warns
 }
 

--- a/forge-cli/cmd/run.go
+++ b/forge-cli/cmd/run.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -321,10 +325,85 @@ func runRun(cmd *cobra.Command, args []string) error {
 				}
 				return plugin.SendResponse(event, response)
 			})
+
+			// Wire up DEFER (R4c) interactive approvals (#310): route a
+			// deferred tool call's `to: channel:<adapter>:<target>` to a
+			// channel adapter that supports interactive approvals, and resolve
+			// the approver's click back to the decisions endpoint.
+			resolver := func(ctx context.Context, d corechannels.ApprovalDecision) error {
+				return postDeferDecision(ctx, agentURL, runner.AuthToken(), d)
+			}
+			for _, plugin := range activePlugins {
+				if deliverer, ok := plugin.(corechannels.ApprovalDeliverer); ok {
+					deliverer.SetApprovalResolver(resolver)
+				}
+			}
+			runner.SetDeferralNotifier(func(ctx context.Context, to, taskID, tool, approverContext string, timeout time.Duration) error {
+				adapter, target, ok := parseDeferTarget(to)
+				if !ok {
+					return fmt.Errorf("defer `to` %q is not in channel:<adapter>:<target> form", to)
+				}
+				plugin, ok := activePlugins[adapter]
+				if !ok {
+					return fmt.Errorf("defer target adapter %q is not active", adapter)
+				}
+				deliverer, ok := plugin.(corechannels.ApprovalDeliverer)
+				if !ok {
+					return fmt.Errorf("channel adapter %q does not support interactive approvals", adapter)
+				}
+				return deliverer.DeliverApproval(ctx, corechannels.ApprovalRequest{
+					TaskID:  taskID,
+					Tool:    tool,
+					Context: approverContext,
+					Timeout: timeout,
+					Target:  target,
+				})
+			})
 		}
 	}
 
 	return runner.Run(ctx)
+}
+
+// parseDeferTarget parses a DEFER `to:` value of the form
+// "channel:<adapter>:<target>" (e.g. "channel:slack:#oncall") into its adapter
+// and target. Returns ok=false for any other shape.
+func parseDeferTarget(to string) (adapter, target string, ok bool) {
+	parts := strings.SplitN(strings.TrimSpace(to), ":", 3)
+	if len(parts) != 3 || parts[0] != "channel" || parts[1] == "" || parts[2] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
+}
+
+// postDeferDecision POSTs an approver's decision to the agent's DEFER decisions
+// endpoint (the same endpoint a human would curl). Topology-agnostic: works
+// whether the channel adapter runs in-process or as a separate process.
+func postDeferDecision(ctx context.Context, agentURL, token string, d corechannels.ApprovalDecision) error {
+	body, _ := json.Marshal(map[string]string{
+		"decision": d.Decision,
+		"approver": d.Approver,
+		"note":     d.Note,
+	})
+	url := fmt.Sprintf("%s/tasks/%s/decisions", agentURL, d.TaskID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("decisions endpoint HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
 }
 
 // buildRateLimitOverride translates the runRateLimit* flag vars into

--- a/forge-cli/cmd/run_test.go
+++ b/forge-cli/cmd/run_test.go
@@ -68,3 +68,28 @@ func TestRunCmd_InvalidConfigContent(t *testing.T) {
 		t.Error("expected error for invalid config")
 	}
 }
+
+// TestParseDeferTarget covers the DEFER `to:` routing parse (#310).
+func TestParseDeferTarget(t *testing.T) {
+	cases := []struct {
+		in              string
+		adapter, target string
+		ok              bool
+	}{
+		{"channel:slack:#oncall", "slack", "#oncall", true},
+		{"channel:telegram:12345", "telegram", "12345", true},
+		{"channel:slack:C0123ABC", "slack", "C0123ABC", true},
+		{"  channel:slack:#oncall  ", "slack", "#oncall", true}, // trimmed
+		{"slack:#oncall", "", "", false},                        // missing scheme
+		{"channel:slack", "", "", false},                        // missing target
+		{"channel::#oncall", "", "", false},                     // empty adapter
+		{"channel:slack:", "", "", false},                       // empty target
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		a, tg, ok := parseDeferTarget(c.in)
+		if ok != c.ok || a != c.adapter || tg != c.target {
+			t.Errorf("parseDeferTarget(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, a, tg, ok, c.adapter, c.target, c.ok)
+		}
+	}
+}

--- a/forge-cli/cmd/run_test.go
+++ b/forge-cli/cmd/run_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/initializ/forge/forge-cli/channels"
 	"github.com/initializ/forge/forge-core/types"
 )
 
@@ -140,4 +142,49 @@ func TestDeferChannelTargetWarnings(t *testing.T) {
 			t.Errorf("disabled defer must not warn, got %v", w)
 		}
 	})
+}
+
+// TestDeferTimeoutWarnings covers the #314 timeout-mismatch warning: a
+// channel-routed DEFER with a timeout longer than the sync wait warns.
+func TestDeferTimeoutWarnings(t *testing.T) {
+	syncWait := 6 * time.Minute
+	cfg := types.DeferConfig{
+		Enabled: true,
+		Tools: map[string]types.DeferToolConfig{
+			"long_channel":  {To: "channel:slack:#oncall", Timeout: 15 * time.Minute}, // > 6m → warn
+			"short_channel": {To: "channel:slack:#oncall", Timeout: 5 * time.Minute},  // <= 6m → ok
+			"default_to":    {To: "channel:slack:#oncall"},                            // default 10m → warn
+			"human_target":  {To: "human:oncall", Timeout: 30 * time.Minute},          // not a channel → ignored
+		},
+	}
+
+	warns := deferTimeoutWarnings(cfg, syncWait)
+	if len(warns) != 2 { // long_channel + default_to
+		t.Fatalf("expected 2 timeout warnings, got %d: %v", len(warns), warns)
+	}
+	joined := strings.Join(warns, "\n")
+	for _, want := range []string{"long_channel", "default_to", "6m0s", "Set timeout <="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("timeout warning missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "short_channel") || strings.Contains(joined, "human_target") {
+		t.Errorf("should not warn for short_channel/human_target:\n%s", joined)
+	}
+
+	t.Run("disabled → no warnings", func(t *testing.T) {
+		off := cfg
+		off.Enabled = false
+		if w := deferTimeoutWarnings(off, syncWait); w != nil {
+			t.Errorf("disabled defer must not warn, got %v", w)
+		}
+	})
+}
+
+// TestSyncRequestTimeout_IsReferenced guards the single-source-of-truth: the
+// warning threshold uses the exported router constant.
+func TestSyncRequestTimeout_IsReferenced(t *testing.T) {
+	if channels.SyncRequestTimeout != 360*time.Second {
+		t.Errorf("SyncRequestTimeout = %v, want 360s", channels.SyncRequestTimeout)
+	}
 }

--- a/forge-cli/cmd/run_test.go
+++ b/forge-cli/cmd/run_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/initializ/forge/forge-core/types"
 )
 
 func TestRunCmd_FlagDefaults(t *testing.T) {
@@ -92,4 +95,49 @@ func TestParseDeferTarget(t *testing.T) {
 			t.Errorf("parseDeferTarget(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, a, tg, ok, c.adapter, c.target, c.ok)
 		}
 	}
+}
+
+// TestDeferChannelTargetWarnings covers the #311-review edge case: a DEFER tool
+// routing approvals to a channel adapter that isn't active must warn at startup.
+func TestDeferChannelTargetWarnings(t *testing.T) {
+	cfg := types.DeferConfig{
+		Enabled: true,
+		Tools: map[string]types.DeferToolConfig{
+			"cli_execute":                  {To: "channel:slack:#oncall"}, // slack NOT active → warn
+			"atlassian__jira_create_issue": {To: "channel:telegram:123"},  // telegram active → no warn
+			"human_tool":                   {To: "human:oncall"},          // non-channel → no warn
+		},
+	}
+
+	t.Run("warns for inactive adapter, not active ones", func(t *testing.T) {
+		warns := deferChannelTargetWarnings(cfg, map[string]bool{"telegram": true})
+		if len(warns) != 1 {
+			t.Fatalf("expected exactly 1 warning, got %d: %v", len(warns), warns)
+		}
+		if !strings.Contains(warns[0], "cli_execute") || !strings.Contains(warns[0], `"slack"`) || !strings.Contains(warns[0], "--with slack") {
+			t.Errorf("warning wording off: %q", warns[0])
+		}
+	})
+
+	t.Run("no channels active → warns for the channel target", func(t *testing.T) {
+		warns := deferChannelTargetWarnings(cfg, map[string]bool{})
+		// slack (inactive) warns; telegram (inactive) warns; human: not a channel.
+		if len(warns) != 2 {
+			t.Fatalf("expected 2 warnings with no active channels, got %d: %v", len(warns), warns)
+		}
+	})
+
+	t.Run("all targets active → no warnings", func(t *testing.T) {
+		if w := deferChannelTargetWarnings(cfg, map[string]bool{"slack": true, "telegram": true}); len(w) != 0 {
+			t.Errorf("expected no warnings, got %v", w)
+		}
+	})
+
+	t.Run("defer disabled → no warnings", func(t *testing.T) {
+		off := cfg
+		off.Enabled = false
+		if w := deferChannelTargetWarnings(off, map[string]bool{}); w != nil {
+			t.Errorf("disabled defer must not warn, got %v", w)
+		}
+	})
 }

--- a/forge-cli/runtime/defer.go
+++ b/forge-cli/runtime/defer.go
@@ -101,6 +101,21 @@ func (r *Runner) registerDeferHook(hooks *coreruntime.HookRegistry, store TaskSt
 			},
 		})
 
+		// #310 — deliver an interactive approval request to the channel named
+		// in `to:` (e.g. Slack Block Kit buttons). Best-effort: a delivery
+		// failure is logged, never fatal — the approver can still POST
+		// /tasks/{id}/decisions, and blocking/denying on a Slack outage would
+		// be worse than a missing button.
+		if r.deferralNotifier != nil {
+			if nErr := r.deferralNotifier(ctx, spec.To, hctx.TaskID, hctx.ToolName, spec.ContextForApprover, spec.Timeout); nErr != nil {
+				r.logger.Warn("defer: approval delivery failed", map[string]any{
+					"tool":  hctx.ToolName,
+					"to":    spec.To,
+					"error": nErr.Error(),
+				})
+			}
+		}
+
 		start := time.Now()
 		res, waitErr := handle.WaitCtx(ctx)
 		if waitErr != nil {

--- a/forge-cli/runtime/defer_test.go
+++ b/forge-cli/runtime/defer_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -349,3 +350,72 @@ func TestDecisionsEndpoint_BadDecision(t *testing.T) {
 	// Cleanup — the pending deferral would leak otherwise.
 	_ = engine.Resolve("task-x", deferengine.Resolution{Decision: deferengine.DecisionTimeout})
 }
+
+// TestDeferHook_FiresDeferralNotifier pins the #310 wiring: when a tool call is
+// deferred and a DeferralNotifier is set, the hook invokes it with the routing
+// target + task/tool/context, so a channel adapter can deliver the approval.
+func TestDeferHook_FiresDeferralNotifier(t *testing.T) {
+	cfg := types.DeferConfig{
+		Enabled:        true,
+		DefaultTimeout: 500 * time.Millisecond,
+		Tools: map[string]types.DeferToolConfig{
+			"cli_execute": {To: "channel:slack:#oncall", Timeout: 500 * time.Millisecond,
+				ContextTemplate: "run {tool}"},
+		},
+	}
+	r, _, _, hooks := buildTestRunner(t, cfg)
+
+	type call struct{ to, taskID, tool, ctx string }
+	got := make(chan call, 1)
+	r.SetDeferralNotifier(func(_ context.Context, to, taskID, tool, approverCtx string, _ time.Duration) error {
+		got <- call{to, taskID, tool, approverCtx}
+		return nil
+	})
+
+	hctx := &coreruntime.HookContext{ToolName: "cli_execute", ToolInput: `{}`, TaskID: "task-notify"}
+	done := make(chan error, 1)
+	go func() { done <- hooks.Fire(context.Background(), coreruntime.BeforeToolExec, hctx) }()
+
+	select {
+	case c := <-got:
+		if c.to != "channel:slack:#oncall" || c.taskID != "task-notify" || c.tool != "cli_execute" || c.ctx != "run cli_execute" {
+			t.Errorf("notifier got %+v", c)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("deferral notifier was not invoked")
+	}
+
+	// Unblock the hook so the goroutine exits cleanly.
+	_ = r.deferEngine.Resolve("task-notify", deferengine.Resolution{Decision: deferengine.DecisionApprove})
+	<-done
+}
+
+// TestDeferHook_NotifierFailureNonFatal: a delivery failure must NOT deny — the
+// hook still blocks and a direct approve still lets the tool proceed.
+func TestDeferHook_NotifierFailureNonFatal(t *testing.T) {
+	cfg := types.DeferConfig{
+		Enabled: true, DefaultTimeout: 500 * time.Millisecond,
+		Tools: map[string]types.DeferToolConfig{"cli_execute": {To: "channel:slack:#x", Timeout: 500 * time.Millisecond}},
+	}
+	r, _, _, hooks := buildTestRunner(t, cfg)
+	r.SetDeferralNotifier(func(context.Context, string, string, string, string, time.Duration) error {
+		return errTestDelivery
+	})
+
+	hctx := &coreruntime.HookContext{ToolName: "cli_execute", ToolInput: `{}`, TaskID: "task-nf"}
+	done := make(chan error, 1)
+	go func() { done <- hooks.Fire(context.Background(), coreruntime.BeforeToolExec, hctx) }()
+	time.Sleep(30 * time.Millisecond)
+	_ = r.deferEngine.Resolve("task-nf", deferengine.Resolution{Decision: deferengine.DecisionApprove})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("delivery failure must not fail the hook on approve; got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("hook did not return")
+	}
+}
+
+var errTestDelivery = fmt.Errorf("simulated delivery failure")

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -111,6 +111,14 @@ type RunnerConfig struct {
 // result to the appropriate channel (e.g. Slack, Telegram).
 type ScheduleNotifier func(ctx context.Context, channel, target string, response *a2a.Message) error
 
+// DeferralNotifier is called when a tool call is deferred for human approval
+// (R4c #211) to deliver an interactive approval request to a channel (#310).
+// `to` is the tool's `security.defer.tools.<tool>.to` value (e.g.
+// "channel:slack:#oncall"). Optional — a nil notifier means no channel
+// delivery; the approver can still POST /tasks/{id}/decisions directly. A
+// delivery error is logged, never fatal (a Slack outage must not auto-deny).
+type DeferralNotifier func(ctx context.Context, to, taskID, tool, approverContext string, timeout time.Duration) error
+
 // codeAgentDirective is appended to the system prompt when code-agent skill
 // is active. Forces the LLM to always call tools — never respond with text only.
 const codeAgentDirective = `## Code Agent — MANDATORY RULES
@@ -152,6 +160,7 @@ type Runner struct {
 	schedBackend         scheduler.Backend                 // schedule backend (nil until started); FileBackend in non-cluster deploys, KubernetesBackend (#162 part 2b) when running in-cluster with scheduler.backend=auto|kubernetes
 	startTime            time.Time                         // server start time (for /health uptime)
 	scheduleNotifier     ScheduleNotifier                  // optional: delivers cron results to channels
+	deferralNotifier     DeferralNotifier                  // optional: delivers DEFER approval requests to channels (#310)
 	authToken            string                            // resolved auth token (empty if --no-auth)
 	cancelRegistry       *coreruntime.CancellationRegistry // per-Runner in-flight cancellation registry (issue #88 / FWS-4)
 	auditSigningKey      *coreruntime.LoadedKey            // loaded once at startup; nil when signing is off (#213). Served on JWKS endpoint.
@@ -189,6 +198,12 @@ func NewRunner(cfg RunnerConfig) (*Runner, error) {
 // to channel adapters. Must be called before Run().
 func (r *Runner) SetScheduleNotifier(fn ScheduleNotifier) {
 	r.scheduleNotifier = fn
+}
+
+// SetDeferralNotifier sets the callback used to deliver DEFER (R4c) approval
+// requests to channel adapters (#310). Must be called before Run().
+func (r *Runner) SetDeferralNotifier(fn DeferralNotifier) {
+	r.deferralNotifier = fn
 }
 
 // ResolveAuth resolves the auth token early (before Run). This is needed so

--- a/forge-core/channels/plugin.go
+++ b/forge-core/channels/plugin.go
@@ -5,6 +5,7 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/initializ/forge/forge-core/a2a"
 )
@@ -57,4 +58,45 @@ type Attachment struct {
 	Name     string `json:"name,omitempty"`
 	MimeType string `json:"mime_type,omitempty"`
 	URL      string `json:"url,omitempty"`
+}
+
+// --- Interactive human-approval (DEFER / R4c, #211) delivery -----------------
+
+// ApprovalRequest is a pending human-approval to deliver to an approver via an
+// interactive channel message (e.g. Slack Block Kit buttons). The runtime
+// builds one when a tool call is deferred; a channel adapter renders it.
+type ApprovalRequest struct {
+	TaskID  string        // the deferred A2A task; the resolution key
+	Tool    string        // the tool call awaiting approval
+	Context string        // rendered context_template (what the agent wants to do)
+	Timeout time.Duration // how long until auto-deny
+	Target  string        // adapter-specific destination (e.g. a Slack channel "#oncall")
+}
+
+// ApprovalDecision is an approver's response, delivered back to the runtime by
+// the adapter that received the interaction.
+type ApprovalDecision struct {
+	TaskID   string // must match the ApprovalRequest.TaskID
+	Decision string // "approve" | "reject"
+	Approver string // who acted (platform user id / name)
+	Note     string // optional justification
+}
+
+// ApprovalResolver is invoked by an adapter when an approver acts on a
+// delivered ApprovalRequest. The runtime routes it to the deferred task's
+// decision (typically POST /tasks/{id}/decisions). Wired via
+// ApprovalDeliverer.SetApprovalResolver at startup.
+type ApprovalResolver func(ctx context.Context, d ApprovalDecision) error
+
+// ApprovalDeliverer is an OPTIONAL capability. A channel adapter that can post
+// an interactive approval request AND receive the approver's response
+// implements it (Slack via Block Kit over Socket Mode, #310). Adapters that
+// don't implement it simply can't be a DEFER `to:` target; the deferral still
+// works via a direct POST /tasks/{id}/decisions.
+type ApprovalDeliverer interface {
+	// DeliverApproval posts the interactive approval request to req.Target.
+	DeliverApproval(ctx context.Context, req ApprovalRequest) error
+	// SetApprovalResolver wires the callback the adapter invokes when an
+	// approver acts. The runtime sets this once at startup.
+	SetApprovalResolver(r ApprovalResolver)
 }

--- a/forge-core/channels/plugin.go
+++ b/forge-core/channels/plugin.go
@@ -88,6 +88,24 @@ type ApprovalDecision struct {
 // ApprovalDeliverer.SetApprovalResolver at startup.
 type ApprovalResolver func(ctx context.Context, d ApprovalDecision) error
 
+// Logger is the minimal structured ops logger a channel adapter uses for
+// operational signals (the FWS-9 stdout ops stream). Satisfied by
+// forge-core/runtime.Logger, so the runtime can wire its logger without this
+// package importing it.
+type Logger interface {
+	Info(msg string, fields map[string]any)
+	Warn(msg string, fields map[string]any)
+	Error(msg string, fields map[string]any)
+	Debug(msg string, fields map[string]any)
+}
+
+// LoggerAware is an OPTIONAL capability: an adapter that routes operational
+// signals through a structured logger implements it. The runtime wires it at
+// startup; adapters that don't implement it keep their own logging.
+type LoggerAware interface {
+	SetLogger(Logger)
+}
+
 // ApprovalDeliverer is an OPTIONAL capability. A channel adapter that can post
 // an interactive approval request AND receive the approver's response
 // implements it (Slack via Block Kit over Socket Mode, #310). Adapters that

--- a/forge-plugins/channels/slack/approvals.go
+++ b/forge-plugins/channels/slack/approvals.go
@@ -1,0 +1,206 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/initializ/forge/forge-core/channels"
+)
+
+// Interactive DEFER (R4c, #211) human-approval delivery over Socket Mode
+// (#310). The bot posts a Block Kit message with Approve/Reject buttons; the
+// click returns as an `interactive` envelope on the same outbound WebSocket
+// (no inbound exposure), which resolves the deferred task via the wired
+// resolver. Compile-time assertion that Plugin satisfies the capability:
+var _ channels.ApprovalDeliverer = (*Plugin)(nil)
+
+const (
+	approveActionID = "forge_defer_approve"
+	rejectActionID  = "forge_defer_reject"
+)
+
+// SetApprovalResolver wires the callback invoked when an approver clicks a
+// button. Called once by the runtime at startup.
+func (p *Plugin) SetApprovalResolver(r channels.ApprovalResolver) {
+	p.approvalResolver = r
+}
+
+// DeliverApproval posts a Block Kit Approve/Reject message to req.Target (a
+// Slack channel like "#oncall"). The buttons carry the task id so the click
+// can be routed back to the deferral. Delivery failure is returned to the
+// caller (the runtime logs it, non-fatal — the approver can still POST the
+// decision directly).
+func (p *Plugin) DeliverApproval(ctx context.Context, req channels.ApprovalRequest) error {
+	if req.Target == "" {
+		return fmt.Errorf("slack DeliverApproval: empty target channel")
+	}
+	return p.postMessage(buildApprovalPayload(req))
+}
+
+// buildApprovalPayload renders the chat.postMessage body for an approval
+// request. Split out (pure) so tests can assert the Block Kit shape without a
+// live Slack. `text` is the notification fallback; the blocks carry the
+// interactive buttons whose `value` is the task id (the resolution key).
+func buildApprovalPayload(req channels.ApprovalRequest) map[string]any {
+	summary := fmt.Sprintf("*Approval required* for `%s`", req.Tool)
+	detail := summary
+	if req.Context != "" {
+		detail += "\n" + req.Context
+	}
+	if req.Timeout > 0 {
+		detail += fmt.Sprintf("\n_Auto-denies in %s._", req.Timeout.Round(time.Second))
+	}
+	return map[string]any{
+		"channel": req.Target,
+		"text":    fmt.Sprintf("Approval required for %s", req.Tool), // fallback / a11y
+		"blocks": []any{
+			map[string]any{
+				"type": "section",
+				"text": map[string]any{"type": "mrkdwn", "text": detail},
+			},
+			map[string]any{
+				"type":     "actions",
+				"block_id": "forge_defer:" + req.TaskID,
+				"elements": []any{
+					map[string]any{
+						"type":      "button",
+						"action_id": approveActionID,
+						"style":     "primary",
+						"text":      map[string]any{"type": "plain_text", "text": "Approve"},
+						"value":     req.TaskID,
+					},
+					map[string]any{
+						"type":      "button",
+						"action_id": rejectActionID,
+						"style":     "danger",
+						"text":      map[string]any{"type": "plain_text", "text": "Reject"},
+						"value":     req.TaskID,
+					},
+				},
+			},
+		},
+	}
+}
+
+// slackInteraction is the subset of Slack's block_actions payload we consume.
+type slackInteraction struct {
+	Type string `json:"type"`
+	User struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Name     string `json:"name"`
+	} `json:"user"`
+	Actions []struct {
+		ActionID string `json:"action_id"`
+		Value    string `json:"value"`
+	} `json:"actions"`
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+	Message struct {
+		TS string `json:"ts"`
+	} `json:"message"`
+}
+
+// parseApprovalInteraction extracts an ApprovalDecision from a Slack
+// block_actions payload. Pure + testable. Returns ok=false for any payload
+// that isn't one of our approval buttons (other apps' interactions, non-button
+// types) so the caller ignores it. `channelID`/`msgTS` locate the message for
+// the outcome update.
+func parseApprovalInteraction(payload []byte) (dec channels.ApprovalDecision, channelID, msgTS string, ok bool) {
+	var in slackInteraction
+	if err := json.Unmarshal(payload, &in); err != nil {
+		return dec, "", "", false
+	}
+	if in.Type != "block_actions" || len(in.Actions) == 0 {
+		return dec, "", "", false
+	}
+	a := in.Actions[0]
+	var decision string
+	switch a.ActionID {
+	case approveActionID:
+		decision = "approve"
+	case rejectActionID:
+		decision = "reject"
+	default:
+		return dec, "", "", false // not our button
+	}
+	if a.Value == "" {
+		return dec, "", "", false
+	}
+	approver := in.User.Username
+	if approver == "" {
+		approver = in.User.Name
+	}
+	if approver == "" {
+		approver = in.User.ID
+	}
+	return channels.ApprovalDecision{
+		TaskID:   a.Value,
+		Decision: decision,
+		Approver: approver,
+	}, in.Channel.ID, in.Message.TS, true
+}
+
+// handleInteractive resolves an approval button click. No-op for interactions
+// that aren't ours. Best-effort updates the source message with the outcome.
+func (p *Plugin) handleInteractive(ctx context.Context, payload []byte) error {
+	dec, channelID, msgTS, ok := parseApprovalInteraction(payload)
+	if !ok {
+		return nil // not a forge approval interaction; ignore quietly
+	}
+	if p.approvalResolver == nil {
+		return fmt.Errorf("approval click for task %s but no resolver wired", dec.TaskID)
+	}
+	if err := p.approvalResolver(ctx, dec); err != nil {
+		// e.g. the deferral already resolved or timed out (404/409). Surface it
+		// on the message so the approver isn't left guessing.
+		p.updateApprovalMessage(channelID, msgTS, fmt.Sprintf(":warning: could not record %s: %v", dec.Decision, err))
+		return err
+	}
+	p.updateApprovalMessage(channelID, msgTS, approvalOutcomeText(dec))
+	return nil
+}
+
+// approvalOutcomeText is the message body that replaces the buttons after a
+// decision.
+func approvalOutcomeText(d channels.ApprovalDecision) string {
+	icon := ":white_check_mark:"
+	verb := "approved"
+	if d.Decision == "reject" {
+		icon, verb = ":no_entry:", "rejected"
+	}
+	return fmt.Sprintf("%s %s by @%s", icon, verb, d.Approver)
+}
+
+// updateApprovalMessage replaces the approval message's blocks with a plain
+// outcome line via chat.update. Best-effort — a failure to update the UI must
+// not affect the (already-recorded) decision.
+func (p *Plugin) updateApprovalMessage(channelID, msgTS, text string) {
+	if channelID == "" || msgTS == "" {
+		return
+	}
+	body, _ := json.Marshal(map[string]any{
+		"channel": channelID,
+		"ts":      msgTS,
+		"text":    text,
+		"blocks":  []any{map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": text}}},
+	})
+	req, err := http.NewRequest(http.MethodPost, p.apiBase+"/chat.update", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.botToken)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}

--- a/forge-plugins/channels/slack/approvals.go
+++ b/forge-plugins/channels/slack/approvals.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/initializ/forge/forge-core/channels"
@@ -31,21 +34,138 @@ func (p *Plugin) SetApprovalResolver(r channels.ApprovalResolver) {
 }
 
 // DeliverApproval posts a Block Kit Approve/Reject message to req.Target (a
-// Slack channel like "#oncall"). The buttons carry the task id so the click
-// can be routed back to the deferral. Delivery failure is returned to the
-// caller (the runtime logs it, non-fatal — the approver can still POST the
-// decision directly).
+// Slack channel ID like "C0123ABC5" or a name like "#oncall"). The buttons
+// carry the task id so the click can be routed back to the deferral. Delivery
+// failure is returned to the caller (the runtime logs it, non-fatal — the
+// approver can still POST the decision directly).
 func (p *Plugin) DeliverApproval(ctx context.Context, req channels.ApprovalRequest) error {
 	if req.Target == "" {
 		return fmt.Errorf("slack DeliverApproval: empty target channel")
 	}
-	return p.postMessage(buildApprovalPayload(req))
+	channelID, err := p.resolveChannelID(ctx, req.Target)
+	if err != nil {
+		return fmt.Errorf("slack DeliverApproval: %w", err)
+	}
+	payload := buildApprovalPayload(req)
+	payload["channel"] = channelID
+	return p.postMessage(payload)
+}
+
+// channelIDPattern matches an encoded Slack channel/group/DM id (C…/G…/D…),
+// which chat.postMessage accepts directly. A "#name" or bare name is resolved.
+var channelIDPattern = regexp.MustCompile(`^[CGD][A-Z0-9]{6,}$`)
+
+// resolveChannelID turns a DEFER `to:` channel target into a Slack channel id.
+// An encoded id passes through unchanged (no API call). A "#name" or bare name
+// is resolved via conversations.list (public + private, matched
+// case-insensitively) and cached — Slack ids are stable across renames, so the
+// cache never goes stale on a rename. FAILS CLOSED: an unresolvable target
+// returns an error so an approval is never silently misrouted (needed because
+// chat.postMessage cannot address a PRIVATE channel by #name, and private is
+// the recommended approvals channel).
+func (p *Plugin) resolveChannelID(ctx context.Context, target string) (string, error) {
+	target = strings.TrimSpace(target)
+	name := strings.TrimPrefix(target, "#")
+	// No "#" prefix AND looks like an encoded id → already an id.
+	if target == name && channelIDPattern.MatchString(target) {
+		return target, nil
+	}
+	name = strings.ToLower(name)
+	if name == "" {
+		return "", fmt.Errorf("empty channel target")
+	}
+
+	p.chanMu.Lock()
+	if id, ok := p.chanIDCache[name]; ok {
+		p.chanMu.Unlock()
+		return id, nil
+	}
+	p.chanMu.Unlock()
+
+	id, err := p.lookupChannelID(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	p.chanMu.Lock()
+	if p.chanIDCache == nil {
+		p.chanIDCache = map[string]string{}
+	}
+	p.chanIDCache[name] = id
+	p.chanMu.Unlock()
+	return id, nil
+}
+
+type slackConversation struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// lookupChannelID pages through conversations.list to find the channel whose
+// name matches (case-insensitive). Bounded to 20 pages (≈20k channels) so a
+// pathological workspace can't spin forever. Requires the bot's channels:read
+// (public) + groups:read (private) scopes, and the bot must be a member.
+func (p *Plugin) lookupChannelID(ctx context.Context, name string) (string, error) {
+	cursor := ""
+	for range 20 { // bound ≈ 20k channels
+		convs, next, err := p.listConversations(ctx, cursor)
+		if err != nil {
+			return "", err
+		}
+		for _, c := range convs {
+			if strings.EqualFold(c.Name, name) {
+				return c.ID, nil
+			}
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return "", fmt.Errorf("channel %q not found — is the bot a member, and does it have channels:read + groups:read? (or use the channel id)", "#"+name)
+}
+
+// listConversations fetches one page of the workspace's public + private
+// channels the bot can see.
+func (p *Plugin) listConversations(ctx context.Context, cursor string) ([]slackConversation, string, error) {
+	q := url.Values{}
+	q.Set("types", "public_channel,private_channel")
+	q.Set("limit", "1000")
+	q.Set("exclude_archived", "true")
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.apiBase+"/conversations.list?"+q.Encode(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.botToken)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out struct {
+		OK               bool                `json:"ok"`
+		Error            string              `json:"error"`
+		Channels         []slackConversation `json:"channels"`
+		ResponseMetadata struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"response_metadata"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, "", fmt.Errorf("conversations.list decode: %w", err)
+	}
+	if !out.OK {
+		return nil, "", fmt.Errorf("conversations.list: %s", out.Error)
+	}
+	return out.Channels, out.ResponseMetadata.NextCursor, nil
 }
 
 // buildApprovalPayload renders the chat.postMessage body for an approval
-// request. Split out (pure) so tests can assert the Block Kit shape without a
-// live Slack. `text` is the notification fallback; the blocks carry the
-// interactive buttons whose `value` is the task id (the resolution key).
+// request (minus the `channel`, which DeliverApproval sets from the resolved
+// id). Split out (pure) so tests can assert the Block Kit shape without a live
+// Slack. `text` is the notification fallback; the blocks carry the interactive
+// buttons whose `value` is the task id (the resolution key).
 func buildApprovalPayload(req channels.ApprovalRequest) map[string]any {
 	summary := fmt.Sprintf("*Approval required* for `%s`", req.Tool)
 	detail := summary
@@ -56,8 +176,7 @@ func buildApprovalPayload(req channels.ApprovalRequest) map[string]any {
 		detail += fmt.Sprintf("\n_Auto-denies in %s._", req.Timeout.Round(time.Second))
 	}
 	return map[string]any{
-		"channel": req.Target,
-		"text":    fmt.Sprintf("Approval required for %s", req.Tool), // fallback / a11y
+		"text": fmt.Sprintf("Approval required for %s", req.Tool), // fallback / a11y
 		"blocks": []any{
 			map[string]any{
 				"type": "section",

--- a/forge-plugins/channels/slack/approvals_test.go
+++ b/forge-plugins/channels/slack/approvals_test.go
@@ -1,0 +1,198 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/initializ/forge/forge-core/channels"
+)
+
+// TestBuildApprovalPayload pins the Block Kit shape (#310): the target channel,
+// an accessible text fallback, and two buttons whose action_ids + value (task
+// id) drive resolution.
+func TestBuildApprovalPayload(t *testing.T) {
+	payload := buildApprovalPayload(channels.ApprovalRequest{
+		TaskID:  "task-42",
+		Tool:    "atlassian__jira_create_issue",
+		Context: "create issue in PROJ",
+		Timeout: 15 * time.Minute,
+		Target:  "#oncall",
+	})
+
+	if payload["channel"] != "#oncall" {
+		t.Errorf("channel = %v, want #oncall", payload["channel"])
+	}
+	if txt, _ := payload["text"].(string); !strings.Contains(txt, "atlassian__jira_create_issue") {
+		t.Errorf("fallback text missing tool: %q", txt)
+	}
+
+	// Re-marshal + walk to find the two buttons (avoids brittle type assertions).
+	raw, _ := json.Marshal(payload)
+	blob := string(raw)
+	for _, want := range []string{
+		`"block_id":"forge_defer:task-42"`,
+		`"action_id":"` + approveActionID + `"`,
+		`"action_id":"` + rejectActionID + `"`,
+		`"value":"task-42"`,
+		`"style":"primary"`,
+		`"style":"danger"`,
+		"create issue in PROJ",
+	} {
+		if !strings.Contains(blob, want) {
+			t.Errorf("block kit payload missing %q\n%s", want, blob)
+		}
+	}
+}
+
+func interactionJSON(actionID, taskID, username string) []byte {
+	m := map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U1", "username": username, "name": "Alice N"},
+		"actions": []any{map[string]any{
+			"action_id": actionID, "value": taskID, "type": "button",
+		}},
+		"channel": map[string]any{"id": "C1"},
+		"message": map[string]any{"ts": "1700000000.000100"},
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
+
+// TestParseApprovalInteraction covers the block_actions → decision mapping and
+// the ignore paths (not our buttons / wrong shape).
+func TestParseApprovalInteraction(t *testing.T) {
+	t.Run("approve", func(t *testing.T) {
+		d, ch, ts, ok := parseApprovalInteraction(interactionJSON(approveActionID, "task-7", "alice"))
+		if !ok || d.Decision != "approve" || d.TaskID != "task-7" || d.Approver != "alice" {
+			t.Fatalf("got %+v ok=%v", d, ok)
+		}
+		if ch != "C1" || ts != "1700000000.000100" {
+			t.Errorf("message locator wrong: ch=%q ts=%q", ch, ts)
+		}
+	})
+	t.Run("reject", func(t *testing.T) {
+		d, _, _, ok := parseApprovalInteraction(interactionJSON(rejectActionID, "task-7", "bob"))
+		if !ok || d.Decision != "reject" {
+			t.Fatalf("got %+v ok=%v", d, ok)
+		}
+	})
+	t.Run("approver falls back to name then id", func(t *testing.T) {
+		d, _, _, _ := parseApprovalInteraction(interactionJSON(approveActionID, "t", "")) // no username
+		if d.Approver != "Alice N" {
+			t.Errorf("approver fallback = %q, want name", d.Approver)
+		}
+	})
+	t.Run("not our button ignored", func(t *testing.T) {
+		if _, _, _, ok := parseApprovalInteraction(interactionJSON("some_other_app_action", "t", "x")); ok {
+			t.Error("a non-forge action_id must be ignored")
+		}
+	})
+	t.Run("wrong type ignored", func(t *testing.T) {
+		if _, _, _, ok := parseApprovalInteraction([]byte(`{"type":"view_submission"}`)); ok {
+			t.Error("non-block_actions must be ignored")
+		}
+	})
+	t.Run("empty task id ignored", func(t *testing.T) {
+		if _, _, _, ok := parseApprovalInteraction(interactionJSON(approveActionID, "", "x")); ok {
+			t.Error("empty value (task id) must be ignored")
+		}
+	})
+}
+
+// TestHandleInteractive_ResolvesAndUpdates: a button click invokes the wired
+// resolver with the right decision, then best-effort updates the message.
+func TestHandleInteractive_ResolvesAndUpdates(t *testing.T) {
+	var updated bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/chat.update") {
+			updated = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var got channels.ApprovalDecision
+	p := New()
+	p.apiBase = srv.URL
+	p.botToken = "xoxb-test"
+	p.SetApprovalResolver(func(_ context.Context, d channels.ApprovalDecision) error {
+		got = d
+		return nil
+	})
+
+	if err := p.handleInteractive(context.Background(), interactionJSON(approveActionID, "task-9", "carol")); err != nil {
+		t.Fatalf("handleInteractive: %v", err)
+	}
+	if got.TaskID != "task-9" || got.Decision != "approve" || got.Approver != "carol" {
+		t.Errorf("resolver got %+v", got)
+	}
+	if !updated {
+		t.Error("expected a chat.update to replace the buttons with the outcome")
+	}
+}
+
+// TestHandleInteractive_NoResolver errors (surfaced/logged by the caller) so a
+// misconfiguration is visible rather than silently dropping the approval.
+func TestHandleInteractive_NoResolver(t *testing.T) {
+	p := New()
+	if err := p.handleInteractive(context.Background(), interactionJSON(approveActionID, "t", "x")); err == nil {
+		t.Fatal("expected an error when no resolver is wired")
+	}
+}
+
+// TestHandleInteractive_IgnoresForeign returns nil (and doesn't call the
+// resolver) for interactions that aren't ours.
+func TestHandleInteractive_IgnoresForeign(t *testing.T) {
+	called := false
+	p := New()
+	p.SetApprovalResolver(func(context.Context, channels.ApprovalDecision) error { called = true; return nil })
+	if err := p.handleInteractive(context.Background(), []byte(`{"type":"shortcut"}`)); err != nil {
+		t.Fatalf("foreign interaction should be a no-op, got %v", err)
+	}
+	if called {
+		t.Error("resolver must not fire for a foreign interaction")
+	}
+}
+
+// TestDeliverApproval_PostsBlockKit: the send path posts a Block Kit message
+// with the buttons to chat.postMessage.
+func TestDeliverApproval_PostsBlockKit(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/chat.postMessage") {
+			body, _ = io.ReadAll(r.Body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := New()
+	p.apiBase = srv.URL
+	p.botToken = "xoxb-test"
+
+	err := p.DeliverApproval(context.Background(), channels.ApprovalRequest{
+		TaskID: "task-1", Tool: "cli_execute", Context: "kubectl delete pod x", Target: "#oncall",
+	})
+	if err != nil {
+		t.Fatalf("DeliverApproval: %v", err)
+	}
+	blob := string(body)
+	for _, want := range []string{`"channel":"#oncall"`, `"action_id":"` + approveActionID + `"`, `"value":"task-1"`, "kubectl delete pod x"} {
+		if !strings.Contains(blob, want) {
+			t.Errorf("posted message missing %q\n%s", want, blob)
+		}
+	}
+}
+
+// TestDeliverApproval_EmptyTarget guards the obvious misconfig.
+func TestDeliverApproval_EmptyTarget(t *testing.T) {
+	if err := New().DeliverApproval(context.Background(), channels.ApprovalRequest{TaskID: "t"}); err == nil {
+		t.Fatal("expected an error for an empty target channel")
+	}
+}

--- a/forge-plugins/channels/slack/approvals_test.go
+++ b/forge-plugins/channels/slack/approvals_test.go
@@ -25,8 +25,8 @@ func TestBuildApprovalPayload(t *testing.T) {
 		Target:  "#oncall",
 	})
 
-	if payload["channel"] != "#oncall" {
-		t.Errorf("channel = %v, want #oncall", payload["channel"])
+	if _, present := payload["channel"]; present {
+		t.Error("channel must be set by DeliverApproval (from the resolved id), not the builder")
 	}
 	if txt, _ := payload["text"].(string); !strings.Contains(txt, "atlassian__jira_create_issue") {
 		t.Errorf("fallback text missing tool: %q", txt)
@@ -160,16 +160,35 @@ func TestHandleInteractive_IgnoresForeign(t *testing.T) {
 	}
 }
 
-// TestDeliverApproval_PostsBlockKit: the send path posts a Block Kit message
-// with the buttons to chat.postMessage.
+// slackTestServer stands in for the Slack API: it resolves a fixed channel
+// (#oncall → C999, private) via conversations.list and captures the
+// chat.postMessage body. listCalls counts conversations.list hits (for the
+// cache test).
+func slackTestServer(t *testing.T, postBody *[]byte, listCalls *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/conversations.list"):
+			if listCalls != nil {
+				*listCalls++
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[{"id":"C999","name":"oncall"}],"response_metadata":{"next_cursor":""}}`))
+		case strings.HasSuffix(r.URL.Path, "/chat.postMessage"):
+			if postBody != nil {
+				*postBody, _ = io.ReadAll(r.Body)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// TestDeliverApproval_PostsBlockKit: the send path resolves the target name to
+// an id and posts a Block Kit message with the buttons to chat.postMessage.
 func TestDeliverApproval_PostsBlockKit(t *testing.T) {
 	var body []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/chat.postMessage") {
-			body, _ = io.ReadAll(r.Body)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
+	srv := slackTestServer(t, &body, nil)
 	defer srv.Close()
 
 	p := New()
@@ -183,11 +202,73 @@ func TestDeliverApproval_PostsBlockKit(t *testing.T) {
 		t.Fatalf("DeliverApproval: %v", err)
 	}
 	blob := string(body)
-	for _, want := range []string{`"channel":"#oncall"`, `"action_id":"` + approveActionID + `"`, `"value":"task-1"`, "kubectl delete pod x"} {
+	// #oncall resolved to its id C999 before posting.
+	for _, want := range []string{`"channel":"C999"`, `"action_id":"` + approveActionID + `"`, `"value":"task-1"`, "kubectl delete pod x"} {
 		if !strings.Contains(blob, want) {
 			t.Errorf("posted message missing %q\n%s", want, blob)
 		}
 	}
+}
+
+// TestResolveChannelID covers id passthrough (no API call), name → id
+// resolution (public + private), the cache, and fail-closed on not-found.
+func TestResolveChannelID(t *testing.T) {
+	t.Run("encoded id passes through without an API call", func(t *testing.T) {
+		p := New()
+		p.apiBase = "http://127.0.0.1:0" // any call would fail
+		for _, id := range []string{"C0123ABC5", "G0456DEF7", "D0789GHI9"} {
+			got, err := p.resolveChannelID(context.Background(), id)
+			if err != nil || got != id {
+				t.Errorf("resolveChannelID(%q) = (%q,%v), want passthrough", id, got, err)
+			}
+		}
+	})
+
+	t.Run("name resolves and caches", func(t *testing.T) {
+		var calls int
+		srv := slackTestServer(t, nil, &calls)
+		defer srv.Close()
+		p := New()
+		p.apiBase = srv.URL
+		p.botToken = "xoxb-test"
+
+		for _, in := range []string{"#oncall", "oncall", "#OnCall"} { // #, bare, mixed-case
+			got, err := p.resolveChannelID(context.Background(), in)
+			if err != nil || got != "C999" {
+				t.Fatalf("resolveChannelID(%q) = (%q,%v), want C999", in, got, err)
+			}
+		}
+		if calls != 1 {
+			t.Errorf("conversations.list called %d times, want 1 (cached)", calls)
+		}
+	})
+
+	t.Run("not found fails closed", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[],"response_metadata":{"next_cursor":""}}`))
+		}))
+		defer srv.Close()
+		p := New()
+		p.apiBase = srv.URL
+		p.botToken = "xoxb-test"
+		if _, err := p.resolveChannelID(context.Background(), "#ghost"); err == nil {
+			t.Fatal("expected an error for an unresolvable channel (fail closed)")
+		}
+	})
+
+	t.Run("slack API error surfaces", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope"}`))
+		}))
+		defer srv.Close()
+		p := New()
+		p.apiBase = srv.URL
+		p.botToken = "xoxb-test"
+		_, err := p.resolveChannelID(context.Background(), "#oncall")
+		if err == nil || !strings.Contains(err.Error(), "missing_scope") {
+			t.Fatalf("expected the slack error to surface, got %v", err)
+		}
+	})
 }
 
 // TestDeliverApproval_EmptyTarget guards the obvious misconfig.

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -50,6 +50,11 @@ type Plugin struct {
 	// logger is an optional structured ops logger (SetLogger). When set, the
 	// approval-resolution error path routes through it; nil → fmt.Printf.
 	logger channels.Logger
+
+	// chanIDCache memoizes resolved channel name → id for approval delivery
+	// (#310) so a repeated deferral to the same channel skips conversations.list.
+	chanMu      sync.Mutex
+	chanIDCache map[string]string
 }
 
 // SetLogger wires a structured ops logger (channels.LoggerAware). Optional.
@@ -68,9 +73,10 @@ func (p *Plugin) logWarn(msg string, fields map[string]any) {
 // New creates an uninitialised Slack plugin.
 func New() *Plugin {
 	return &Plugin{
-		client:     &http.Client{Timeout: 30 * time.Second},
-		apiBase:    slackAPIBase,
-		dedupCache: make(map[string]time.Time),
+		client:      &http.Client{Timeout: 30 * time.Second},
+		apiBase:     slackAPIBase,
+		dedupCache:  make(map[string]time.Time),
+		chanIDCache: make(map[string]string),
 	}
 }
 

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -46,6 +46,23 @@ type Plugin struct {
 	// interactive DEFER approval click resolves the deferred task (#310).
 	// nil when interactive approvals aren't wired.
 	approvalResolver channels.ApprovalResolver
+
+	// logger is an optional structured ops logger (SetLogger). When set, the
+	// approval-resolution error path routes through it; nil → fmt.Printf.
+	logger channels.Logger
+}
+
+// SetLogger wires a structured ops logger (channels.LoggerAware). Optional.
+func (p *Plugin) SetLogger(l channels.Logger) { p.logger = l }
+
+// logWarn routes an operational warning through the structured logger when set,
+// else falls back to the plugin's existing fmt.Printf style.
+func (p *Plugin) logWarn(msg string, fields map[string]any) {
+	if p.logger != nil {
+		p.logger.Warn(msg, fields)
+		return
+	}
+	fmt.Printf("  slack: %s %v\n", msg, fields)
 }
 
 // New creates an uninitialised Slack plugin.
@@ -370,7 +387,9 @@ func (p *Plugin) readLoop(ctx context.Context, conn *websocket.Conn, handler cha
 		// Approve/Reject buttons land here (#310). Already acked above.
 		if envelope.Type == "interactive" {
 			if err := p.handleInteractive(ctx, envelope.Payload); err != nil {
-				fmt.Printf("  slack: interactive handling error: %v\n", err)
+				// The approval-resolution error path — surface it on the
+				// structured ops stream when wired (#311 review).
+				p.logWarn("interactive approval handling failed", map[string]any{"error": err.Error()})
 			}
 			continue
 		}

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -41,6 +41,11 @@ type Plugin struct {
 	apiBase     string // overridable for tests
 	dedupMu     sync.Mutex
 	dedupCache  map[string]time.Time
+
+	// approvalResolver is wired by the runtime (SetApprovalResolver) so an
+	// interactive DEFER approval click resolves the deferred task (#310).
+	// nil when interactive approvals aren't wired.
+	approvalResolver channels.ApprovalResolver
 }
 
 // New creates an uninitialised Slack plugin.
@@ -358,6 +363,16 @@ func (p *Plugin) readLoop(ctx context.Context, conn *websocket.Conn, handler cha
 		if envelope.Type == "disconnect" {
 			fmt.Println("  slack: received disconnect, will reconnect")
 			return nil
+		}
+
+		// Interactive components (Block Kit button clicks) arrive as
+		// `interactive` envelopes, not `events_api`. DEFER approval
+		// Approve/Reject buttons land here (#310). Already acked above.
+		if envelope.Type == "interactive" {
+			if err := p.handleInteractive(ctx, envelope.Payload); err != nil {
+				fmt.Printf("  slack: interactive handling error: %v\n", err)
+			}
+			continue
 		}
 
 		if envelope.Type != "events_api" {


### PR DESCRIPTION
Closes #310.

## Problem

DEFER authorization (R4c, #211/#248) pauses a tool call and waits for a human to `POST /tasks/{id}/decisions` — but the tool's `security.defer.tools.<name>.to` value (e.g. `channel:slack:#oncall`) was **inert metadata**: written into the deferred task-status message and the `task_deferred` audit event, and nothing more. Operators had to build their own Slack↔decisions-endpoint bridge, which also needed a way to reach Forge inbound.

## Why the Slack adapter

Forge's Slack adapter connects via **Socket Mode** — `apps.connections.open` → an **outbound** WebSocket. So a button click arrives over the agent's existing outbound connection: **no inbound exposure to Forge is required**. The adapter runs in-process under `forge run --with slack`. It's the ideal delivery + resolution path.

## Change

- **`forge-core/channels`** — optional capability `ApprovalDeliverer { DeliverApproval(ctx, ApprovalRequest); SetApprovalResolver(ApprovalResolver) }` + `ApprovalRequest`/`ApprovalDecision` types. Adapters that don't implement it are unaffected (they just can't be a `to:` target).
- **`forge-plugins/channels/slack`** — implement it. `DeliverApproval` posts a **Block Kit** Approve/Reject message (button `value` = task id) to the `to:` channel; `readLoop` gains an `interactive` (`block_actions`) branch that parses the click → `ApprovalDecision` → the wired resolver → `chat.update` with the outcome + approver. Interactive envelopes were already acked before the `events_api` filter, so no ack change.
- **`forge-cli`** — `Runner.SetDeferralNotifier` (mirrors `SetScheduleNotifier`), called from the defer hook **best-effort, non-fatal** (a Slack outage must never auto-deny; the approver can still POST directly). `run.go` routes `to: channel:<adapter>:<target>` to the `ApprovalDeliverer` and sets a resolver that POSTs the decision to the existing `/tasks/{id}/decisions` endpoint — **topology-agnostic** (works in-process or via a separate `forge channel serve`), and reuses the tested handler + `deferEngine.Resolve` + audit.

```yaml
security:
  defer:
    enabled: true
    tools:
      atlassian__jira_create_issue:      # MCP tools register as <server>__<tool>
        to: channel:slack:#oncall        # channel:<adapter>:<target>
        timeout: 15m
        context_template: "Agent wants to run {tool} with args: {args}"
```

## Flow

```
deferred tool call → defer hook fires DeferralNotifier
   → Slack posts Block Kit "Approve / Reject" to #oncall   (outbound)
   → approver clicks → interactive envelope on the same WS  (outbound)
   → resolver POSTs {decision, approver} → /tasks/{id}/decisions
   → deferEngine.Resolve → tool proceeds (approve) or fails (reject/timeout)
   → Slack message updates: "✅ approved by @alice"
```

## Acceptance

- [x] Deferred call with `to: channel:slack:#oncall` posts a Block Kit Approve/Reject message.
- [x] Clicking resolves via `/tasks/{id}/decisions`; tool proceeds/fails; message updates with outcome + approver.
- [x] No inbound exposure (Socket Mode outbound).
- [x] Delivery failure logged, not fatal; direct `POST /tasks/{id}/decisions` still works.
- [x] Unit tests: Block Kit build, interactive→decision parse (+ ignore paths), resolver invocation + update, `DeliverApproval` send, `parseDeferTarget`, defer-hook notifier-fires + delivery-failure-non-fatal.

## Tests

`approvals_test.go` (Block Kit shape, `parseApprovalInteraction` table incl. foreign/empty ignores, `handleInteractive` resolver+update, no-resolver error, `DeliverApproval` posts to `chat.postMessage`), `run_test.go` (`parseDeferTarget`), `defer_test.go` (`TestDeferHook_FiresDeferralNotifier`, `TestDeferHook_NotifierFailureNonFatal`). Full `forge-plugins` + `forge-cli` suites pass; lint clean.

## Docs

`docs/security/defer-decisions.md` — the "Notify integration" section now documents the native Slack path (was "follow-up").

## Out of scope
- Argument-level defer (name-only today — #223).
- Cross-restart persistence of pending deferrals (in-process).
- Telegram / MS Teams interactive approvals (same `ApprovalDeliverer` interface; follow-up per adapter).
