### PR TITLE
feat(mcp): expand ${VAR} env placeholders in MCP config fields at load (closes #321)

### DIFF
--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -202,6 +202,37 @@ mcp:
       required: true
 ```
 
+#### Environment placeholders (#321)
+
+`${VAR}` / `$VAR` placeholders in the MCP connection fields — `url`,
+`client_id`, `authorize_url`, `token_url`, and `scopes` — are **expanded
+at load** from the process environment (and the `.env` file loaded by
+`forge run`), matching the egress-domain expansion semantics. This is how
+managed/platform mode ships a server: the generated `forge.yaml` bakes
+only the *shape* (literal `url` + placeholders), and the values are
+injected into the agent's env at deploy — so rotating a pinned client is
+a redeploy, not a rebuild.
+
+```yaml
+auth:
+  type: oauth
+  client_id: ${MCP_LINEAR_CLIENT_ID}
+  authorize_url: ${MCP_LINEAR_AUTHORIZE_URL}
+  token_url: ${MCP_LINEAR_TOKEN_URL}
+  scopes: ["${MCP_LINEAR_SCOPES}"]     # one var carrying "read write" → two scopes
+```
+
+- With all of `client_id`/`authorize_url`/`token_url` present after
+  expansion, resolution takes the **explicit** branch — no runtime
+  discovery or DCR (the managed-mode contract).
+- An **unset** variable expands to `""`, so the block reads as
+  *unconfigured* and falls to the discovery / fail-closed path — never a
+  literal `${…}` dial.
+- A single `scopes` entry is **split on whitespace** post-expansion, so
+  `${MCP_LINEAR_SCOPES}="read write"` becomes `[read, write]`.
+- `token_env` (for `bearer`/`static`) is **not** expanded — it is the
+  *name* of an env var, resolved at runtime.
+
 ### In-cluster MCP with bearer token from a K8s Secret
 
 ```yaml

--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -228,10 +228,22 @@ auth:
 - An **unset** variable expands to `""`, so the block reads as
   *unconfigured* and falls to the discovery / fail-closed path — never a
   literal `${…}` dial.
-- A single `scopes` entry is **split on whitespace** post-expansion, so
-  `${MCP_LINEAR_SCOPES}="read write"` becomes `[read, write]`.
+- A `scopes` entry is **split on whitespace** post-expansion, so
+  `${MCP_LINEAR_SCOPES}="read write"` becomes `[read, write]`. (The split
+  is unconditional — a literal `["read write"]` splits too; OAuth scopes
+  are space-delimited by RFC 6749, so a value never has an internal space.)
 - `token_env` (for `bearer`/`static`) is **not** expanded — it is the
   *name* of an env var, resolved at runtime.
+
+> ⚠️ **Keep `url` literal.** Although `url` accepts placeholders for
+> symmetry, the **build-time egress freeze** reads MCP hosts from the
+> config at *build* time — where the deploy env is unset, so a
+> `url: ${MCP_URL}` expands to `""`. That empty value fails the
+> `url is required for http transport` validation (a loud build error),
+> and even if it slipped through it wouldn't be in the frozen
+> `egress_allowlist.json` / NetworkPolicy, blocking the host at runtime in
+> a container. Managed mode keeps `url` literal and places placeholders
+> only on the auth fields — do the same.
 
 ### In-cluster MCP with bearer token from a K8s Secret
 

--- a/forge-cli/cmd/common.go
+++ b/forge-cli/cmd/common.go
@@ -26,6 +26,22 @@ func loadAndPrepareConfig(envFilePath string) (*types.ForgeConfig, string, error
 		cfgPath = filepath.Join(wd, cfgPath)
 	}
 
+	workDir := filepath.Dir(cfgPath)
+
+	// Load .env into the process environment BEFORE parsing forge.yaml so
+	// ${VAR} placeholders in the config (MCP connection fields, #321)
+	// expand at parse time — and so channel adapters can resolve env vars.
+	envPath := resolveEnvPath(workDir, envFilePath)
+	envVars, err := runtime.LoadEnvFile(envPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading env file: %w", err)
+	}
+	for k, v := range envVars {
+		if os.Getenv(k) == "" {
+			_ = os.Setenv(k, v)
+		}
+	}
+
 	cfg, err := config.LoadForgeConfig(cfgPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("loading config: %w", err)
@@ -37,25 +53,6 @@ func loadAndPrepareConfig(envFilePath string) (*types.ForgeConfig, string, error
 			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e)
 		}
 		return nil, "", fmt.Errorf("config validation failed: %d error(s)", len(result.Errors))
-	}
-
-	workDir := filepath.Dir(cfgPath)
-
-	// Resolve env file path relative to workdir
-	envPath := envFilePath
-	if !filepath.IsAbs(envPath) {
-		envPath = filepath.Join(workDir, envPath)
-	}
-
-	// Load .env into process environment so channel adapters can resolve env vars
-	envVars, err := runtime.LoadEnvFile(envPath)
-	if err != nil {
-		return nil, "", fmt.Errorf("loading env file: %w", err)
-	}
-	for k, v := range envVars {
-		if os.Getenv(k) == "" {
-			_ = os.Setenv(k, v)
-		}
 	}
 
 	// Prompt for passphrase if encrypted secrets are configured but passphrase is missing.

--- a/forge-cli/cmd/mcp.go
+++ b/forge-cli/cmd/mcp.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/initializ/forge/forge-cli/config"
+	"github.com/initializ/forge/forge-cli/runtime"
 	"github.com/initializ/forge/forge-core/mcp"
 	"github.com/initializ/forge/forge-core/types"
 	"github.com/initializ/forge/forge-core/validate"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // mcpCmd is the root for "forge mcp" subcommands. Phase 1 ships
@@ -84,15 +85,26 @@ func loadForgeConfig(cmd *cobra.Command) (*types.ForgeConfig, error) {
 		wd, _ := os.Getwd()
 		path = filepath.Join(wd, path)
 	}
-	data, err := os.ReadFile(path)
+	// Load .env into the process env BEFORE parsing so ${VAR} placeholders
+	// in MCP connection fields (#321) expand here too — laptop-time
+	// `forge mcp login` must resolve the same placeholders the runtime
+	// does, or a managed `client_id: ${…}` reaches the OAuth flow as a
+	// literal. Best-effort: a missing .env is fine.
+	if envVars, err := runtime.LoadEnvFile(resolveEnvPath(filepath.Dir(path), ".env")); err == nil {
+		for k, v := range envVars {
+			if os.Getenv(k) == "" {
+				_ = os.Setenv(k, v)
+			}
+		}
+	}
+	// config.LoadForgeConfig → types.ParseForgeConfig expands the
+	// placeholders and checks required fields; then run the full validator
+	// for the mcp-specific error messages (review B14).
+	cfg, err := config.LoadForgeConfig(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", path, err)
+		return nil, err
 	}
-	var cfg types.ForgeConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", path, err)
-	}
-	result := validate.ValidateForgeConfig(&cfg)
+	result := validate.ValidateForgeConfig(cfg)
 	if !result.IsValid() {
 		return nil, fmt.Errorf("%s is invalid:\n  - %s", path,
 			strings.Join(result.Errors, "\n  - "))
@@ -101,7 +113,7 @@ func loadForgeConfig(cmd *cobra.Command) (*types.ForgeConfig, error) {
 	for _, w := range result.Warnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
-	return &cfg, nil
+	return cfg, nil
 }
 
 // findServerSpec returns the MCPServer entry for the given name, or

--- a/forge-cli/cmd/mcp_env_test.go
+++ b/forge-cli/cmd/mcp_env_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadForgeConfig_ExpandsMCPEnv verifies the mcp-subcommand loader
+// (used by `forge mcp login`/`list`/`test`) routes through ParseForgeConfig
+// so ${VAR} placeholders in MCP fields expand — #323 review finding 1. The
+// bug was that `mcp.go:loadForgeConfig` did a raw yaml.Unmarshal, so a
+// managed `client_id: ${…}` reached the OAuth flow as a literal string.
+func TestLoadForgeConfig_ExpandsMCPEnv(t *testing.T) {
+	const y = `
+agent_id: a
+version: 0.1.0
+framework: custom
+entrypoint: /bin/true
+mcp:
+  servers:
+    - name: linear
+      transport: http
+      url: https://mcp.linear.app/mcp
+      auth:
+        type: oauth
+        client_id: ${MCP_LOGIN_CID}
+        authorize_url: https://as/authorize
+        token_url: https://as/token
+      tools: { allow: ["*"] }
+`
+	writeCfg := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "forge.yaml"), []byte(y), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return filepath.Join(dir, "forge.yaml")
+	}
+	withCfgFile := func(path string) func() {
+		old := cfgFile
+		cfgFile = path
+		return func() { cfgFile = old }
+	}
+
+	t.Run("from process env", func(t *testing.T) {
+		p := writeCfg(t)
+		t.Setenv("MCP_LOGIN_CID", "cid-from-env")
+		defer withCfgFile(p)()
+		cfg, err := loadForgeConfig(nil)
+		if err != nil {
+			t.Fatalf("loadForgeConfig: %v", err)
+		}
+		if got := cfg.MCP.Servers[0].Auth.ClientID; got != "cid-from-env" {
+			t.Errorf("client_id = %q, want expanded from the process env", got)
+		}
+	})
+
+	t.Run("from .env file — login must resolve .env too", func(t *testing.T) {
+		p := writeCfg(t)
+		if err := os.WriteFile(filepath.Join(filepath.Dir(p), ".env"), []byte("MCP_LOGIN_CID=cid-from-dotenv\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("MCP_LOGIN_CID", "") // present-but-empty → .env value fills it
+		defer withCfgFile(p)()
+		cfg, err := loadForgeConfig(nil)
+		if err != nil {
+			t.Fatalf("loadForgeConfig: %v", err)
+		}
+		if got := cfg.MCP.Servers[0].Auth.ClientID; got != "cid-from-dotenv" {
+			t.Errorf("client_id = %q, want expanded from the .env file", got)
+		}
+	})
+}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -957,11 +957,13 @@ func expandEnvRef(s string) string {
 	return os.Expand(s, os.Getenv)
 }
 
-// expandScopeRefs expands each scope entry and splits any post-expansion
+// expandScopeRefs expands each scope entry and splits its (post-expansion)
 // value on whitespace — so a single `${…_SCOPES}` carrying "read write"
-// becomes two scopes (OAuth scopes are space-delimited by RFC 6749, so a
-// value never legitimately contains an internal space). Empty entries
-// are dropped.
+// becomes two scopes. The split is UNCONDITIONAL: a literal
+// `scopes: ["read write"]` (no `$`) also becomes ["read", "write"]. That
+// is intentional and safe — OAuth scopes are space-delimited by RFC 6749,
+// so a single scope value never legitimately contains an internal space.
+// Empty entries are dropped.
 func expandScopeRefs(in []string) []string {
 	if len(in) == 0 {
 		return in

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -3,6 +3,8 @@ package types
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/initializ/forge/forge-core/credentials"
@@ -904,6 +906,12 @@ func ParseForgeConfig(data []byte) (*ForgeConfig, error) {
 		return nil, fmt.Errorf("parsing forge config: %w", err)
 	}
 
+	// Expand ${VAR}/$VAR env placeholders in MCP connection fields at
+	// parse time (#321) — so every consumer (runner, mcp login/test,
+	// validate, security.MCPDomains, the build pipeline) sees resolved
+	// values, and the egress allowlist is computed from real hosts.
+	expandMCPEnv(&cfg)
+
 	if cfg.AgentID == "" {
 		return nil, fmt.Errorf("forge config: agent_id is required")
 	}
@@ -915,4 +923,52 @@ func ParseForgeConfig(data []byte) (*ForgeConfig, error) {
 	}
 
 	return &cfg, nil
+}
+
+// expandMCPEnv expands ${VAR}/$VAR env placeholders in MCP connection
+// fields against the process env (os.Expand semantics, matching the
+// egress-domain expansion) — #321.
+//
+// An unset variable expands to "" (os.Expand default): a fully-unset
+// oauth block then reads as "unconfigured" and correctly falls to the
+// discovery / fail-closed paths rather than dialing a literal `${…}` URL.
+//
+// TokenEnv is intentionally NOT expanded — it is the NAME of an env var,
+// resolved at runtime, not a value.
+func expandMCPEnv(cfg *ForgeConfig) {
+	for i := range cfg.MCP.Servers {
+		s := &cfg.MCP.Servers[i]
+		s.URL = expandEnvRef(s.URL)
+		if s.Auth != nil {
+			s.Auth.ClientID = expandEnvRef(s.Auth.ClientID)
+			s.Auth.AuthorizeURL = expandEnvRef(s.Auth.AuthorizeURL)
+			s.Auth.TokenURL = expandEnvRef(s.Auth.TokenURL)
+			s.Auth.Scopes = expandScopeRefs(s.Auth.Scopes)
+		}
+	}
+}
+
+// expandEnvRef expands ${VAR}/$VAR in s against the process env. A
+// string with no `$` is returned unchanged; an unset var expands to "".
+func expandEnvRef(s string) string {
+	if !strings.Contains(s, "$") {
+		return s
+	}
+	return os.Expand(s, os.Getenv)
+}
+
+// expandScopeRefs expands each scope entry and splits any post-expansion
+// value on whitespace — so a single `${…_SCOPES}` carrying "read write"
+// becomes two scopes (OAuth scopes are space-delimited by RFC 6749, so a
+// value never legitimately contains an internal space). Empty entries
+// are dropped.
+func expandScopeRefs(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, strings.Fields(expandEnvRef(s))...)
+	}
+	return out
 }

--- a/forge-core/types/config_mcpenv_test.go
+++ b/forge-core/types/config_mcpenv_test.go
@@ -84,6 +84,32 @@ func TestParseForgeConfig_UnsetMCPEnv(t *testing.T) {
 	}
 }
 
+// TestParseForgeConfig_LiteralScopeSplit pins the intentional behavior
+// (#323 review finding 3): a literal, space-containing scopes entry is
+// split on whitespace too — not only an expanded `${SCOPES}`.
+func TestParseForgeConfig_LiteralScopeSplit(t *testing.T) {
+	const y = `
+agent_id: a
+version: 0.1.0
+framework: custom
+entrypoint: /bin/true
+mcp:
+  servers:
+    - name: linear
+      transport: http
+      url: https://x/mcp
+      auth: { type: oauth, scopes: ["read write"] }
+      tools: { allow: ["*"] }
+`
+	cfg, err := ParseForgeConfig([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.MCP.Servers[0].Auth.Scopes; !reflect.DeepEqual(got, []string{"read", "write"}) {
+		t.Errorf("literal space-scope = %v, want [read write] (unconditional split is intended)", got)
+	}
+}
+
 // TestParseForgeConfig_TokenEnvNotExpanded: TokenEnv is a NAME, not a
 // value — it must survive verbatim even when it looks like a placeholder.
 func TestParseForgeConfig_TokenEnvNotExpanded(t *testing.T) {

--- a/forge-core/types/config_mcpenv_test.go
+++ b/forge-core/types/config_mcpenv_test.go
@@ -1,0 +1,147 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+// baseMCPYAML is a minimal valid forge.yaml with one oauth MCP server
+// whose connection fields are ${VAR} placeholders (#321).
+const baseMCPYAML = `
+agent_id: a
+version: 0.1.0
+framework: custom
+entrypoint: /bin/true
+mcp:
+  servers:
+    - name: linear
+      transport: http
+      url: ${MCP_LINEAR_URL}
+      auth:
+        type: oauth
+        client_id: ${MCP_LINEAR_CLIENT_ID}
+        authorize_url: ${MCP_LINEAR_AUTHORIZE_URL}
+        token_url: ${MCP_LINEAR_TOKEN_URL}
+        scopes: ["${MCP_LINEAR_SCOPES}"]
+      tools: { allow: [create_issue] }
+`
+
+// TestParseForgeConfig_ExpandsMCPEnv: with the vars set, the placeholders
+// expand to their values and one whitespace-joined scopes var splits into
+// multiple scopes — the managed-mode "explicit config" shape.
+func TestParseForgeConfig_ExpandsMCPEnv(t *testing.T) {
+	t.Setenv("MCP_LINEAR_URL", "https://mcp.linear.app/mcp")
+	t.Setenv("MCP_LINEAR_CLIENT_ID", "dyn-abc")
+	t.Setenv("MCP_LINEAR_AUTHORIZE_URL", "https://mcp.linear.app/authorize")
+	t.Setenv("MCP_LINEAR_TOKEN_URL", "https://mcp.linear.app/token")
+	t.Setenv("MCP_LINEAR_SCOPES", "read write")
+
+	cfg, err := ParseForgeConfig([]byte(baseMCPYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	s := cfg.MCP.Servers[0]
+	if s.URL != "https://mcp.linear.app/mcp" {
+		t.Errorf("URL not expanded: %q", s.URL)
+	}
+	if s.Auth.ClientID != "dyn-abc" {
+		t.Errorf("client_id not expanded: %q", s.Auth.ClientID)
+	}
+	if s.Auth.AuthorizeURL != "https://mcp.linear.app/authorize" {
+		t.Errorf("authorize_url not expanded: %q", s.Auth.AuthorizeURL)
+	}
+	if s.Auth.TokenURL != "https://mcp.linear.app/token" {
+		t.Errorf("token_url not expanded: %q", s.Auth.TokenURL)
+	}
+	if !reflect.DeepEqual(s.Auth.Scopes, []string{"read", "write"}) {
+		t.Errorf("scopes = %v, want [read write] (single var split on whitespace)", s.Auth.Scopes)
+	}
+}
+
+// TestParseForgeConfig_UnsetMCPEnv: with the vars unset, placeholders
+// expand to "" — so the oauth block reads as unconfigured (discovery /
+// fail-closed at login), never a literal `${…}` dial.
+func TestParseForgeConfig_UnsetMCPEnv(t *testing.T) {
+	// Ensure the vars are unset for this test.
+	for _, k := range []string{"MCP_LINEAR_URL", "MCP_LINEAR_CLIENT_ID", "MCP_LINEAR_AUTHORIZE_URL", "MCP_LINEAR_TOKEN_URL", "MCP_LINEAR_SCOPES"} {
+		t.Setenv(k, "") // set-then-empty; Setenv restores original after the test
+	}
+	cfg, err := ParseForgeConfig([]byte(baseMCPYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	s := cfg.MCP.Servers[0]
+	for name, got := range map[string]string{
+		"url": s.URL, "client_id": s.Auth.ClientID,
+		"authorize_url": s.Auth.AuthorizeURL, "token_url": s.Auth.TokenURL,
+	} {
+		if got != "" {
+			t.Errorf("%s = %q, want empty (unset var must not survive as a literal ${…})", name, got)
+		}
+	}
+	if len(s.Auth.Scopes) != 0 {
+		t.Errorf("scopes = %v, want empty (unset var drops)", s.Auth.Scopes)
+	}
+}
+
+// TestParseForgeConfig_TokenEnvNotExpanded: TokenEnv is a NAME, not a
+// value — it must survive verbatim even when it looks like a placeholder.
+func TestParseForgeConfig_TokenEnvNotExpanded(t *testing.T) {
+	t.Setenv("SOME_TOKEN", "should-not-be-substituted")
+	const y = `
+agent_id: a
+version: 0.1.0
+framework: custom
+entrypoint: /bin/true
+mcp:
+  servers:
+    - name: internal
+      transport: http
+      url: http://x
+      auth:
+        type: bearer
+        token_env: SOME_TOKEN
+      tools: { allow: ["*"] }
+`
+	cfg, err := ParseForgeConfig([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.MCP.Servers[0].Auth.TokenEnv; got != "SOME_TOKEN" {
+		t.Errorf("token_env = %q, want the literal name SOME_TOKEN (must not be expanded)", got)
+	}
+}
+
+// TestParseForgeConfig_LiteralMCPUnchanged: a config with no placeholders
+// round-trips unchanged (no accidental splitting/rewriting).
+func TestParseForgeConfig_LiteralMCPUnchanged(t *testing.T) {
+	const y = `
+agent_id: a
+version: 0.1.0
+framework: custom
+entrypoint: /bin/true
+mcp:
+  servers:
+    - name: linear
+      transport: http
+      url: https://mcp.linear.app/mcp
+      auth:
+        type: oauth
+        client_id: static-id
+        authorize_url: https://as/authorize
+        token_url: https://as/token
+        scopes: [read, write]
+      tools: { allow: ["*"] }
+`
+	cfg, err := ParseForgeConfig([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	s := cfg.MCP.Servers[0]
+	if s.URL != "https://mcp.linear.app/mcp" || s.Auth.ClientID != "static-id" {
+		t.Errorf("literal fields altered: %+v", s.Auth)
+	}
+	if !reflect.DeepEqual(s.Auth.Scopes, []string{"read", "write"}) {
+		t.Errorf("literal scopes altered: %v", s.Auth.Scopes)
+	}
+}


### PR DESCRIPTION
Closes #321.

## Problem

`docs/mcp/configuration.md` documented env placeholders in MCP config (`client_id: ${LINEAR_OAUTH_CLIENT_ID}`), but nothing expanded them — `ParseForgeConfig` was a plain `yaml.Unmarshal`, so a `${…}` survived as a literal string and broke at runtime.

This is now load-bearing for managed mode (initializ/agent-builder#80): the platform resolves + pins a server's OAuth chain at **admission** (RFC 9728→8414, one DCR client per #320) and bakes only the **shape** into `forge.yaml` — literal `url` + placeholders — injecting the values into the agent's env at deploy. Rotating the pinned client becomes a redeploy, not a rebuild.

## Change

Expand `${VAR}` / `$VAR` (`os.Expand` against the process env, same semantics as `expandEgressDomains`) in **`ParseForgeConfig`** — the single parse choke point, so every consumer (runner, `mcp login`/`test`, validate, `security.MCPDomains`, the build pipeline) sees resolved values and the egress allowlist is computed from real hosts, not placeholder strings.

Expanded:
- `MCPServer.URL`
- `MCPAuth.ClientID` / `AuthorizeURL` / `TokenURL`
- each `MCPAuth.Scopes` entry, **split on whitespace** post-expansion (one `${…_SCOPES}` carrying `"read write"` → `[read, write]`; OAuth scopes are space-delimited by RFC 6749, so a value never legitimately contains a space)

Not expanded:
- `MCPAuth.TokenEnv` — it is the **name** of an env var, resolved at runtime, by design.

**Ordering:** `loadAndPrepareConfig` now loads `.env` into the process env **before** parsing `forge.yaml` (previously it loaded `.env` *after* the parse), so the documented `.env`-based example expands at parse time.

## Semantics

| Case | Result |
|---|---|
| All of `client_id`/`authorize_url`/`token_url` set post-expansion | `resolveOAuthConfig` **explicit** branch — no runtime discovery/DCR (managed contract) |
| Vars unset → placeholders expand to `""` | Block reads as **unconfigured** → discovery at login / fail-closed refresh — never a literal `${…}` dial |
| `security.MCPDomains` | Sees expanded hosts (expansion runs at parse, before the allowlist is computed) |

## Acceptance

- [x] Managed `forge.yaml` (shape + placeholders) + env set → explicit branch, verbatim endpoints, no discovery/DCR.
- [x] Same yaml, env unset → behaves as unconfigured oauth (discovery at login only), never a literal-`${…}` dial.
- [x] `security.MCPDomains` sees expanded values (expansion at parse time).
- [x] The documented `configuration.md` example actually works (`.env` loaded before parse).

## Tests

`config_mcpenv_test.go`: expand-all (incl. whitespace scope split), unset→empty (no literal `${…}`), `token_env`-not-expanded, literal-config-unchanged. Full `types` / `security` / `validate` + `cli cmd`/`runtime` suites pass; lint clean.

## Docs

`configuration.md` — new **Environment placeholders (#321)** section documenting the expanded fields, the managed shape-vs-values split, unset→discovery, whitespace scope split, and the `token_env` exception.
