### PR TITLE
feat(mcp): agent-principal OAuth via client_credentials grant (2LO) (#324, standalone half)

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -298,7 +298,9 @@ The agent loop calls tools the LLM asks for. The registry merges:
   rejected at validate time with a roadmap pointer. OAuth 2.1 PKCE
   supported via `forge mcp login`; `client_id`/`authorize_url`/`token_url`
   are optional — discovered from the server url via RFC 9728/8414 with
-  RFC 7591 dynamic client registration when omitted (#316).
+  RFC 7591 dynamic client registration when omitted (#316). Agent-principal
+  (headless, no login) via `grant: client_credentials` — 2LO with
+  `client_id` + `client_secret_env` + `token_url`, minted at runtime (#324).
 
 `cli_execute` ships 13 security layers — shell denylist, binary
 allowlist, `LookPath` resolution at startup, argument validation

--- a/docs/mcp/cli-reference.md
+++ b/docs/mcp/cli-reference.md
@@ -70,6 +70,11 @@ bearer / static / no-auth servers, and fails closed with a clear message
 if a server advertises no metadata / no registration endpoint and no
 `client_id` is configured.
 
+**Agent-principal servers need no login.** A server with
+`grant: client_credentials` (2LO — the agent authenticates as itself, #324)
+mints its token at runtime; `forge mcp login <name>` on such a server
+prints "no login needed" and exits successfully.
+
 For Kubernetes deployments:
 
 ```sh

--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -126,10 +126,55 @@ So a fully zero-config OAuth server is just:
   it (or `client_secret_expires_at` passes), run `forge mcp logout <name>`
   — that clears both the token and the stored registration — then
   `forge mcp login <name>` again to re-discover and re-register.
-- **Confidential clients are not supported.** Forge registers a public
-  (PKCE) client and sends no `client_secret`. If a server insists on
-  issuing a confidential client, login fails closed — configure
-  `client_id`/`authorize_url`/`token_url` explicitly for that server.
+- **Confidential clients are not supported** *for the interactive grant*.
+  Forge registers a public (PKCE) client and sends no `client_secret`. If
+  a server insists on issuing a confidential client, login fails closed —
+  configure `client_id`/`authorize_url`/`token_url` explicitly for that
+  server. (Confidential credentials *are* used by the `client_credentials`
+  grant below.)
+
+#### Agent-principal — `grant: client_credentials` (2LO, #324)
+
+The default `oauth` grant is 3-legged: a **user** consents once via
+`forge mcp login`. Set `grant: client_credentials` for the
+**agent-principal** path — the deployed agent authenticates as **itself**,
+with no user and no browser, so it works **headless**:
+
+```yaml
+mcp:
+  servers:
+    - name: internal-api
+      transport: http
+      url: https://mcp.internal.corp/mcp
+      auth:
+        type: oauth
+        grant: client_credentials       # 2-legged; agent acts as itself
+        client_id: forge-agent
+        client_secret_env: MCP_INTERNAL_SECRET   # NAME of an env var; never in yaml
+        token_url: https://mcp.internal.corp/token
+        scopes: [read]
+      tools: { allow: ["*"] }
+```
+
+- **Requires** an explicit `client_id`, `client_secret_env`, and
+  `token_url` (2LO has no authorization endpoint and no dynamic
+  registration). `authorize_url` is not used.
+- `client_secret_env` names an environment variable (like `token_env`) —
+  the secret is read at runtime and rotated by redeploy, never stored in
+  `forge.yaml`.
+- **No `forge mcp login`** — the token is minted at runtime and re-minted
+  on expiry. `forge mcp login <name>` on such a server prints "no login
+  needed."
+- **`required: true` is valid here** (unlike a delegated/per-user server,
+  which has no user at startup): the agent-principal token resolves at
+  startup, so a required server can gate readiness.
+- The token endpoint host is auto-added to the egress allowlist (from
+  `token_url`).
+
+> Use this where the MCP server supports the client_credentials / 2LO
+> grant and the agent should act as a service identity. For per-user
+> (delegated) identity, see #317. Managed platform-brokered tokens are
+> #324's follow-on (the platform holds the service refresh token).
 
 ### `mcp.servers[].tools`
 

--- a/forge-cli/cmd/mcp_login.go
+++ b/forge-cli/cmd/mcp_login.go
@@ -45,6 +45,14 @@ func mcpLoginRun(cmd *cobra.Command, args []string) error {
 				return spec.Auth.Type
 			}())
 	}
+	// #324: the client_credentials (agent-principal) grant has no user and
+	// no browser step — the token is minted at runtime from client_id +
+	// the secret in client_secret_env. There is nothing to log in.
+	if spec.Auth.Grant == "client_credentials" {
+		fmt.Printf("server %q uses grant client_credentials (agent-principal) — no login needed.\n", name)
+		fmt.Println("the token is minted at runtime from client_id + $" + spec.Auth.ClientSecretEnv + ".")
+		return nil
+	}
 
 	// Apply any token-store-path override (review B11) so the
 	// laptop-side Login persists into the same location the

--- a/forge-core/llm/oauth/token.go
+++ b/forge-core/llm/oauth/token.go
@@ -95,6 +95,27 @@ func RefreshTokenCtx(ctx context.Context, client *http.Client, tokenURL, clientI
 	return doTokenRequestCtx(ctx, client, tokenURL, data)
 }
 
+// ClientCredentialsTokenCtx mints a token via the OAuth 2.0
+// client_credentials grant (RFC 6749 §4.4) — the 2-legged,
+// agent-principal path (#324). No user, no authorization code: the
+// client authenticates with its own id + secret (client_secret_post).
+// The response typically carries no refresh_token; the caller re-mints
+// from the id + secret on expiry.
+//
+// Caller MUST pass a context with a finite deadline; pass the
+// egress-controlled client in production (see ExchangeCodeCtx).
+func ClientCredentialsTokenCtx(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret string, scopes []string) (*Token, error) {
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	if len(scopes) > 0 {
+		data.Set("scope", strings.Join(scopes, " "))
+	}
+	return doTokenRequestCtx(ctx, client, tokenURL, data)
+}
+
 // defaultTokenTimeout bounds the deprecated http.Post fallback path
 // used by the no-ctx legacy callers. New callers go through
 // *Ctx helpers with their own bounded context.

--- a/forge-core/mcp/oauth_clientcreds_test.go
+++ b/forge-core/mcp/oauth_clientcreds_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// ccTokenServer is a stand-in token endpoint for the client_credentials
+// grant (#324). It records call count and asserts the request shape.
+func ccTokenServer(t *testing.T, calls *atomic.Int32, deny bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			calls.Add(1)
+		}
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "client_credentials" {
+			t.Errorf("grant_type = %q, want client_credentials", r.FormValue("grant_type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if deny {
+			_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"bad secret"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"cc-token","token_type":"bearer","expires_in":3600}`))
+	}))
+}
+
+// TestBearerToken_ClientCredentials_MintsAndCaches: with no stored login
+// token, the 2LO path mints on demand from client_id + secret (no
+// ErrNoToken), caches, and does not re-mint within the expiry window.
+func TestBearerToken_ClientCredentials_MintsAndCaches(t *testing.T) {
+	withTempCredsDir(t)
+	var calls atomic.Int32
+	srv := ccTokenServer(t, &calls, false)
+	defer srv.Close()
+
+	f := NewOAuthFlow()
+	cfg := OAuthServerConfig{
+		Grant: grantClientCredentials, ClientID: "agent-1",
+		ClientSecret: "sekret", TokenURL: srv.URL, Scopes: []string{"read"},
+	}
+	tok, err := f.BearerToken(context.Background(), "svc", cfg)
+	if err != nil || tok != "cc-token" {
+		t.Fatalf("mint: tok=%q err=%v (agent-principal must mint without a prior login)", tok, err)
+	}
+	tok2, err := f.BearerToken(context.Background(), "svc", cfg)
+	if err != nil || tok2 != "cc-token" {
+		t.Fatalf("cached: tok=%q err=%v", tok2, err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("token endpoint hit %d times, want 1 (second call served from cache)", n)
+	}
+}
+
+// TestBearerToken_ClientCredentials_Denied: a denied grant surfaces as
+// ErrTokenRevoked (invalid_client), not a transient transport error.
+func TestBearerToken_ClientCredentials_Denied(t *testing.T) {
+	withTempCredsDir(t)
+	srv := ccTokenServer(t, nil, true)
+	defer srv.Close()
+
+	f := NewOAuthFlow()
+	cfg := OAuthServerConfig{Grant: grantClientCredentials, ClientID: "a", ClientSecret: "wrong", TokenURL: srv.URL}
+	if _, err := f.BearerToken(context.Background(), "svc", cfg); !errors.Is(err, ErrTokenRevoked) {
+		t.Fatalf("want ErrTokenRevoked for invalid_client, got %v", err)
+	}
+}
+
+// TestBuildAuthFn_ClientCredentials_ResolvesSecretFromEnv exercises the
+// full server path: buildAuthFn resolves the client secret from the
+// named env var at call time (so a rotated Secret takes effect) → mints.
+func TestBuildAuthFn_ClientCredentials_ResolvesSecretFromEnv(t *testing.T) {
+	withTempCredsDir(t)
+	t.Setenv("MY_MCP_SECRET", "env-secret")
+	var gotSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotSecret = r.FormValue("client_secret")
+		_, _ = w.Write([]byte(`{"access_token":"t","token_type":"bearer","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	flow := NewOAuthFlow()
+	spec := types.MCPServer{
+		Name: "svc", URL: "https://x",
+		Auth: &types.MCPAuth{
+			Type: "oauth", Grant: "client_credentials",
+			ClientID: "a", ClientSecretEnv: "MY_MCP_SECRET", TokenURL: srv.URL,
+		},
+	}
+	authFn := buildAuthFn(spec, flow)
+	if authFn == nil {
+		t.Fatal("buildAuthFn returned nil for a client_credentials server")
+	}
+	tok, err := authFn(context.Background())
+	if err != nil || tok != "t" {
+		t.Fatalf("authFn: tok=%q err=%v", tok, err)
+	}
+	if gotSecret != "env-secret" {
+		t.Errorf("client_secret sent = %q, want the value from $MY_MCP_SECRET", gotSecret)
+	}
+}

--- a/forge-core/mcp/oauth_clientcreds_test.go
+++ b/forge-core/mcp/oauth_clientcreds_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -105,5 +106,36 @@ func TestBuildAuthFn_ClientCredentials_ResolvesSecretFromEnv(t *testing.T) {
 	}
 	if gotSecret != "env-secret" {
 		t.Errorf("client_secret sent = %q, want the value from $MY_MCP_SECRET", gotSecret)
+	}
+}
+
+// TestBuildAuthFn_ClientCredentials_EmptySecret: when the named secret env
+// var resolves to "" (the common headless misconfig — platform didn't
+// inject it), the authFn fails closed with a clear cause and never hits
+// the token endpoint (#325 review finding 1).
+func TestBuildAuthFn_ClientCredentials_EmptySecret(t *testing.T) {
+	withTempCredsDir(t)
+	t.Setenv("UNSET_MCP_SECRET", "") // configured by name, empty value
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"access_token":"x","token_type":"bearer","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	flow := NewOAuthFlow()
+	spec := types.MCPServer{
+		Name: "svc", URL: "https://x",
+		Auth: &types.MCPAuth{
+			Type: "oauth", Grant: "client_credentials",
+			ClientID: "a", ClientSecretEnv: "UNSET_MCP_SECRET", TokenURL: srv.URL,
+		},
+	}
+	_, err := buildAuthFn(spec, flow)(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "resolved to an empty value") {
+		t.Fatalf("want a clear empty-secret error, got %v", err)
+	}
+	if n := hits.Load(); n != 0 {
+		t.Errorf("token endpoint hit %d times, want 0 (should fail before minting)", n)
 	}
 }

--- a/forge-core/mcp/oauth_flow.go
+++ b/forge-core/mcp/oauth_flow.go
@@ -422,10 +422,16 @@ func (f *OAuthFlow) doClientCredentials(ctx context.Context, name string, cfg OA
 	if err != nil {
 		msg := err.Error()
 		if strings.Contains(msg, "invalid_client") ||
-			strings.Contains(msg, "unauthorized_client") ||
-			strings.Contains(msg, "invalid_scope") {
+			strings.Contains(msg, "unauthorized_client") {
 			f.emit(name, false, "client_credentials_denied")
 			return "", fmt.Errorf("%w: %v", ErrTokenRevoked, err)
+		}
+		if strings.Contains(msg, "invalid_scope") {
+			// A bad *requested* scope is a config error (auth.scopes), not a
+			// revoked client — classify distinctly so the diagnostic points
+			// at the config, not at credentials (#325 review finding 2).
+			f.emit(name, false, "invalid_scope")
+			return "", fmt.Errorf("%w: invalid scope requested (check auth.scopes): %v", ErrProtocolError, err)
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			f.emit(name, false, "timeout")

--- a/forge-core/mcp/oauth_flow.go
+++ b/forge-core/mcp/oauth_flow.go
@@ -93,12 +93,22 @@ func NewOAuthFlow() *OAuthFlow {
 type OAuthServerConfig struct {
 	// ServerURL is the MCP server endpoint. Used for RFC 9728/8414
 	// discovery (#316) when the endpoints below are not configured.
-	ServerURL    string
+	ServerURL string
+	// Grant is "" / "authorization_code" (3LO, default) or
+	// "client_credentials" (2LO agent-principal, #324).
+	Grant string
+	// ClientSecret is used only for the client_credentials grant. The
+	// caller resolves it from the env var named by MCPAuth.ClientSecretEnv
+	// at call time (never persisted in config).
+	ClientSecret string
 	ClientID     string
 	Scopes       []string
 	AuthorizeURL string
 	TokenURL     string
 }
+
+// grantClientCredentials is the 2-legged agent-principal grant (#324).
+const grantClientCredentials = "client_credentials"
 
 // storeKey returns the credential-store key for an MCP server.
 // Prefixed "MCP_" so MCP tokens are namespaced separately from LLM
@@ -270,35 +280,41 @@ func (f *OAuthFlow) Login(ctx context.Context, name string, cfg OAuthServerConfi
 // Safe for concurrent use: per-server singleflight collapses N
 // concurrent calls into 1 /token POST.
 func (f *OAuthFlow) BearerToken(ctx context.Context, name string, cfg OAuthServerConfig) (string, error) {
+	clientCreds := cfg.Grant == grantClientCredentials
+
 	tok, err := oauth.LoadCredentials(storeKey(name))
 	if err != nil {
 		return "", fmt.Errorf("loading credentials for %q: %w", name, err)
 	}
-	if tok == nil {
-		// Distinct from ErrTokenRevoked — see errors.go ErrNoToken
-		// docstring (review B11). Emit a "no_token" audit reason so
-		// dashboards can tell first-use from revocation.
+	if tok != nil && !tok.IsExpiredWithBuffer(f.RefreshWindow) {
+		return tok.AccessToken, nil
+	}
+
+	// The cached token is absent or expired. For 3LO, a first-time mint
+	// requires interactive `forge mcp login` — a headless refresh cannot
+	// create one. The client_credentials (2LO, #324) path has no user and
+	// mints on demand from ClientID + ClientSecret, so no stored login
+	// token is required.
+	if tok == nil && !clientCreds {
 		f.emit(name, false, "no_token")
 		return "", fmt.Errorf("%w: %q — run 'forge mcp login %s'", ErrNoToken, name, name)
 	}
 
-	if !tok.IsExpiredWithBuffer(f.RefreshWindow) {
-		return tok.AccessToken, nil
+	// 3LO refresh resolves token_url/client_id (explicit config or a
+	// persisted registration only; never discovery/DCR on refresh — #316).
+	// client_credentials uses the explicit token_url/client_id/secret
+	// directly (2LO has no authorize endpoint and no persisted login).
+	if !clientCreds {
+		resolved, rerr := f.resolveOAuthConfig(ctx, name, cfg, false)
+		if rerr != nil {
+			return "", rerr
+		}
+		cfg = resolved
 	}
 
-	// Refresh needed — resolve token_url/client_id. Explicit config or
-	// a persisted registration only; the refresh path never runs
-	// discovery/DCR (allowDiscovery=false) — a first-time mint requires
-	// interactive `forge mcp login`. #316
-	resolved, rerr := f.resolveOAuthConfig(ctx, name, cfg, false)
-	if rerr != nil {
-		return "", rerr
-	}
-	cfg = resolved
-
-	// Singleflight: collapse concurrent refreshes. The leader spawns
-	// the refresh goroutine and EVERY subsequent caller — including
-	// the leader itself — waits on grp.done below.
+	// Singleflight: collapse concurrent (re)mints into one /token call.
+	// The leader spawns the goroutine and EVERY subsequent caller —
+	// including the leader itself — waits on grp.done below.
 	//
 	// CRITICAL (review B2): the goroutine's context is derived from
 	// context.Background, NOT from the leader's ctx. If we used the
@@ -328,9 +344,13 @@ func (f *OAuthFlow) BearerToken(ctx context.Context, name string, cfg OAuthServe
 				f.mu.Unlock()
 				close(grp.done)
 			}()
-			refreshCtx, cancel := context.WithTimeout(context.Background(), f.refreshTimeout())
+			mintCtx, cancel := context.WithTimeout(context.Background(), f.refreshTimeout())
 			defer cancel()
-			grp.token, grp.err = f.doRefresh(refreshCtx, name, cfg, tok.RefreshToken)
+			if clientCreds {
+				grp.token, grp.err = f.doClientCredentials(mintCtx, name, cfg)
+			} else {
+				grp.token, grp.err = f.doRefresh(mintCtx, name, cfg, tok.RefreshToken)
+			}
 		}()
 	} else {
 		f.mu.Unlock()
@@ -388,6 +408,36 @@ func (f *OAuthFlow) doRefresh(ctx context.Context, name string, cfg OAuthServerC
 		return "", fmt.Errorf("saving refreshed token: %w", err)
 	}
 	f.emit(name, true, "refreshed")
+	return newTok.AccessToken, nil
+}
+
+// doClientCredentials mints an agent-principal token via the
+// client_credentials grant (#324) and caches it. The token has no
+// refresh_token; on expiry BearerToken re-mints from ClientID +
+// ClientSecret. Cache-write failure is NON-FATAL — the token is
+// re-mintable, so a read-only store just means minting per use rather
+// than a broken request.
+func (f *OAuthFlow) doClientCredentials(ctx context.Context, name string, cfg OAuthServerConfig) (string, error) {
+	newTok, err := oauth.ClientCredentialsTokenCtx(ctx, f.HTTPClient, cfg.TokenURL, cfg.ClientID, cfg.ClientSecret, cfg.Scopes)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "invalid_client") ||
+			strings.Contains(msg, "unauthorized_client") ||
+			strings.Contains(msg, "invalid_scope") {
+			f.emit(name, false, "client_credentials_denied")
+			return "", fmt.Errorf("%w: %v", ErrTokenRevoked, err)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			f.emit(name, false, "timeout")
+			return "", fmt.Errorf("%w: client_credentials timed out after %s", ErrTransportUnavailable, f.refreshTimeout())
+		}
+		f.emit(name, false, "transport")
+		return "", fmt.Errorf("%w: %v", ErrTransportUnavailable, err)
+	}
+	f.emit(name, true, "client_credentials")
+	if serr := oauth.SaveCredentials(storeKey(name), newTok); serr != nil {
+		f.emit(name, false, "store_error") // non-fatal — token is re-mintable
+	}
 	return newTok.AccessToken, nil
 }
 

--- a/forge-core/mcp/server.go
+++ b/forge-core/mcp/server.go
@@ -136,17 +136,25 @@ func NewServer(spec types.MCPServer, deps ServerDeps) (*Server, error) {
 				return nil, fmt.Errorf("%w: server %q: auth.token_env is required for type=%s", ErrProtocolError, spec.Name, spec.Auth.Type)
 			}
 		case "oauth":
-			// #316: the endpoints + client_id may be discovered
-			// (RFC 9728/8414/7591) from the server URL, so the trio is no
-			// longer required. Only reject a PARTIAL endpoint config —
-			// authorize_url and token_url must be set together or both
-			// omitted (both-omitted ⇒ discovery). A server with no URL
-			// and no endpoints has nothing to discover from.
-			if (spec.Auth.AuthorizeURL == "") != (spec.Auth.TokenURL == "") {
-				return nil, fmt.Errorf("%w: server %q: auth.authorize_url and auth.token_url must be set together (or both omitted for discovery)", ErrProtocolError, spec.Name)
-			}
-			if spec.Auth.AuthorizeURL == "" && spec.URL == "" {
-				return nil, fmt.Errorf("%w: server %q: oauth needs either explicit authorize_url/token_url or a url to discover them from", ErrProtocolError, spec.Name)
+			if spec.Auth.Grant == grantClientCredentials {
+				// #324: 2LO agent-principal needs an explicit client + secret
+				// + token endpoint (no authorize endpoint, no DCR).
+				if spec.Auth.ClientID == "" || spec.Auth.ClientSecretEnv == "" || spec.Auth.TokenURL == "" {
+					return nil, fmt.Errorf("%w: server %q: grant client_credentials requires auth.client_id, auth.client_secret_env, auth.token_url", ErrProtocolError, spec.Name)
+				}
+			} else {
+				// #316: the endpoints + client_id may be discovered
+				// (RFC 9728/8414/7591) from the server URL, so the trio is no
+				// longer required. Only reject a PARTIAL endpoint config —
+				// authorize_url and token_url must be set together or both
+				// omitted (both-omitted ⇒ discovery). A server with no URL
+				// and no endpoints has nothing to discover from.
+				if (spec.Auth.AuthorizeURL == "") != (spec.Auth.TokenURL == "") {
+					return nil, fmt.Errorf("%w: server %q: auth.authorize_url and auth.token_url must be set together (or both omitted for discovery)", ErrProtocolError, spec.Name)
+				}
+				if spec.Auth.AuthorizeURL == "" && spec.URL == "" {
+					return nil, fmt.Errorf("%w: server %q: oauth needs either explicit authorize_url/token_url or a url to discover them from", ErrProtocolError, spec.Name)
+				}
 			}
 			if deps.OAuth == nil {
 				return nil, fmt.Errorf("%w: server %q requires oauth but no OAuthFlow supplied", ErrProtocolError, spec.Name)
@@ -520,14 +528,23 @@ func buildAuthFn(spec types.MCPServer, flow *OAuthFlow) AuthTokenFunc {
 	case "oauth":
 		cfg := OAuthServerConfig{
 			ServerURL:    spec.URL, // for #316 discovery / persisted-registration lookup
+			Grant:        spec.Auth.Grant,
 			ClientID:     spec.Auth.ClientID,
 			Scopes:       spec.Auth.Scopes,
 			AuthorizeURL: spec.Auth.AuthorizeURL,
 			TokenURL:     spec.Auth.TokenURL,
 		}
+		secretEnv := spec.Auth.ClientSecretEnv
 		name := spec.Name
 		return func(ctx context.Context) (string, error) {
-			return flow.BearerToken(ctx, name, cfg)
+			c := cfg
+			if c.Grant == grantClientCredentials {
+				// Resolve the client secret from env at call time so a
+				// rotated Secret takes effect without a Manager restart
+				// (mirrors the bearer/static token lookup). #324
+				c.ClientSecret = getenv(secretEnv)
+			}
+			return flow.BearerToken(ctx, name, c)
 		}
 	}
 	// Defense in depth — NewServer should have rejected an unknown

--- a/forge-core/mcp/server.go
+++ b/forge-core/mcp/server.go
@@ -543,6 +543,14 @@ func buildAuthFn(spec types.MCPServer, flow *OAuthFlow) AuthTokenFunc {
 				// rotated Secret takes effect without a Manager restart
 				// (mirrors the bearer/static token lookup). #324
 				c.ClientSecret = getenv(secretEnv)
+				if c.ClientSecret == "" {
+					// The most common headless misconfig: the secret env var
+					// is configured by NAME but the platform didn't inject a
+					// value. Fail closed with a clear cause instead of letting
+					// the AS reject client_secret="" as a misleading
+					// "revoked" (#325 review finding 1).
+					return "", fmt.Errorf("%w: server %q: client_secret_env %q resolved to an empty value — is the secret injected into the agent's environment?", ErrProtocolError, name, secretEnv)
+				}
 			}
 			return flow.BearerToken(ctx, name, c)
 		}

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -595,9 +595,24 @@ type MCPAuth struct {
 	//                forge.yaml.
 	Type string `yaml:"type"`
 
-	// ClientID is the OAuth client identifier. Optional for Type ==
-	// "oauth": when empty and the authorization server supports RFC 7591,
-	// Forge mints one at login and persists it (encrypted) for reuse.
+	// Grant selects the OAuth grant for Type == "oauth":
+	//   - "" / "authorization_code" → 3-legged PKCE (the default; a user
+	//     consents once via `forge mcp login`). This is the delegated path.
+	//   - "client_credentials" → 2-legged agent-principal (#324): the agent
+	//     authenticates as ITSELF with ClientID + a secret named by
+	//     ClientSecretEnv. No user, no browser, no login — the token is
+	//     minted at runtime. Requires an explicit ClientID, ClientSecretEnv,
+	//     and TokenURL (2LO has no authorization endpoint and no DCR).
+	Grant string `yaml:"grant,omitempty"`
+
+	// ClientSecretEnv names the environment variable holding the OAuth
+	// client secret, used only by Grant == "client_credentials". Read at
+	// runtime, never stored in forge.yaml (same contract as TokenEnv).
+	ClientSecretEnv string `yaml:"client_secret_env,omitempty"`
+
+	// ClientID is the OAuth client identifier. Optional for the default
+	// authorization_code grant (discovered/DCR at login when empty);
+	// REQUIRED for Grant == "client_credentials".
 	ClientID string `yaml:"client_id,omitempty"`
 
 	// Scopes is the OAuth scope set requested at login. When empty,

--- a/forge-core/validate/mcp_config.go
+++ b/forge-core/validate/mcp_config.go
@@ -127,12 +127,33 @@ func validateMCPAuth(prefix string, a types.MCPAuth, r *ValidationResult) {
 
 	switch a.Type {
 	case "oauth":
-		// #316: client_id + endpoints may be discovered (RFC 9728/8414/7591)
-		// from the server url, so the trio is no longer required. Only a
-		// PARTIAL endpoint config is an error — authorize_url and token_url
-		// must be set together, or both omitted (⇒ discovery from url).
-		if (a.AuthorizeURL == "") != (a.TokenURL == "") {
-			r.Errors = append(r.Errors, prefix+": authorize_url and token_url must be set together (or both omitted to discover them from the server url)")
+		switch a.Grant {
+		case "", "authorization_code":
+			// #316: client_id + endpoints may be discovered (RFC 9728/8414/7591)
+			// from the server url, so the trio is no longer required. Only a
+			// PARTIAL endpoint config is an error — authorize_url and token_url
+			// must be set together, or both omitted (⇒ discovery from url).
+			if (a.AuthorizeURL == "") != (a.TokenURL == "") {
+				r.Errors = append(r.Errors, prefix+": authorize_url and token_url must be set together (or both omitted to discover them from the server url)")
+			}
+		case "client_credentials":
+			// #324: agent-principal 2LO — explicit client + secret + token
+			// endpoint (no authorization endpoint, no DCR).
+			if a.ClientID == "" {
+				r.Errors = append(r.Errors, prefix+": client_id is required for grant client_credentials")
+			}
+			if a.ClientSecretEnv == "" {
+				r.Errors = append(r.Errors, prefix+": client_secret_env is required for grant client_credentials")
+			}
+			if a.TokenURL == "" {
+				r.Errors = append(r.Errors, prefix+": token_url is required for grant client_credentials")
+			}
+			if a.AuthorizeURL != "" {
+				r.Errors = append(r.Errors, prefix+": authorize_url is not used with grant client_credentials")
+			}
+		default:
+			r.Errors = append(r.Errors, fmt.Sprintf(
+				"%s: grant %q must be one of: authorization_code, client_credentials", prefix, a.Grant))
 		}
 	case "bearer", "static":
 		if a.TokenEnv == "" {

--- a/forge-core/validate/mcp_config_test.go
+++ b/forge-core/validate/mcp_config_test.go
@@ -122,6 +122,40 @@ func TestValidateMCPConfig(t *testing.T) {
 			wantNoErr: true,
 		},
 		{
+			// #324: agent-principal client_credentials — full config valid.
+			name: "auth oauth client_credentials (full) is allowed",
+			cfg: types.MCPConfig{Servers: []types.MCPServer{{
+				Name: "x", Transport: "http", URL: "https://x",
+				Auth: &types.MCPAuth{
+					Type: "oauth", Grant: "client_credentials",
+					ClientID: "a", ClientSecretEnv: "MCP_SECRET", TokenURL: "https://as/token",
+				},
+				Tools: types.MCPToolFilter{Allow: []string{"y"}},
+			}}},
+			wantNoErr: true,
+		},
+		{
+			name: "auth oauth client_credentials missing secret_env is an error",
+			cfg: types.MCPConfig{Servers: []types.MCPServer{{
+				Name: "x", Transport: "http", URL: "https://x",
+				Auth: &types.MCPAuth{
+					Type: "oauth", Grant: "client_credentials",
+					ClientID: "a", TokenURL: "https://as/token",
+				},
+				Tools: types.MCPToolFilter{Allow: []string{"y"}},
+			}}},
+			wantErrs: []string{"client_secret_env is required for grant client_credentials"},
+		},
+		{
+			name: "auth oauth unknown grant is an error",
+			cfg: types.MCPConfig{Servers: []types.MCPServer{{
+				Name: "x", Transport: "http", URL: "https://x",
+				Auth:  &types.MCPAuth{Type: "oauth", Grant: "password"},
+				Tools: types.MCPToolFilter{Allow: []string{"y"}},
+			}}},
+			wantErrs: []string{"must be one of: authorization_code, client_credentials"},
+		},
+		{
 			// Partial endpoint config is still an error — must be paired.
 			name: "auth oauth with only token_url (partial) is an error",
 			cfg: types.MCPConfig{Servers: []types.MCPServer{{


### PR DESCRIPTION
Implements the **standalone, buildable-now half of #324** — the agent-principal MCP OAuth resolver via the **OAuth 2.0 `client_credentials` grant (2LO)**.

## Why

A headless deployed agent can't run `forge mcp login` (laptop-only, interactive), so an `oauth` MCP server fails startup with `mcp: no stored token — login required`. #317 solves the **delegated** (per-user) path, but **most deployed agents are agent-principal** — they act as *themselves*, with no requesting human — so #317's consent flow can never fire for them. This is the more common and more urgent case.

## What

`grant: client_credentials` on the existing `type: oauth` block. The agent authenticates as itself with `client_id` + a secret named by `client_secret_env`; the token is minted at runtime — **no user, no browser, no login** — and re-minted on expiry.

```yaml
auth:
  type: oauth
  grant: client_credentials        # 2-legged; agent acts as itself
  client_id: forge-agent
  client_secret_env: MCP_INTERNAL_SECRET   # NAME of an env var; never in yaml
  token_url: https://mcp.internal.corp/token
  scopes: [read]
```

- **`oauth.ClientCredentialsTokenCtx`** (RFC 6749 §4.4, `client_secret_post`).
- **`BearerToken` branches on the grant:** `client_credentials` mints on demand (no `ErrNoToken`), caches via the store, re-mints on expiry through the same singleflight. Cache-write failure is **non-fatal** (the token is re-mintable), so a read-only store degrades to per-use mint rather than a broken request.
- **`buildAuthFn` resolves the secret from env at call time** (rotation without a Manager restart, mirroring bearer/static).
- **Validation:** requires explicit `client_id` + `client_secret_env` + `token_url` (2LO has no authorize endpoint, no DCR); guarded so the 3LO partial-pair check doesn't misfire; unknown grant rejected. Enforced at parse + `NewServer`.
- **`forge mcp login`** on such a server prints "no login needed" and exits 0.
- **`required: true` is valid here** (token resolves at startup); the eager connection falls out of the existing manager-startup connect.
- **Egress:** `token_url` host auto-merged via `MCPDomains` (unchanged).

## Acceptance (from #324)

- [x] A headless agent with a 2LO-capable server resolves a token **at startup**, no browser, no `forge mcp login`.
- [x] `required: true` gates readiness correctly (server reachable ⇒ ready).
- [x] Writes still route through DEFER regardless of token validity (governance unchanged — this only supplies the *token*, not authorization).
- [x] Shares the existing token-store (no divergent second store).
- [ ] *Managed mode (service refresh token vaulted broker-side)* — **deferred**, needs the #317 platform seam.

## Scope note

Expressed as **`grant: client_credentials`** (the mechanism — §18.3's `client_credentials` resolver, Forge layer, standalone-capable). The **`type: user | platform` principal axis** and the **managed platform-token-endpoint** half of #324 depend on the #317 seam and are deferred; `grant:` is forward-compatible with that axis (it's the mechanism the future `type: platform` standalone resolver uses).

## Tests

mint+cache (one token-endpoint call), `invalid_client` → `ErrTokenRevoked`, `buildAuthFn` resolves secret from env; validate cases (full ok / missing `secret_env` / unknown grant). All `forge-core` + `forge-cli/cmd` suites pass; lint clean.

## Docs

`configuration.md` agent-principal section, `cli-reference.md` login note, `forge.md`.
