### PR TITLE
fix(mcp): platform token requests send Org-Id/Workspace-Id tenancy headers

### DIFF
--- a/forge-core/mcp/platform_token.go
+++ b/forge-core/mcp/platform_token.go
@@ -98,6 +98,19 @@ func (p *platformTokenSource) fetch(ctx context.Context) (string, time.Duration,
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+identity)
+	// Tenancy headers, exactly as the admission + remote-session-store
+	// clients send them: the platform verifies a PER-ORG HS256 token, so it
+	// needs Org-Id to select the signing secret BEFORE it can validate the
+	// bearer (without this the endpoint 401s "missing org-id header"), and
+	// Workspace-Id to authorize the request against the entry (entitlement).
+	// Read from the standard FORGE_ORG_ID / FORGE_WORKSPACE_ID env the
+	// platform always injects; omitted when empty (standalone/dev).
+	if org := os.Getenv("FORGE_ORG_ID"); org != "" {
+		req.Header.Set("Org-Id", org)
+	}
+	if ws := os.Getenv("FORGE_WORKSPACE_ID"); ws != "" {
+		req.Header.Set("Workspace-Id", ws)
+	}
 
 	client := p.client
 	if client == nil {

--- a/forge-core/mcp/platform_token_test.go
+++ b/forge-core/mcp/platform_token_test.go
@@ -16,9 +16,19 @@ import (
 // server ref, and can emit a (forbidden) refresh_token.
 func newFakeResolver(t *testing.T, expiresIn int, includeRefresh bool) (*httptest.Server, *int) {
 	t.Helper()
+	t.Setenv("FORGE_ORG_ID", "org-42")
+	t.Setenv("FORGE_WORKSPACE_ID", "ws-7")
 	hits := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits++
+		// Tenancy headers must ride along so the platform can select the
+		// per-org HS256 secret + authorize the workspace (the "missing
+		// org-id header" 401 fix).
+		if r.Header.Get("Org-Id") != "org-42" || r.Header.Get("Workspace-Id") != "ws-7" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "missing org-id header"})
+			return
+		}
 		if r.Header.Get("Authorization") != "Bearer agent-cred-1" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return


### PR DESCRIPTION
Follow-up to #326 (merged). Found live on the FanDuel testbed — a deployed agent's `auth.type=platform` read fails at startup:

```
initialize: mcp: protocol error: platform token endpoint returned 401 for
server "mcp.atlassian": {"error":"missing org-id header"}
```

## Cause

The platform token endpoint verifies a **per-org HS256** token (the workspace `FORGE_PLATFORM_TOKEN`), so it needs `Org-Id` to select the signing secret **before** it can validate the bearer — and `Workspace-Id` to authorize the request against the registry entry (the entitlement check). `platform_token.go` sent only `Authorization: Bearer`, so the request 401s before verification, and the required read server backs off in a degraded loop.

## Fix

Send `Org-Id` + `Workspace-Id` from the standard `FORGE_ORG_ID` / `FORGE_WORKSPACE_ID` env the platform always injects (omitted when empty for standalone/dev) — **exactly** as the admission client (`admission_loader.go`) and the remote session-store client (`remote_session_store.go`) already do. This is the established Forge→platform tenancy-header convention; the platform token client just wasn't following it.

Test updated: the fake resolver now rejects a request missing the tenancy headers, so the regression is covered.

## Rollout

The fix is in the agent **runtime**, so a deployed agent picks it up on its next **rebuild** with a forge runtime that includes this (e.g. `AGENT_FORGE_VERSION=vnext` once the edge build publishes from main). No agent-builder platform-side change needed — its token endpoint was correct (requiring `org-id` is right for per-org HS256 verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)