### PR TITLE
feat(mcp): per-user connection lifecycle — pool + routing seam + materialized type=user servers (#317 increments 1–3)

### DIFF
--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -102,29 +102,66 @@ mcp:
   is valid.
 - **`type: user`** (#317) — delegated. Forge resolves the **requesting user's**
   identity from the authenticated request and POSTs `{server: <ref>, subject}`,
-  so each user gets **their own** token (cached per subject). It is **inherently
-  lazy**: `required: true` is rejected (there is no user at startup), and until
-  the platform has a grant for that user the call fails auth-required — the
-  server simply carries no tools for a user who hasn't consented yet.
+  so each user gets **their own** token *and its own connection*. It is
+  **inherently lazy**: `required: true` is rejected (there is no user at
+  startup), and until the platform has a grant for that user the call fails
+  auth-required.
+- **`tools.schemas`** is **required** for `type: user` — the server has no
+  connection at startup (no user), so it can't run `tools/list`. The platform
+  **materializes** the tool schemas from the registry entry into config, and
+  Forge registers them without a live connection; the per-user connection is
+  established lazily on the first call. See [Materialized tool schemas](#materialized-tool-schemas-317).
 - **`ref`** names the platform tool-registry entry the token is authorized
   against (defaults to the server name).
 - **Egress:** the platform token-endpoint host is auto-merged into the
   allowlist.
 
-> ⚠️ **Isolation boundary (today).** `type: user` currently resolves a
-> per-user **token on each call**; the underlying MCP **connection is still
-> shared** across users (per-subject connection isolation is a follow-up).
-> A **stateless** MCP server that re-authorizes on every request honors the
-> per-call token, so this gives real per-user isolation. A **session-stateful**
-> server that binds identity at `initialize` may not re-scope the session
-> when the per-call token changes — so confirm your MCP server re-authorizes
-> per request before relying on `type: user` for hard isolation against such
-> a server.
+> **Per-user connection isolation.** For `type: user`, Forge establishes one
+> MCP **connection per requesting user** — the connection's `initialize` runs
+> under that user's token, so identity is bound at the connection level, not
+> just per call. This holds even for a **session-stateful** server that binds
+> identity at `initialize`: user A's calls ride user A's session, user B's ride
+> B's. Connections are established lazily (first call) and per subject.
 
 > The platform materializes both the `platform` block and the per-identity
 > server entries (same URL, split by `type`). For the **standalone** (no
 > platform) equivalents, use `type: oauth` — 3-legged `forge mcp login` for a
 > user, or `grant: client_credentials` for an agent-principal (above).
+
+#### Materialized tool schemas (#317)
+
+A `type: user` server can't discover tools at startup (no user ⇒ no
+connection), so its tools are declared under `tools.schemas` — the platform
+materializes them from the tool-registry entry. Forge registers them without
+a live connection; `allow`/`deny` still filter this set.
+
+```yaml
+mcp:
+  servers:
+    - name: atlassian-write
+      transport: http
+      url: https://mcp.atlassian.com/mcp
+      auth: { type: user, ref: mcp.atlassian }
+      required: false
+      tools:
+        allow: ["*"]
+        schemas:                    # platform-materialized; no live tools/list
+          - name: create_issue
+            description: Create a Jira issue
+            input_schema:
+              type: object
+              properties:
+                project: { type: string }
+                summary: { type: string }
+              required: [project, summary]
+```
+
+- Each schema is `name` + optional `description` + `input_schema` (a JSON
+  Schema authored as YAML; an omitted `input_schema` defaults to
+  `{"type":"object"}`). Names are validated exactly as discovered tools are —
+  non-empty and no `__` (the namespace separator).
+- The first call by a user establishes that user's connection lazily and runs
+  `initialize` under their token; subsequent calls reuse it.
 
 #### OAuth discovery & dynamic client registration (#316)
 

--- a/docs/mcp/configuration.md
+++ b/docs/mcp/configuration.md
@@ -163,6 +163,18 @@ mcp:
 - The first call by a user establishes that user's connection lazily and runs
   `initialize` under their token; subsequent calls reuse it.
 
+> **The schema set is a global declaration — per-user access is enforced at
+> call time.** `tools.schemas` (and the `allow`/`deny` filter) is the same for
+> every user: it's what the server *can* expose. A user whose platform grant
+> doesn't cover a materialized tool still sees it registered, so the LLM may
+> attempt it and get a **runtime auth error from that user's own connection** —
+> the per-user gate is the connection, not registration.
+
+> **Staleness.** Materialized schemas are a snapshot. If the MCP server's real
+> tool set changes, the `tools.schemas` in `forge.yaml` is stale until the
+> platform re-materializes the registry entry (a redeploy) — the same
+> snapshot semantics as the `allow: ["*"]` discovery filter.
+
 #### OAuth discovery & dynamic client registration (#316)
 
 For `type: oauth`, `client_id` / `authorize_url` / `token_url` are all

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1021,6 +1021,7 @@ func (r *Runner) Run(ctx context.Context) error {
 						Server:     h.Server,
 						Descriptor: h.Descriptor,
 						Client:     h.Client,
+						Resolver:   h.Resolver, // per-call client resolution (#317)
 						Audit:      auditLogger,
 					})
 					if ctorErr != nil {

--- a/forge-core/mcp/manager.go
+++ b/forge-core/mcp/manager.go
@@ -208,6 +208,11 @@ type ToolHandle struct {
 	Server     string
 	Descriptor MCPToolDescriptor
 	Client     Client
+	// Resolver selects the Client per call (#317). For ordinary servers
+	// it's a StaticResolver over Client (unchanged behavior); a type=user
+	// server will supply a per-subject pool so each call routes to the
+	// requesting user's own connection.
+	Resolver ClientResolver
 }
 
 func (m *Manager) Tools() []ToolHandle {
@@ -240,7 +245,15 @@ func (m *Manager) Tools() []ToolHandle {
 			continue
 		}
 		for _, d := range srv.Tools() {
-			out = append(out, ToolHandle{Server: n, Descriptor: d, Client: client})
+			out = append(out, ToolHandle{
+				Server:     n,
+				Descriptor: d,
+				Client:     client,
+				// Per-call resolution seam (#317). Ordinary servers resolve
+				// to the same shared client (unchanged); a per-subject pool
+				// server routes per requesting user.
+				Resolver: StaticResolver{Client: client},
+			})
 		}
 	}
 	return out

--- a/forge-core/mcp/manager.go
+++ b/forge-core/mcp/manager.go
@@ -241,18 +241,22 @@ func (m *Manager) Tools() []ToolHandle {
 			continue
 		}
 		client := srv.Client()
-		if client == nil {
+		// A per-subject (type=user) server has no shared client — its calls
+		// resolve per requesting user — so it is still included. A static
+		// server keeps the pre-existing "skip until a client exists" guard.
+		if !srv.usesSubjectPool() && client == nil {
 			continue
 		}
+		resolver := srv.resolver()
 		for _, d := range srv.Tools() {
 			out = append(out, ToolHandle{
 				Server:     n,
 				Descriptor: d,
 				Client:     client,
-				// Per-call resolution seam (#317). Ordinary servers resolve
-				// to the same shared client (unchanged); a per-subject pool
-				// server routes per requesting user.
-				Resolver: StaticResolver{Client: client},
+				// Per-call resolution seam (#317): ordinary servers resolve
+				// to the shared client (unchanged); a pool server routes per
+				// requesting user.
+				Resolver: resolver,
 			})
 		}
 	}

--- a/forge-core/mcp/materialized_test.go
+++ b/forge-core/mcp/materialized_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/initializ/forge/forge-core/auth"
 	"github.com/initializ/forge/forge-core/types"
@@ -50,6 +51,53 @@ func TestServer_MaterializedDescriptors(t *testing.T) {
 	bad := newUserServer(t, "https://x", []types.MCPToolSchema{{Name: "a__b", InputSchema: map[string]any{"type": "object"}}}, pf)
 	if _, err := bad.materializedDescriptors(); err == nil {
 		t.Error("a name containing __ must be rejected")
+	}
+}
+
+// initFailClient fails Initialize and blocks its Run demux until Close —
+// so the test can assert establish's Close stops the just-started Run.
+type initFailClient struct {
+	closed  chan struct{}
+	runDone chan struct{}
+}
+
+func (c *initFailClient) Run(context.Context) { <-c.closed; close(c.runDone) }
+func (c *initFailClient) Initialize(context.Context, ClientInfo) (*InitializeResult, error) {
+	return nil, errNoGrant
+}
+func (c *initFailClient) Initialized(context.Context) error { return nil }
+func (c *initFailClient) ListTools(context.Context) ([]MCPToolDescriptor, error) {
+	return nil, nil
+}
+func (c *initFailClient) CallTool(context.Context, string, json.RawMessage) (*CallToolResult, error) {
+	return nil, nil
+}
+func (c *initFailClient) Close() error { close(c.closed); return nil }
+
+var errNoGrant = &protocolError{"401 no grant for user"}
+
+type protocolError struct{ msg string }
+
+func (e *protocolError) Error() string { return e.msg }
+
+// TestServer_Establish_InitializeFailure_StopsRun: on an Initialize
+// failure (expected — a user without a grant 401s), establish's Close must
+// stop the demux Run goroutine it started, or every failed establish leaks
+// a goroutine (#329 re-review finding B).
+func TestServer_Establish_InitializeFailure_StopsRun(t *testing.T) {
+	srv := newUserServer(t, "https://x", nil,
+		&types.PlatformConfig{TokenEndpoint: "https://p", AgentIdentity: "c"})
+	fc := &initFailClient{closed: make(chan struct{}), runDone: make(chan struct{})}
+	srv.factory = func(context.Context) (Client, error) { return fc, nil }
+
+	if _, err := srv.establish(auth.WithIdentity(context.Background(), &auth.Identity{Email: "bob@corp.com"})); err == nil {
+		t.Fatal("establish must fail when Initialize fails")
+	}
+	select {
+	case <-fc.runDone:
+		// Run stopped by Close — no leak.
+	case <-time.After(2 * time.Second):
+		t.Fatal("demux Run goroutine leaked after Initialize failure — Close did not stop it")
 	}
 }
 

--- a/forge-core/mcp/materialized_test.go
+++ b/forge-core/mcp/materialized_test.go
@@ -1,0 +1,140 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/auth"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+func newUserServer(t *testing.T, url string, schemas []types.MCPToolSchema, platform *types.PlatformConfig) *Server {
+	t.Helper()
+	srv, err := NewServer(types.MCPServer{
+		Name: "atl", Transport: "http", URL: url,
+		Auth:  &types.MCPAuth{Type: "user", Ref: "mcp.atlassian"},
+		Tools: types.MCPToolFilter{Allow: []string{"*"}, Schemas: schemas},
+	}, ServerDeps{HTTPClient: http.DefaultClient, Platform: platform})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+// TestServer_MaterializedDescriptors: config tool schemas convert to
+// descriptors (input_schema YAML → JSON), and bad names/schemas are
+// rejected — the same guards tools/list results get (#317).
+func TestServer_MaterializedDescriptors(t *testing.T) {
+	pf := &types.PlatformConfig{TokenEndpoint: "https://plat/token", AgentIdentity: "c"}
+
+	srv := newUserServer(t, "https://x", []types.MCPToolSchema{
+		{Name: "create_issue", Description: "Create an issue", InputSchema: map[string]any{"type": "object", "properties": map[string]any{"title": map[string]any{"type": "string"}}}},
+		{Name: "list_issues"}, // no input_schema → defaults to {"type":"object"}
+	}, pf)
+	descs, err := srv.materializedDescriptors()
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(descs) != 2 || descs[0].Name != "create_issue" {
+		t.Fatalf("descs = %+v", descs)
+	}
+	if !json.Valid(descs[0].InputSchema) || !json.Valid(descs[1].InputSchema) {
+		t.Errorf("input schemas must be valid JSON: %s / %s", descs[0].InputSchema, descs[1].InputSchema)
+	}
+
+	// Bad name (reserved "__") is rejected.
+	bad := newUserServer(t, "https://x", []types.MCPToolSchema{{Name: "a__b", InputSchema: map[string]any{"type": "object"}}}, pf)
+	if _, err := bad.materializedDescriptors(); err == nil {
+		t.Error("a name containing __ must be rejected")
+	}
+}
+
+// TestManager_Materialized_UserServer_LazyPerUserConnection is the full
+// vertical (#317): a type=user server registers its materialized tools
+// WITHOUT a startup connection, then a call establishes a per-user
+// connection whose initialize carries THAT user's platform token.
+func TestManager_Materialized_UserServer_LazyPerUserConnection(t *testing.T) {
+	// Platform token endpoint → per-subject token.
+	tokEP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b struct{ Server, Subject string }
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok-" + b.Subject, "expires_in": 3600})
+	}))
+	defer tokEP.Close()
+
+	// MCP server: record the Authorization it sees at initialize.
+	var mu sync.Mutex
+	var initAuths []string
+	mcpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg JSONRPCMessage
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		w.Header().Set("Content-Type", "application/json")
+		switch msg.Method {
+		case MethodInitialize:
+			mu.Lock()
+			initAuths = append(initAuths, r.Header.Get("Authorization"))
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", "sess")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + msg.ID.String() + `,"result":{"protocolVersion":"` + ProtocolVersion + `","serverInfo":{"name":"mock","version":"1.0"}}}`))
+		case MethodInitialized:
+			w.WriteHeader(http.StatusAccepted)
+		case MethodToolsCall:
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + msg.ID.String() + `,"result":{"content":[{"type":"text","text":"ok"}]}}`))
+		}
+	}))
+	defer mcpSrv.Close()
+
+	cfg := types.MCPConfig{Servers: []types.MCPServer{{
+		Name: "atl", Transport: "http", URL: mcpSrv.URL,
+		Auth: &types.MCPAuth{Type: "user", Ref: "mcp.atlassian"},
+		Tools: types.MCPToolFilter{
+			Allow:   []string{"*"},
+			Schemas: []types.MCPToolSchema{{Name: "create_issue", InputSchema: map[string]any{"type": "object"}}},
+		},
+	}}}
+	mgr, err := NewManager(cfg, ManagerDeps{
+		HTTPClient: mcpSrv.Client(),
+		Platform:   &types.PlatformConfig{TokenEndpoint: tokEP.URL, AgentIdentity: "agent-cred"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = mgr.Stop() }()
+
+	// Tools register WITHOUT any startup connection.
+	tools := mgr.Tools()
+	if len(tools) != 1 || tools[0].Descriptor.Name != "create_issue" {
+		t.Fatalf("materialized tools = %+v, want [create_issue]", tools)
+	}
+	mu.Lock()
+	n := len(initAuths)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("server connected %d times at startup — a type=user server must be lazy", n)
+	}
+
+	// A call for a user establishes a per-user connection carrying THEIR token.
+	userCtx := auth.WithIdentity(ctx, &auth.Identity{Email: "alice@corp.com"})
+	cli, err := tools[0].Resolver.ClientFor(userCtx)
+	if err != nil {
+		t.Fatalf("ClientFor(alice): %v", err)
+	}
+	if _, err := cli.CallTool(userCtx, "create_issue", json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	mu.Lock()
+	got := append([]string(nil), initAuths...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "Bearer tok-alice@corp.com" {
+		t.Fatalf("initialize Authorization = %v, want [Bearer tok-alice@corp.com] (per-user token)", got)
+	}
+}

--- a/forge-core/mcp/server.go
+++ b/forge-core/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -73,6 +74,12 @@ type Server struct {
 	tools  []MCPToolDescriptor
 	client Client
 	cancel context.CancelFunc
+
+	// pool is non-nil for a type=user server: it holds one connection per
+	// requesting-user subject, established lazily. Such a server runs
+	// "materialized" (no eager connect) and exposes the pool as its
+	// per-call ClientResolver (#317).
+	pool *subjectConnPool
 
 	ready        chan struct{} // closed when first Ready
 	failed       chan struct{} // closed on terminal Failed/Stopped
@@ -200,7 +207,7 @@ func NewServer(spec types.MCPServer, deps ServerDeps) (*Server, error) {
 		}
 		return NewClient(tr), nil
 	}
-	return &Server{
+	srv := &Server{
 		Name:    spec.Name,
 		Spec:    spec,
 		factory: factory,
@@ -210,7 +217,14 @@ func NewServer(spec types.MCPServer, deps ServerDeps) (*Server, error) {
 		state:   StateConfigured,
 		ready:   make(chan struct{}),
 		failed:  make(chan struct{}),
-	}, nil
+	}
+	// #317: a type=user server has no user (and so no connection) at
+	// startup — it runs "materialized": Ready with the platform-supplied
+	// tool schemas, connecting per requesting user lazily for calls.
+	if spec.Auth != nil && spec.Auth.Type == "user" {
+		srv.pool = newSubjectConnPool(srv.establish)
+	}
+	return srv, nil
 }
 
 // State returns the current lifecycle state. Cheap; safe for
@@ -259,6 +273,13 @@ func (s *Server) Run(ctx context.Context) error {
 	s.cancel = cancel
 	s.mu.Unlock()
 	defer cancel()
+
+	// #317: a per-subject (type=user) server has no user at startup, so it
+	// never eager-connects — it registers materialized tools and reaches
+	// Ready, connecting per requesting user lazily on calls.
+	if s.usesSubjectPool() {
+		return s.runMaterialized(ctx)
+	}
 
 	attempt := 0
 	for {
@@ -332,6 +353,97 @@ func (s *Server) Run(ctx context.Context) error {
 // then blocks until the underlying client's demultiplexer exits or
 // ctx is cancelled. Returns a non-nil error if any step failed; nil
 // if the cycle ended cleanly (ctx cancel after Ready).
+// establish opens and initializes a fresh connection for the pool (#317).
+// The ctx carries the requesting user's identity, so the transport's
+// authFn resolves THAT user's token at initialize. The demultiplexer runs
+// for the connection's lifetime (stopped by cli.Close()), not just the
+// establish window.
+func (s *Server) establish(ctx context.Context) (Client, error) {
+	cli, err := s.factory(ctx)
+	if err != nil {
+		return nil, withPhase("connect", err)
+	}
+	if r, ok := cli.(interface{ Run(context.Context) }); ok {
+		go r.Run(context.Background()) // lifetime = connection; cli.Close() stops it
+	}
+	initCtx, cancel := context.WithTimeout(ctx, s.timeout())
+	defer cancel()
+	if _, err := cli.Initialize(initCtx, ClientInfo{Name: "forge-mcp", Version: "0.12.0"}); err != nil {
+		_ = cli.Close()
+		return nil, withPhase("initialize", err)
+	}
+	if err := cli.Initialized(initCtx); err != nil {
+		_ = cli.Close()
+		return nil, withPhase("initialize", fmt.Errorf("initialized notification: %w", err))
+	}
+	return cli, nil
+}
+
+// resolver returns this server's per-call ClientResolver: the per-subject
+// pool for type=user, otherwise a StaticResolver over the shared client.
+func (s *Server) resolver() ClientResolver {
+	if s.pool != nil {
+		return s.pool
+	}
+	return StaticResolver{Client: s.Client()}
+}
+
+// usesSubjectPool reports whether calls route per requesting user (#317).
+func (s *Server) usesSubjectPool() bool { return s.pool != nil }
+
+// materializedDescriptors converts the platform-supplied tool schemas
+// (types) into MCP descriptors, validating names + input schemas the same
+// way tools/list results are (#317).
+func (s *Server) materializedDescriptors() ([]MCPToolDescriptor, error) {
+	out := make([]MCPToolDescriptor, 0, len(s.Spec.Tools.Schemas))
+	for i, sc := range s.Spec.Tools.Schemas {
+		if sc.Name == "" {
+			return nil, fmt.Errorf("tool schema[%d]: name is empty", i)
+		}
+		if strings.Contains(sc.Name, "__") {
+			return nil, fmt.Errorf("tool schema[%d] %q: name contains \"__\" — reserved for the <server>__<tool> separator", i, sc.Name)
+		}
+		raw := json.RawMessage(`{"type":"object"}`)
+		if sc.InputSchema != nil {
+			b, err := json.Marshal(sc.InputSchema)
+			if err != nil {
+				return nil, fmt.Errorf("tool schema[%d] %q: input_schema: %w", i, sc.Name, err)
+			}
+			raw = b
+		}
+		if err := ValidateInputSchema(raw); err != nil {
+			return nil, fmt.Errorf("tool schema[%d] %q: %w", i, sc.Name, err)
+		}
+		out = append(out, MCPToolDescriptor{Name: sc.Name, Description: sc.Description, InputSchema: raw})
+	}
+	return out, nil
+}
+
+// runMaterialized is the type=user lifecycle: register the materialized
+// tool schemas and reach Ready WITHOUT an eager connection (there is no
+// user at startup). Per-user connections are established lazily by the
+// pool on tool calls. Blocks until ctx cancel, then tears the pool down.
+func (s *Server) runMaterialized(ctx context.Context) error {
+	descs, err := s.materializedDescriptors()
+	if err != nil {
+		return withPhase("materialize", err)
+	}
+	filtered := filterTools(descs, s.Spec.Tools)
+	s.mu.Lock()
+	s.tools = filtered
+	s.mu.Unlock()
+	s.transition(StateReady)
+	s.emitStarted(len(filtered))
+	s.once.Do(func() { close(s.ready) })
+
+	<-ctx.Done()
+	if s.pool != nil {
+		_ = s.pool.Close()
+	}
+	s.transition(StateStopped)
+	return nil
+}
+
 func (s *Server) runOnce(ctx context.Context) error {
 	s.transition(StateConnecting)
 

--- a/forge-core/mcp/server_state.go
+++ b/forge-core/mcp/server_state.go
@@ -17,7 +17,10 @@ package mcp
 //
 // Keep this in sync with the state diagram in docs/mcp/index.md.
 var validTransitions = map[ServerState][]ServerState{
-	StateConfigured:   {StateConnecting, StateStopped},
+	// Configured → Ready is the #317 "materialized" path: a type=user
+	// server registers platform-supplied tool schemas and goes Ready
+	// without an eager connection (per-user connections are lazy).
+	StateConfigured:   {StateConnecting, StateReady, StateStopped},
 	StateConnecting:   {StateInitializing, StateDegraded, StateStopped},
 	StateInitializing: {StateDiscovering, StateDegraded, StateStopped},
 	StateDiscovering:  {StateReady, StateDegraded, StateStopped},

--- a/forge-core/mcp/subject_pool.go
+++ b/forge-core/mcp/subject_pool.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/initializ/forge/forge-core/auth"
+)
+
+// ClientResolver resolves which MCP Client a tool call should use. The
+// per-call ctx carries the requesting user's identity, so a per-subject
+// pool can route to that user's own connection (#317 connection
+// lifecycle). Servers that don't need per-user connections will use a
+// static resolver (the shared Client) — added with the tool-routing seam
+// that consumes this (the next increment; see the #317 design comment).
+type ClientResolver interface {
+	ClientFor(ctx context.Context) (Client, error)
+}
+
+// subjectConnPool is the per-user ClientResolver.
+var _ ClientResolver = (*subjectConnPool)(nil)
+
+// poolEstablishTimeout bounds a single per-subject connect+initialize.
+const poolEstablishTimeout = 30 * time.Second
+
+// subjectConnPool maintains one lazily-established MCP connection per
+// requesting-user subject (#317). A type=user server binds identity at
+// initialize, so each user needs their own connection: the pool
+// establishes it on first use — running connect (factory + Initialize)
+// under that user's identity so authFn resolves THEIR token at
+// initialize — and reuses it thereafter.
+//
+// Establishment is single-flighted per subject (a burst of a user's first
+// calls opens exactly one connection); distinct subjects never block each
+// other. Concurrency-safe; Close tears down every connection.
+type subjectConnPool struct {
+	// connect establishes a fresh connection. Its ctx carries the
+	// subject's identity but is decoupled from any caller's cancellation
+	// (background-derived + a hard timeout) so one caller's cancel can't
+	// tear down the shared connection mid-establish (the B2 lesson).
+	connect func(ctx context.Context) (Client, error)
+
+	mu     sync.Mutex
+	conns  map[string]Client
+	inFly  map[string]*connFlight
+	closed bool
+}
+
+type connFlight struct {
+	done   chan struct{}
+	client Client
+	err    error
+}
+
+func newSubjectConnPool(connect func(ctx context.Context) (Client, error)) *subjectConnPool {
+	return &subjectConnPool{
+		connect: connect,
+		conns:   map[string]Client{},
+		inFly:   map[string]*connFlight{},
+	}
+}
+
+// ClientFor returns the connection for the requesting user in ctx,
+// establishing it on first use. No authenticated user → ErrNoToken
+// (lazy; a delegated connection is never established at startup).
+func (p *subjectConnPool) ClientFor(ctx context.Context) (Client, error) {
+	subject := delegatedSubject(ctx)
+	if subject == "" {
+		return nil, fmt.Errorf("%w: no requesting user in context — a delegated MCP connection is established lazily under a user's session", ErrNoToken)
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, ErrClosed
+	}
+	if c, ok := p.conns[subject]; ok {
+		p.mu.Unlock()
+		return c, nil
+	}
+	fl, exists := p.inFly[subject]
+	if !exists {
+		fl = &connFlight{done: make(chan struct{})}
+		p.inFly[subject] = fl
+		p.mu.Unlock()
+
+		// Preserve the subject's identity on a background-derived,
+		// bounded ctx so authFn resolves the right user's token but a
+		// caller's cancel can't abort the shared establish.
+		connCtx, cancel := context.WithTimeout(context.Background(), poolEstablishTimeout)
+		if id := auth.IdentityFromContext(ctx); id != nil {
+			connCtx = auth.WithIdentity(connCtx, id)
+		}
+		go func() {
+			defer cancel()
+			c, err := p.connect(connCtx)
+			p.mu.Lock()
+			delete(p.inFly, subject)
+			switch {
+			case err != nil:
+				// leave nothing cached
+			case p.closed:
+				// pool closed mid-establish — drop it
+				if c != nil {
+					_ = c.Close()
+				}
+				c, err = nil, ErrClosed
+			default:
+				p.conns[subject] = c
+			}
+			p.mu.Unlock()
+			fl.client, fl.err = c, err
+			close(fl.done)
+		}()
+	} else {
+		p.mu.Unlock()
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-fl.done:
+	}
+	return fl.client, fl.err
+}
+
+// Evict drops (and closes) the connection for a subject — call when a
+// request on it fails with a connection error so the next call
+// re-establishes. Idempotent.
+func (p *subjectConnPool) Evict(ctx context.Context) {
+	subject := delegatedSubject(ctx)
+	if subject == "" {
+		return
+	}
+	p.mu.Lock()
+	c, ok := p.conns[subject]
+	delete(p.conns, subject)
+	p.mu.Unlock()
+	if ok && c != nil {
+		_ = c.Close()
+	}
+}
+
+// Close tears down every pooled connection. The pool is unusable after.
+func (p *subjectConnPool) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	conns := p.conns
+	p.conns = map[string]Client{}
+	p.mu.Unlock()
+	for _, c := range conns {
+		if c != nil {
+			_ = c.Close()
+		}
+	}
+	return nil
+}
+
+// len reports the number of live connections (for tests / metrics).
+func (p *subjectConnPool) len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.conns)
+}
+
+// inFlyLen reports in-flight establishments (test-only).
+func (p *subjectConnPool) inFlyLen() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.inFly)
+}

--- a/forge-core/mcp/subject_pool.go
+++ b/forge-core/mcp/subject_pool.go
@@ -12,15 +12,30 @@ import (
 // ClientResolver resolves which MCP Client a tool call should use. The
 // per-call ctx carries the requesting user's identity, so a per-subject
 // pool can route to that user's own connection (#317 connection
-// lifecycle). Servers that don't need per-user connections will use a
-// static resolver (the shared Client) — added with the tool-routing seam
-// that consumes this (the next increment; see the #317 design comment).
+// lifecycle). Servers that don't need per-user connections use a
+// StaticResolver returning the one shared Client.
 type ClientResolver interface {
 	ClientFor(ctx context.Context) (Client, error)
 }
 
-// subjectConnPool is the per-user ClientResolver.
-var _ ClientResolver = (*subjectConnPool)(nil)
+var (
+	_ ClientResolver = (*subjectConnPool)(nil)
+	_ ClientResolver = StaticResolver{}
+)
+
+// StaticResolver returns one fixed Client for every call — the shared
+// single-connection behavior for bearer/static/agent-principal/discovered
+// -oauth servers, where one identity serves all requests. It is the
+// default the tool-routing seam uses so non-per-user servers behave
+// exactly as before.
+type StaticResolver struct{ Client Client }
+
+func (s StaticResolver) ClientFor(context.Context) (Client, error) {
+	if s.Client == nil {
+		return nil, fmt.Errorf("%w: no MCP client available", ErrTransportUnavailable)
+	}
+	return s.Client, nil
+}
 
 // poolEstablishTimeout bounds a single per-subject connect+initialize.
 const poolEstablishTimeout = 30 * time.Second

--- a/forge-core/mcp/subject_pool.go
+++ b/forge-core/mcp/subject_pool.go
@@ -46,6 +46,7 @@ type subjectConnPool struct {
 	conns  map[string]Client
 	inFly  map[string]*connFlight
 	closed bool
+	wg     sync.WaitGroup // tracks in-flight establishes for a synchronous Close
 }
 
 type connFlight struct {
@@ -93,26 +94,42 @@ func (p *subjectConnPool) ClientFor(ctx context.Context) (Client, error) {
 		if id := auth.IdentityFromContext(ctx); id != nil {
 			connCtx = auth.WithIdentity(connCtx, id)
 		}
+		p.wg.Add(1)
 		go func() {
-			defer cancel()
-			c, err := p.connect(connCtx)
-			p.mu.Lock()
-			delete(p.inFly, subject)
-			switch {
-			case err != nil:
-				// leave nothing cached
-			case p.closed:
-				// pool closed mid-establish — drop it
-				if c != nil {
-					_ = c.Close()
+			var (
+				c   Client
+				err error
+			)
+			// Unconditionally clear the flight, cache-or-close the result,
+			// and unblock waiters — even if p.connect panics. Without this,
+			// a panicking factory/Initialize would leave inFly[subject]
+			// populated and fl.done open, wedging EVERY future call for
+			// that subject on a dead flight (#329 review finding 1).
+			defer func() {
+				if r := recover(); r != nil {
+					c, err = nil, fmt.Errorf("%w: connect panicked: %v", ErrProtocolError, r)
 				}
-				c, err = nil, ErrClosed
-			default:
-				p.conns[subject] = c
-			}
-			p.mu.Unlock()
-			fl.client, fl.err = c, err
-			close(fl.done)
+				p.mu.Lock()
+				delete(p.inFly, subject)
+				switch {
+				case err != nil:
+					// leave nothing cached
+				case p.closed:
+					// pool closed mid-establish — drop it
+					if c != nil {
+						_ = c.Close()
+					}
+					c, err = nil, ErrClosed
+				default:
+					p.conns[subject] = c
+				}
+				p.mu.Unlock()
+				fl.client, fl.err = c, err
+				close(fl.done)
+				cancel()
+				p.wg.Done()
+			}()
+			c, err = p.connect(connCtx)
 		}()
 	} else {
 		p.mu.Unlock()
@@ -143,7 +160,12 @@ func (p *subjectConnPool) Evict(ctx context.Context) {
 	}
 }
 
-// Close tears down every pooled connection. The pool is unusable after.
+// Close tears down every pooled connection synchronously. It first marks
+// the pool closed (so any in-flight establish self-closes on completion),
+// waits for those establishes to finish, then closes the cached
+// connections — so when Close returns, no connection remains open and no
+// establish is still running (#329 review finding 2). The pool is
+// unusable after.
 func (p *subjectConnPool) Close() error {
 	p.mu.Lock()
 	if p.closed {
@@ -151,6 +173,13 @@ func (p *subjectConnPool) Close() error {
 		return nil
 	}
 	p.closed = true
+	p.mu.Unlock()
+
+	// Join in-flight establishes: each sees p.closed and drops its own
+	// connection, so after Wait nothing new lands in p.conns.
+	p.wg.Wait()
+
+	p.mu.Lock()
 	conns := p.conns
 	p.conns = map[string]Client{}
 	p.mu.Unlock()

--- a/forge-core/mcp/subject_pool_test.go
+++ b/forge-core/mcp/subject_pool_test.go
@@ -1,0 +1,160 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/auth"
+)
+
+// fakeClient is a no-op Client for pool tests; it records Close.
+type fakeClient struct{ closed atomic.Bool }
+
+func (f *fakeClient) Initialize(context.Context, ClientInfo) (*InitializeResult, error) {
+	return &InitializeResult{}, nil
+}
+func (f *fakeClient) Initialized(context.Context) error { return nil }
+func (f *fakeClient) ListTools(context.Context) ([]MCPToolDescriptor, error) {
+	return nil, nil
+}
+func (f *fakeClient) CallTool(context.Context, string, json.RawMessage) (*CallToolResult, error) {
+	return &CallToolResult{}, nil
+}
+func (f *fakeClient) Close() error { f.closed.Store(true); return nil }
+
+func ctxWithUser(email string) context.Context {
+	return auth.WithIdentity(context.Background(), &auth.Identity{Email: email})
+}
+
+// TestSubjectConnPool_PerSubjectLazyEstablishAndReuse: distinct users get
+// distinct connections established lazily on first use; the same user
+// reuses theirs (one connect each). The connect ctx carries that user's
+// identity so authFn would resolve the right token.
+func TestSubjectConnPool_PerSubjectLazyEstablishAndReuse(t *testing.T) {
+	var connects atomic.Int32
+	seen := map[string]bool{}
+	var mu sync.Mutex
+	pool := newSubjectConnPool(func(ctx context.Context) (Client, error) {
+		connects.Add(1)
+		if id := auth.IdentityFromContext(ctx); id != nil {
+			mu.Lock()
+			seen[id.Email] = true
+			mu.Unlock()
+		}
+		return &fakeClient{}, nil
+	})
+
+	if connects.Load() != 0 {
+		t.Fatal("pool must not connect before first ClientFor (lazy)")
+	}
+
+	a1, err := pool.ClientFor(ctxWithUser("alice@corp.com"))
+	if err != nil {
+		t.Fatalf("alice: %v", err)
+	}
+	a2, _ := pool.ClientFor(ctxWithUser("alice@corp.com"))
+	b1, _ := pool.ClientFor(ctxWithUser("bob@corp.com"))
+
+	if a1 != a2 {
+		t.Error("same user must reuse the same connection")
+	}
+	if a1 == b1 {
+		t.Error("distinct users must get distinct connections")
+	}
+	if n := connects.Load(); n != 2 {
+		t.Errorf("connects = %d, want 2 (one per subject; alice reused)", n)
+	}
+	if !seen["alice@corp.com"] || !seen["bob@corp.com"] {
+		t.Errorf("connect ctx did not carry each user's identity: %v", seen)
+	}
+	if pool.len() != 2 {
+		t.Errorf("pool has %d conns, want 2", pool.len())
+	}
+}
+
+// TestSubjectConnPool_NoSubjectIsLazyErr: no authenticated user → ErrNoToken.
+func TestSubjectConnPool_NoSubjectIsLazyErr(t *testing.T) {
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		t.Fatal("must not connect without a subject")
+		return nil, nil
+	})
+	if _, err := pool.ClientFor(context.Background()); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("no subject must yield ErrNoToken, got: %v", err)
+	}
+}
+
+// TestSubjectConnPool_SingleFlight: concurrent first calls for one subject
+// open exactly one connection.
+func TestSubjectConnPool_SingleFlight(t *testing.T) {
+	var connects atomic.Int32
+	release := make(chan struct{})
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		connects.Add(1)
+		<-release // hold the establish so all callers pile up behind it
+		return &fakeClient{}, nil
+	})
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_, _ = pool.ClientFor(ctxWithUser("carol@corp.com"))
+		}()
+	}
+	// Give the goroutines time to queue behind the single flight, then let go.
+	for pool.inFlyLen() == 0 {
+	}
+	close(release)
+	wg.Wait()
+
+	if c := connects.Load(); c != 1 {
+		t.Errorf("connects = %d, want 1 (single-flighted per subject)", c)
+	}
+}
+
+// TestSubjectConnPool_EvictReconnects: Evict drops the connection so the
+// next call re-establishes.
+func TestSubjectConnPool_EvictReconnects(t *testing.T) {
+	var connects atomic.Int32
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		connects.Add(1)
+		return &fakeClient{}, nil
+	})
+	ctx := ctxWithUser("dave@corp.com")
+	c1, _ := pool.ClientFor(ctx)
+	pool.Evict(ctx)
+	if fc, ok := c1.(*fakeClient); !ok || !fc.closed.Load() {
+		t.Error("Evict must close the evicted connection")
+	}
+	c2, _ := pool.ClientFor(ctx)
+	if c1 == c2 {
+		t.Error("post-evict ClientFor must re-establish a fresh connection")
+	}
+	if n := connects.Load(); n != 2 {
+		t.Errorf("connects = %d, want 2 (establish, evict, re-establish)", n)
+	}
+}
+
+// TestSubjectConnPool_CloseTearsDown: Close closes all connections and the
+// pool is unusable after.
+func TestSubjectConnPool_CloseTearsDown(t *testing.T) {
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		return &fakeClient{}, nil
+	})
+	c, _ := pool.ClientFor(ctxWithUser("erin@corp.com"))
+	if err := pool.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if fc := c.(*fakeClient); !fc.closed.Load() {
+		t.Error("Close must close pooled connections")
+	}
+	if _, err := pool.ClientFor(ctxWithUser("erin@corp.com")); !errors.Is(err, ErrClosed) {
+		t.Errorf("ClientFor after Close must be ErrClosed, got: %v", err)
+	}
+}

--- a/forge-core/mcp/subject_pool_test.go
+++ b/forge-core/mcp/subject_pool_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/initializ/forge/forge-core/auth"
 )
@@ -138,6 +139,73 @@ func TestSubjectConnPool_EvictReconnects(t *testing.T) {
 	}
 	if n := connects.Load(); n != 2 {
 		t.Errorf("connects = %d, want 2 (establish, evict, re-establish)", n)
+	}
+}
+
+// TestSubjectConnPool_ConnectErrorNotCached: a failed establish surfaces
+// the error, caches nothing, and a later retry re-establishes (#329
+// review finding 3).
+func TestSubjectConnPool_ConnectErrorNotCached(t *testing.T) {
+	var connects atomic.Int32
+	var mu sync.Mutex
+	fail := true
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		connects.Add(1)
+		mu.Lock()
+		f := fail
+		mu.Unlock()
+		if f {
+			return nil, errors.New("dial refused")
+		}
+		return &fakeClient{}, nil
+	})
+	ctx := ctxWithUser("frank@corp.com")
+
+	if _, err := pool.ClientFor(ctx); err == nil {
+		t.Fatal("connect error must surface")
+	}
+	if pool.len() != 0 {
+		t.Errorf("a failed establish must not cache a connection; len=%d", pool.len())
+	}
+	mu.Lock()
+	fail = false
+	mu.Unlock()
+	if _, err := pool.ClientFor(ctx); err != nil {
+		t.Fatalf("retry after a failed establish must re-establish: %v", err)
+	}
+	if n := connects.Load(); n != 2 {
+		t.Errorf("connects = %d, want 2 (failed then retried)", n)
+	}
+}
+
+// TestSubjectConnPool_ConnectPanicDoesNotWedge: a panicking connect fails
+// that one establish cleanly (error, not hang) and does NOT wedge the
+// subject's flight — a later call re-establishes (#329 review finding 1).
+func TestSubjectConnPool_ConnectPanicDoesNotWedge(t *testing.T) {
+	var panicOnce atomic.Bool
+	panicOnce.Store(true)
+	pool := newSubjectConnPool(func(context.Context) (Client, error) {
+		if panicOnce.CompareAndSwap(true, false) {
+			panic("boom in transport")
+		}
+		return &fakeClient{}, nil
+	})
+	ctx := ctxWithUser("grace@corp.com")
+
+	done := make(chan error, 1)
+	go func() { _, err := pool.ClientFor(ctx); done <- err }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a connect panic must surface as an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ClientFor hung after connect panicked — the flight is wedged")
+	}
+
+	// The flight must be cleared — the subject is not poisoned.
+	if _, err := pool.ClientFor(ctx); err != nil {
+		t.Fatalf("after a panicked establish the subject must re-establish, got: %v", err)
 	}
 }
 

--- a/forge-core/tools/adapters/mcp_tool.go
+++ b/forge-core/tools/adapters/mcp_tool.go
@@ -50,7 +50,11 @@ const truncatedSuffix = "\n[truncated]"
 type MCPTool struct {
 	server     string
 	descriptor mcp.MCPToolDescriptor
-	client     mcp.Client
+	// resolver selects the Client per call (#317). When nil, client is
+	// used directly (a fixed connection). A per-subject pool resolver
+	// routes each call to the requesting user's own connection.
+	resolver mcp.ClientResolver
+	client   mcp.Client
 
 	maxResultChars int
 	audit          *runtime.AuditLogger
@@ -64,8 +68,14 @@ type MCPToolOpts struct {
 	// Descriptor is the tool's discovery payload from tools/list.
 	Descriptor mcp.MCPToolDescriptor
 
-	// Client is the per-server JSON-RPC client. Required.
+	// Client is the per-server JSON-RPC client. Used when Resolver is nil.
 	Client mcp.Client
+
+	// Resolver selects the Client per call (#317). Preferred over Client
+	// when set; the runtime passes the ToolHandle's resolver so a
+	// per-subject-pool server routes each call to the requesting user's
+	// connection. Optional — nil falls back to Client.
+	Resolver mcp.ClientResolver
 
 	// MaxResultChars truncates tool results above this size. 0 ⇒ default.
 	MaxResultChars int
@@ -93,6 +103,7 @@ func NewMCPTool(opts MCPToolOpts) (*MCPTool, error) {
 	return &MCPTool{
 		server:         opts.Server,
 		descriptor:     opts.Descriptor,
+		resolver:       opts.Resolver,
 		client:         opts.Client,
 		maxResultChars: maxChars,
 		audit:          opts.Audit,
@@ -124,6 +135,16 @@ func validateDescriptorName(name string) error {
 // tools.Registry admits "__" in the name.
 func (m *MCPTool) MCPSource() {}
 
+// resolveClient selects the Client for this call: the per-subject pool
+// resolver when set (routing to the requesting user's connection), else
+// the fixed client (#317).
+func (m *MCPTool) resolveClient(ctx context.Context) (mcp.Client, error) {
+	if m.resolver != nil {
+		return m.resolver.ClientFor(ctx)
+	}
+	return m.client, nil
+}
+
 // Name returns "<server>__<tool>".
 func (m *MCPTool) Name() string {
 	return m.server + "__" + m.descriptor.Name
@@ -153,7 +174,16 @@ func (m *MCPTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	correlationID := runtime.CorrelationIDFromContext(ctx)
 
 	m.emitCall(correlationID, len(args))
-	res, err := m.client.CallTool(ctx, m.descriptor.Name, args)
+	// Resolve the connection for THIS call's requesting user (#317). A
+	// static resolver returns the shared client (unchanged); a per-subject
+	// pool returns that user's own connection, establishing it lazily.
+	client, err := m.resolveClient(ctx)
+	if err != nil {
+		durMs := time.Since(start).Milliseconds()
+		m.emitResult(correlationID, durMs, 0, false, classifyToolErr(err))
+		return "", fmt.Errorf("mcp %s/%s: %w", m.server, m.descriptor.Name, err)
+	}
+	res, err := client.CallTool(ctx, m.descriptor.Name, args)
 	durMs := time.Since(start).Milliseconds()
 
 	if err != nil {

--- a/forge-core/tools/adapters/mcp_tool_test.go
+++ b/forge-core/tools/adapters/mcp_tool_test.go
@@ -95,6 +95,67 @@ func TestMCPTool_Execute_Happy(t *testing.T) {
 	}
 }
 
+// userKey carries a fake subject in ctx for the per-call resolution test.
+type userKey struct{}
+
+// resolverStub routes to a client chosen by the ctx's fake subject.
+type resolverStub struct {
+	byUser map[string]mcp.Client
+	err    error
+}
+
+func (r resolverStub) ClientFor(ctx context.Context) (mcp.Client, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	u, _ := ctx.Value(userKey{}).(string)
+	return r.byUser[u], nil
+}
+
+// TestMCPTool_Execute_ResolvesClientPerCall: with a Resolver, Execute
+// picks the connection from the per-call ctx — two users' calls route to
+// their own clients (#317 routing seam).
+func TestMCPTool_Execute_ResolvesClientPerCall(t *testing.T) {
+	t.Parallel()
+	alice := &mockClient{res: &mcp.CallToolResult{Content: []mcp.ToolContent{{Type: "text", Text: "alice-result"}}}}
+	bob := &mockClient{res: &mcp.CallToolResult{Content: []mcp.ToolContent{{Type: "text", Text: "bob-result"}}}}
+	a, err := NewMCPTool(MCPToolOpts{
+		Server:     "srv",
+		Descriptor: mcp.MCPToolDescriptor{Name: "echo", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		Resolver:   resolverStub{byUser: map[string]mcp.Client{"alice": alice, "bob": bob}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := a.Execute(context.WithValue(context.Background(), userKey{}, "alice"), json.RawMessage(`{}`))
+	if err != nil || got != "alice-result" {
+		t.Fatalf("alice: got=%q err=%v", got, err)
+	}
+	got, err = a.Execute(context.WithValue(context.Background(), userKey{}, "bob"), json.RawMessage(`{}`))
+	if err != nil || got != "bob-result" {
+		t.Fatalf("bob: got=%q err=%v (each call must route to its own connection)", got, err)
+	}
+}
+
+// TestMCPTool_Execute_ResolverErrorSurfaces: a resolver that can't produce
+// a connection (e.g. no user in ctx / no grant yet) surfaces as a tool
+// error rather than a nil-deref.
+func TestMCPTool_Execute_ResolverErrorSurfaces(t *testing.T) {
+	t.Parallel()
+	a, err := NewMCPTool(MCPToolOpts{
+		Server:     "srv",
+		Descriptor: mcp.MCPToolDescriptor{Name: "echo", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		Resolver:   resolverStub{err: errors.New("no connection for this user")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Execute(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("a resolver error must surface, not nil-deref")
+	}
+}
+
 func TestMCPTool_Execute_Truncation(t *testing.T) {
 	t.Parallel()
 	long := strings.Repeat("a", 100_000)

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -580,6 +580,26 @@ type MCPToolFilter struct {
 	// when Allow=["*"]). A tool listed in both Allow and Deny is a
 	// validation error.
 	Deny []string `yaml:"deny,omitempty"`
+
+	// Schemas are platform-MATERIALIZED tool descriptors (#317). A
+	// type=user server has no connection at startup (no requesting user),
+	// so it can't run tools/list — the platform materializes the tool
+	// schemas from the registry entry into config, and Forge registers
+	// them without a live connection, connecting per-user lazily only for
+	// calls. Allow/Deny still filter this set.
+	Schemas []MCPToolSchema `yaml:"schemas,omitempty"`
+}
+
+// MCPToolSchema is a materialized MCP tool descriptor (#317) — the
+// platform's substitute for a live tools/list entry. Lives in types (not
+// mcp) to avoid an import cycle; the mcp package converts it to an
+// MCPToolDescriptor.
+type MCPToolSchema struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	// InputSchema is the JSON Schema for the tool's arguments, authored as
+	// a YAML mapping and marshaled to JSON when the descriptor is built.
+	InputSchema map[string]any `yaml:"input_schema,omitempty"`
 }
 
 // PlatformConfig wires a deployed agent to its managing platform's token


### PR DESCRIPTION
**Stacked on #327** (base: `feat/mcp-delegated-user-resolver` — it uses `delegatedSubject` from there). Rebase onto `main` once #327 merges.

First increment of **#317's per-user connection lifecycle** ([design recorded on the issue](https://github.com/initializ/forge/issues/317)). #327 landed per-user **tokens** on a shared connection; a **session-stateful** MCP server binds identity at `initialize`, so full per-user isolation needs one **connection per user**. The investigation settled that per-subject sessions require per-subject `Client` instances (initialize is Client-driven) — i.e. a **pool**.

## What

`subjectConnPool` — one lazily-established MCP `Client` per requesting-user subject (keyed off `auth.IdentityFromContext(ctx)`), implementing the `ClientResolver` seam the tool-call path will use to route each call to the right user's connection.

- **Lazy** — nothing connects until a user's first call; no user in ctx → `ErrNoToken` (never at startup).
- **Identity-preserving, cancel-decoupled establish** — the connect ctx carries the subject's identity (so `authFn` resolves *their* token at `initialize`) but is background-derived with a hard timeout, so one caller's cancel can't tear down the shared establish (the B2 lesson from the OAuth refresh path).
- **Single-flighted per subject** — a burst of a user's first calls opens exactly one connection; distinct subjects never block each other.
- **Lifecycle** — `Evict` (drop+close on a connection error → next call re-establishes) and `Close` (tear down all).

## Scope

Self-contained library component, no hot-path wiring yet — deliberately, because the tool-call path is core and a bug there breaks every MCP tool. The documented increments after this:
2. **`ClientResolver` routing seam** — `ToolHandle`/`MCPTool` resolve the client per-call from the ctx subject (backward-compatible: a static resolver preserves today's shared-connection behavior for non-per-user servers).
3. **Materialized tool schemas** — so a `type: user` server (no connection at startup) registers its tools from platform-materialized config, then connects per-user lazily only for calls.

## Tests

Per-subject lazy establish + reuse (distinct users → distinct connections, one connect each), no-subject → `ErrNoToken`, single-flight (20 concurrent first-calls → one connect), evict-reconnects, close-teardown, and identity-preserved-on-the-connect-ctx. Full `forge-core` mcp suite passes; `golangci-lint` 0 issues (the component is exercised by tests, not flagged unused).
