### PR TITLE
Switch embedded weather skill to keyless wttr.in endpoint

### DIFF
--- a/.claude/skills/forge.md
+++ b/.claude/skills/forge.md
@@ -1096,10 +1096,10 @@ metadata:
     requires:
       bins: [curl]                   # binaries that must be in PATH
       env:
-        required: [WEATHER_API_KEY]
+        required: []
         one_of: []
         optional: []
-    egress_domains: [api.openweathermap.org]
+    egress_domains: [wttr.in]
     denied_tools: [http_request]     # tools this skill must NOT use
     timeout_hint: 60                 # suggested execution timeout in seconds
 ---

--- a/forge-cli/internal/tui/steps/egress_step.go
+++ b/forge-cli/internal/tui/steps/egress_step.go
@@ -182,10 +182,9 @@ func inferSource(domain string, ctx *tui.WizardContext) string {
 
 	// Skill domains
 	skillDomains := map[string]string{
-		"api.github.com":         "github skill",
-		"github.com":             "github skill",
-		"api.openweathermap.org": "weather skill",
-		"api.weatherapi.com":     "weather skill",
+		"api.github.com": "github skill",
+		"github.com":     "github skill",
+		"wttr.in":        "weather skill",
 	}
 	if src, ok := skillDomains[domain]; ok {
 		return src

--- a/forge-skills/local/embedded/weather/SKILL.md
+++ b/forge-skills/local/embedded/weather/SKILL.md
@@ -12,6 +12,7 @@ metadata:
     requires:
       bins:
         - curl
+        - jq
       env:
         required: []
         one_of: []

--- a/forge-skills/local/embedded/weather/SKILL.md
+++ b/forge-skills/local/embedded/weather/SKILL.md
@@ -17,8 +17,7 @@ metadata:
         one_of: []
         optional: []
     egress_domains:
-      - api.openweathermap.org
-      - api.weatherapi.com
+      - wttr.in
 ---
 ## Tool: weather_current
 
@@ -27,9 +26,19 @@ Get current weather for a location.
 **Input:** location (string) - City name or coordinates
 **Output:** Current temperature, conditions, humidity, and wind speed
 
+```bash
+curl -s "https://wttr.in/${location}?format=j1"
+```
+Relevant fields in the response: `current_condition[0].temp_C`, `current_condition[0].weatherDesc[0].value`, `current_condition[0].humidity`, `current_condition[0].windspeedKmph`.
+
 ## Tool: weather_forecast
 
 Get weather forecast for a location.
 
-**Input:** location (string), days (integer: 1-7)
+**Input:** location (string), days (integer: 1-3)
 **Output:** Daily forecast with high/low temperatures and conditions
+
+```bash
+curl -s "https://wttr.in/${location}?format=j1"
+```
+The `weather` array in the response contains up to 3 days of forecast (today + 2 days ahead). Each entry has `date`, `maxtempC`, `mintempC`, and `hourly[].weatherDesc[0].value`. wttr.in's free JSON endpoint caps at 3 days — for a longer forecast window, `open-meteo.com` would be needed instead.

--- a/forge-skills/local/embedded/weather/scripts/weather-current.sh
+++ b/forge-skills/local/embedded/weather/scripts/weather-current.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$1"
+
+location=$(jq -r '.location // empty' <<< "$input" 2>/dev/null) || location=""
+
+if [[ -z "$location" ]]; then
+  jq -n '{error: "location is required"}'
+  exit 0
+fi
+
+encoded_location=$(jq -rn --arg s "$location" '$s|@uri')
+
+response=$(curl -s -w "\n%{http_code}" "https://wttr.in/${encoded_location}?format=j1")
+http_code=$(tail -n1 <<< "$response")
+body=$(sed '$d' <<< "$response")
+
+if [[ "$http_code" != "200" ]]; then
+  jq -n --arg code "$http_code" '{error: "wttr.in request failed with status \($code)"}'
+  exit 0
+fi
+
+echo "$body" | jq '{
+  temperature_c: .current_condition[0].temp_C,
+  condition: .current_condition[0].weatherDesc[0].value,
+  humidity: .current_condition[0].humidity,
+  wind_speed_kmph: .current_condition[0].windspeedKmph
+}' 2>/dev/null || jq -n '{error: "failed to parse weather data"}'

--- a/forge-skills/local/embedded/weather/scripts/weather-forecast.sh
+++ b/forge-skills/local/embedded/weather/scripts/weather-forecast.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$1"
+
+location=$(jq -r '.location // empty' <<< "$input" 2>/dev/null) || location=""
+days=$(jq -r '.days // 3' <<< "$input" 2>/dev/null) || days=3
+
+if [[ -z "$location" ]]; then
+  jq -n '{error: "location is required"}'
+  exit 0
+fi
+
+if ! [[ "$days" =~ ^[0-9]+$ ]]; then
+  days=3
+fi
+if (( days < 1 )); then days=1; fi
+if (( days > 3 )); then days=3; fi
+
+encoded_location=$(jq -rn --arg s "$location" '$s|@uri')
+
+response=$(curl -s -w "\n%{http_code}" "https://wttr.in/${encoded_location}?format=j1")
+http_code=$(tail -n1 <<< "$response")
+body=$(sed '$d' <<< "$response")
+
+if [[ "$http_code" != "200" ]]; then
+  jq -n --arg code "$http_code" '{error: "wttr.in request failed with status \($code)"}'
+  exit 0
+fi
+
+echo "$body" | jq --argjson days "$days" '{
+  forecast: [.weather[0:$days][] | {
+    date: .date,
+    max_temp_c: .maxtempC,
+    min_temp_c: .mintempC,
+    condition: .hourly[0].weatherDesc[0].value
+  }]
+}' 2>/dev/null || jq -n '{error: "failed to parse forecast data"}'

--- a/forge-skills/local/scanner_test.go
+++ b/forge-skills/local/scanner_test.go
@@ -38,7 +38,7 @@ metadata:
       bins:
         - curl
     egress_domains:
-      - api.openweathermap.org
+      - wttr.in
 ---
 ## Tool: weather_current
 Get current weather.


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Description

The embedded weather skill was dead on arrival: it only allowed egress to `api.openweathermap.org` and `api.weatherapi.com`, both of which require an API key, while the skill declared no `env.required` key. On top of that, the tool sections were prose-only with no runnable command — nothing was actually wired to make a request.

This switches the skill to `wttr.in`, which needs no API key for reasonable free traffic, and adds runnable `curl` commands to both tools.

## General Checklist

- [x] Tests pass for affected modules (`go test ./...`)
- [x] Code is formatted (`gofmt -w`)
- [x] Linter passes (`golangci-lint run`)
- [x] `go vet` reports no issues
- [x] No new egress domains added without justification

## Skill Contribution Checklist

- [ ] `forge skills validate` passes with no errors
- [x] `forge skills audit` reports no policy violations
- [x] `egress_domains` lists every domain the skill contacts
- [x] No secrets or credentials are hardcoded
- [x] SKILL.md includes `## Tool:` sections with input/output tables
- [x] Skill tested locally with expected input/output

## Related Issues
Closes #349 

## Notes

- `forge skills validate` expects a project-level `forge.yaml`/`skills/` layout rather than the embedded skills path, so I validated via `forge skills audit --embedded` and `--dir` instead — both report `weather` at low risk (3/100) with no violations.
- Corrected the forecast range from "1-7" to "1-3" days in `SKILL.md`, since wttr.in's free JSON endpoint caps at 3 days (today + 2).
- Side note: while testing with `forge skills audit`, I noticed egress domains aren't reported correctly for `weather` (and pre-existing, for `github` too, which I didn't touch) — seems unrelated to this fix. Happy to open a separate issue if useful.
