### PR TITLE
fix(validate): accept hyphenated MCP tool names in allow/deny lists

### DIFF
--- a/forge-core/validate/mcp_config.go
+++ b/forge-core/validate/mcp_config.go
@@ -15,10 +15,15 @@ import (
 // ≤31 chars.
 var mcpServerNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
 
-// MCP tool name format. Allowed in Tools.Allow / Tools.Deny. Names
-// containing "__" are reserved for the namespaced runtime form
-// "<server>__<tool>"; here we only validate the bare tool name.
-var mcpToolNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{1,64}$`)
+// MCP tool name format. Allowed in Tools.Allow / Tools.Deny. Matches the
+// MCP spec's SHOULD pattern for tool names (`^[a-zA-Z0-9_-]{1,128}$`) —
+// real servers expose hyphenated names (Calendly's users-get_current_user,
+// event_types-list_event_types, …), and rejecting the hyphen bricked any
+// agent at startup whose allow-list carried the server's genuine tool
+// names. Names containing "__" are reserved for the namespaced runtime
+// form "<server>__<tool>" and rejected by a separate check; single "-"
+// or "_" pose no conflict with that separator.
+var mcpToolNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
 
 // knownMCPTransports is the closed set of accepted transport values.
 // Phase 1: HTTP only. Stdio is on the roadmap.

--- a/forge-core/validate/mcp_config_test.go
+++ b/forge-core/validate/mcp_config_test.go
@@ -234,12 +234,28 @@ func TestValidateMCPConfig(t *testing.T) {
 			wantErrs: []string{"invalid tool name"},
 		},
 		{
-			name: "deny tool name with hyphen rejected",
+			// Hyphenated names are the MCP-ecosystem norm (Calendly:
+			// users-get_current_user, event_types-list_event_types, …)
+			// and match the spec's SHOULD pattern. Rejecting them bricked
+			// agents at startup whose allow-lists carried the server's
+			// real tool names.
+			name: "tool names with hyphens accepted",
 			cfg: types.MCPConfig{Servers: []types.MCPServer{{
 				Name: "x", Transport: "http", URL: "http://x",
-				Tools: types.MCPToolFilter{Allow: []string{"good"}, Deny: []string{"bad-tool"}},
+				Tools: types.MCPToolFilter{
+					Allow: []string{"users-get_current_user", "scheduling_links-create_single_use_scheduling_link"},
+					Deny:  []string{"meetings-cancel_event"},
+				},
 			}}},
-			wantErrs: []string{"invalid tool name"},
+			wantErrs: nil,
+		},
+		{
+			name: "tool name with double underscore still rejected",
+			cfg: types.MCPConfig{Servers: []types.MCPServer{{
+				Name: "x", Transport: "http", URL: "http://x",
+				Tools: types.MCPToolFilter{Allow: []string{"foo__bar"}},
+			}}},
+			wantErrs: []string{"reserved for MCP namespacing"},
 		},
 		{
 			name: "tool in both allow and deny",


### PR DESCRIPTION
## Problem

`mcpToolNamePattern` (`forge-core/validate/mcp_config.go`) was `^[a-zA-Z0-9_]{1,64}$` — no hyphen. Hyphenated tool names are the MCP-ecosystem norm and match the spec's SHOULD pattern (`^[a-zA-Z0-9_-]{1,128}$`).

Field case (FanDuel): an agent built with the Calendly MCP registry entry crash-loops at startup, because its allow-list carries the server's **genuine** tool names:

```
ERROR: mcp.servers[0].tools.allow[0]: invalid tool name "event_types-get_event_type"
ERROR: mcp.servers[0].tools.allow[4]: invalid tool name "users-get_current_user"
Error: config validation failed: 5 error(s)
```

The platform can't rename these — they're what the upstream server exposes via `tools/list`, and `tools/call` must use them verbatim. Any MCP server with hyphenated tool names is currently undeployable.

## Fix

- Pattern → `^[a-zA-Z0-9_-]{1,128}$` (adds `-`, raises the length cap to the spec's 128).
- The `__` reservation is untouched — it's enforced by a separate check (the runtime `<server>__<tool>` namespace separator), and a single `-`/`_` poses no conflict with it. Now pinned by its own test case.
- Flipped the test that deliberately pinned hyphen rejection to instead pin acceptance of real Calendly names; added a `foo__bar` still-rejected case.

Runtime side needs no change: `validateDescriptorName` (adapter boundary, review B9) only enforces non-empty + no `__`, and the registry/DEFER keys use the namespaced form which is hyphen-safe.

## Testing

`go test ./...` green in forge-core; forge-cli builds. gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)