### PR TITLE
fix(runtime): dedup only a trailing identical user turn on session recovery (closes #378)

### DIFF
--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -308,21 +308,24 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 		}
 	}
 
-	// Append the new user message, but skip if the recovered session
-	// already ends with an identical user message (avoids duplicates
-	// when users retry after a premature loop exit).
+	// Append the new user message, but skip a genuine duplicate: a recovered
+	// session whose TRAILING message is an identical user turn — the
+	// premature-loop-exit case where the turn was persisted but never
+	// answered, so a retry resends it.
+	//
+	// The dedup MUST be trailing-only. An identical user turn EARLIER in
+	// history that was already answered (the session ends in an assistant
+	// message) is NOT a duplicate — the user is legitimately re-running the
+	// same request (e.g. after connecting a delegated MCP account). Matching
+	// the last user message anywhere dropped that re-run, so the loop
+	// replayed the poisoned transcript and repeated the last answer without
+	// re-attempting tools (#378).
 	newMsg := a2aMessageToLLM(*msg)
 	if recovered {
 		msgs := mem.Messages()
-		// Find the last user message in the recovered session.
-		lastUserIdx := -1
-		for j := len(msgs) - 1; j >= 0; j-- {
-			if msgs[j].Role == llm.RoleUser {
-				lastUserIdx = j
-				break
-			}
-		}
-		if lastUserIdx < 0 || msgs[lastUserIdx].Content != newMsg.Content {
+		n := len(msgs)
+		trailingDup := n > 0 && msgs[n-1].Role == llm.RoleUser && msgs[n-1].Content == newMsg.Content
+		if !trailingDup {
 			mem.Append(newMsg)
 		}
 	} else {

--- a/forge-core/runtime/loop_session_recovery_test.go
+++ b/forge-core/runtime/loop_session_recovery_test.go
@@ -351,3 +351,104 @@ func strconvItoa(n int) string {
 	}
 	return string(buf[i:])
 }
+
+// TestExecute_RecoveredSession_VerbatimReRunIsAppended is the #378 regression:
+// a recovered session that was ALREADY ANSWERED (ends in an assistant turn)
+// plus an identical incoming user message must APPEND the message and re-enter
+// the loop. The old dedup matched the last user message anywhere in history,
+// so a verbatim re-run (same text) was dropped — the loop replayed the
+// answered transcript and repeated the last reply without re-attempting tools
+// (field: a failed Jira exec never recovered after the account was connected).
+func TestExecute_RecoveredSession_VerbatimReRunIsAppended(t *testing.T) {
+	store, err := NewMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	const prompt = "give me top 3 open tickets under INIT Project"
+	// Seed an ANSWERED session: user asked, agent refused (ends in assistant).
+	if err := store.Save(&SessionData{
+		TaskID: "rerun", Messages: []llm.ChatMessage{
+			{Role: llm.RoleUser, Content: prompt},
+			{Role: llm.RoleAssistant, Content: "Jira access isn't connected yet."},
+		},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var captured []llm.ChatMessage
+	client := &mockLLMClient{chatFunc: func(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+		if captured == nil {
+			captured = req.Messages
+		}
+		return &llm.ChatResponse{
+			Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "here are the tickets"},
+			FinishReason: "stop",
+		}, nil
+	}}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: client, MaxIterations: 5, ModelName: "test", Provider: "openai", Store: store,
+	})
+	task := &a2a.Task{ID: "rerun"}
+	msg := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: prompt}}}
+	if _, err := exec.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// The loop must have seen the re-run as the TRAILING turn — otherwise the
+	// model is prompted to continue from its own last (refusal) message.
+	if len(captured) == 0 {
+		t.Fatal("the loop never called the model on a recovered re-run")
+	}
+	last := captured[len(captured)-1]
+	if last.Role != llm.RoleUser || last.Content != prompt {
+		t.Fatalf("recovered re-run not appended: last message is %s/%q, want user/%q\nfull: %s",
+			last.Role, last.Content, prompt, summarizeRoles(captured))
+	}
+}
+
+// TestExecute_RecoveredSession_TrailingUserDupSkipped is the no-regression
+// guard: a session ending in a USER turn (premature loop exit — persisted but
+// never answered) plus an identical incoming message must NOT duplicate that
+// turn (the case the dedup was written for).
+func TestExecute_RecoveredSession_TrailingUserDupSkipped(t *testing.T) {
+	store, err := NewMemoryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	const prompt = "summarize the repo"
+	if err := store.Save(&SessionData{
+		TaskID: "dup", Messages: []llm.ChatMessage{{Role: llm.RoleUser, Content: prompt}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var captured []llm.ChatMessage
+	client := &mockLLMClient{chatFunc: func(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
+		if captured == nil {
+			captured = req.Messages
+		}
+		return &llm.ChatResponse{
+			Message:      llm.ChatMessage{Role: llm.RoleAssistant, Content: "done"},
+			FinishReason: "stop",
+		}, nil
+	}}
+	exec := NewLLMExecutor(LLMExecutorConfig{
+		Client: client, MaxIterations: 5, ModelName: "test", Provider: "openai", Store: store,
+	})
+	task := &a2a.Task{ID: "dup"}
+	msg := &a2a.Message{Role: a2a.MessageRoleUser, Parts: []a2a.Part{{Kind: a2a.PartKindText, Text: prompt}}}
+	if _, err := exec.Execute(context.Background(), task, msg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	users := 0
+	for _, m := range captured {
+		if m.Role == llm.RoleUser && m.Content == prompt {
+			users++
+		}
+	}
+	if users != 1 {
+		t.Fatalf("trailing-user duplicate must be skipped: saw %d copies of the prompt\nfull: %s",
+			users, summarizeRoles(captured))
+	}
+}

--- a/forge-core/tools/adapters/mcp_tool.go
+++ b/forge-core/tools/adapters/mcp_tool.go
@@ -198,29 +198,37 @@ func (m *MCPTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	correlationID := runtime.CorrelationIDFromContext(ctx)
 
 	m.emitCall(correlationID, len(args))
-	// Resolve the connection for THIS call's requesting user (#317). A
-	// static resolver returns the shared client (unchanged); a per-subject
-	// pool returns that user's own connection, establishing it lazily.
-	client, err := m.resolveClient(ctx)
+	// resolveAndCall runs the whole resolve→call sequence for THIS request.
+	// ErrNoToken can surface from EITHER half: the per-subject connection
+	// establish (transports that authenticate at initialize) OR CallTool
+	// itself (transports that attach the token per-request and only 403 on
+	// the tools/call frame — Atlassian and most OAuth MCP servers). The auth
+	// gate (#330) must catch both, so it wraps the whole sequence rather than
+	// just resolveClient (the call-time case previously slipped past the gate
+	// and failed hard with reason=no_token — forge#376).
+	resolveAndCall := func() (*mcp.CallToolResult, error) {
+		client, err := m.resolveClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return client.CallTool(ctx, m.descriptor.Name, args)
+	}
+
+	res, err := resolveAndCall()
 	if err != nil && m.authGate != nil && errors.Is(err, mcp.ErrNoToken) {
 		// No grant yet for this user (#330). Rather than fail the call, park
-		// the executor and let the user consent; on a granted resume,
-		// re-resolve — the delegated path now finds the grant and the
-		// per-user connection establishes. A gate error (timeout / cancel /
-		// no requesting user) means give up; it flows to the emit+return
-		// below and classifies like the underlying ErrNoToken.
+		// the executor and let the user consent; on a granted resume, retry
+		// the full resolve→call — the delegated path now finds the grant, the
+		// per-user connection establishes, and the tool call goes through. A
+		// gate error (timeout / cancel / no requesting user) means give up;
+		// it flows to the emit+return below and classifies like the
+		// underlying ErrNoToken.
 		if gateErr := m.authGate.Await(ctx, m.server); gateErr != nil {
 			err = gateErr
 		} else {
-			client, err = m.resolveClient(ctx)
+			res, err = resolveAndCall()
 		}
 	}
-	if err != nil {
-		durMs := time.Since(start).Milliseconds()
-		m.emitResult(correlationID, durMs, 0, false, classifyToolErr(err))
-		return "", fmt.Errorf("mcp %s/%s: %w", m.server, m.descriptor.Name, err)
-	}
-	res, err := client.CallTool(ctx, m.descriptor.Name, args)
 	durMs := time.Since(start).Milliseconds()
 
 	if err != nil {

--- a/forge-core/tools/adapters/mcp_tool_test.go
+++ b/forge-core/tools/adapters/mcp_tool_test.go
@@ -343,3 +343,91 @@ func (b *safeBuf) String() string {
 	defer b.mu.Store(0)
 	return b.buf.String()
 }
+
+// gateStub records Await calls and returns a scripted outcome. nil err ⇒
+// "granted" (caller retries); non-nil ⇒ give up.
+type gateStub struct {
+	calls   atomic.Int32
+	err     error
+	onAwait func() // optional side effect on grant (e.g. flip the client to succeed)
+}
+
+func (g *gateStub) Await(context.Context, string) error {
+	g.calls.Add(1)
+	if g.onAwait != nil {
+		g.onAwait()
+	}
+	return g.err
+}
+
+// TestMCPTool_Execute_CallTimeNoToken_Parks is the forge#376 regression: an
+// ErrNoToken raised by CallTool (per-request auth transports — the token is
+// attached per frame, so the 403 lands on tools/call, not at establish) must
+// route through the auth gate and retry, exactly like an establish-time
+// ErrNoToken. Before the fix this path never consulted the gate and failed
+// hard with reason=no_token.
+func TestMCPTool_Execute_CallTimeNoToken_Parks(t *testing.T) {
+	t.Parallel()
+	// Client 403s on the first CallTool, succeeds after consent (the gate's
+	// onAwait flips it), modelling "grant now exists → retry resolves it".
+	c := &mockClient{err: mcp.ErrNoToken}
+	gate := &gateStub{onAwait: func() {
+		c.err = nil
+		c.res = &mcp.CallToolResult{Content: []mcp.ToolContent{{Type: "text", Text: "ok-after-consent"}}}
+	}}
+	a := newAdapter(t, c, func(m *MCPTool) { m.authGate = gate })
+
+	got, err := a.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected park+retry to succeed, got err=%v", err)
+	}
+	if gate.calls.Load() != 1 {
+		t.Fatalf("auth gate consulted %d times, want 1 (a call-time no-token must park)", gate.calls.Load())
+	}
+	if got != "ok-after-consent" {
+		t.Fatalf("got %q, want the post-consent retry result", got)
+	}
+}
+
+// TestMCPTool_Execute_CallTimeNoToken_GateGivesUp: when Await returns an error
+// (timeout / cancel / no requesting user), the call fails as no_token — no
+// second CallTool, no regression from prior fail-hard behavior.
+func TestMCPTool_Execute_CallTimeNoToken_GateGivesUp(t *testing.T) {
+	t.Parallel()
+	c := &mockClient{err: mcp.ErrNoToken}
+	gate := &gateStub{err: errors.New("consent timed out")}
+	a := newAdapter(t, c, func(m *MCPTool) { m.authGate = gate })
+
+	if _, err := a.Execute(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("a gate give-up must surface as an error")
+	}
+	if gate.calls.Load() != 1 {
+		t.Fatalf("gate consulted %d times, want exactly 1", gate.calls.Load())
+	}
+}
+
+// TestMCPTool_Execute_CallTimeError_NoSpuriousPark: a NON-ErrNoToken CallTool
+// error returns immediately without touching the gate.
+func TestMCPTool_Execute_CallTimeError_NoSpuriousPark(t *testing.T) {
+	t.Parallel()
+	c := &mockClient{err: errors.New("upstream 500")}
+	gate := &gateStub{}
+	a := newAdapter(t, c, func(m *MCPTool) { m.authGate = gate })
+
+	if _, err := a.Execute(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("a non-auth CallTool error must surface")
+	}
+	if gate.calls.Load() != 0 {
+		t.Fatalf("gate consulted %d times for a non-auth error, want 0", gate.calls.Load())
+	}
+}
+
+// TestMCPTool_Execute_NoGate_NoTokenSurfaces: with no gate wired, a call-time
+// ErrNoToken surfaces as before (nil-gate safety).
+func TestMCPTool_Execute_NoGate_NoTokenSurfaces(t *testing.T) {
+	t.Parallel()
+	a := newAdapter(t, &mockClient{err: mcp.ErrNoToken})
+	if _, err := a.Execute(context.Background(), json.RawMessage(`{}`)); !errors.Is(err, mcp.ErrNoToken) {
+		t.Fatalf("want ErrNoToken to surface with no gate, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #378.

## Problem

Re-running the **same** request in an already-answered execution does nothing — the agent replays its previous answer and never re-attempts tools. Field case: a delegated MCP (Atlassian) call failed "not connected"; the user connected the account and re-sent the identical request; the execution stayed broken (no tool call), while a fresh execution worked.

Log proof (`next-SNAPSHOT-50cd5e3`): `session recovered messages=7`, then one `llm_call` whose prompt **ends with the assistant's prior refusal — no new user turn appended** — and no `mcp_tool_call`/`tool_exec`. The re-send's message never reached the model.

## Root cause — `forge-core/runtime/loop.go`

On a recovered session, the dedup compared the incoming message against the last user message *anywhere* in history:

```go
for j := len(msgs) - 1; j >= 0; j-- { if msgs[j].Role == llm.RoleUser { lastUserIdx = j; break } }
if lastUserIdx < 0 || msgs[lastUserIdx].Content != newMsg.Content { mem.Append(newMsg) }
```

Its own comment scopes the intent to "already **ends with** an identical user message" (a premature-loop-exit duplicate). But when a prior identical request was already answered — the session ends in an assistant turn — a verbatim re-run matched that earlier user turn and was dropped. The model was re-run on the poisoned transcript with no new input.

## Fix

Dedup **trailing-only**:

```go
n := len(msgs)
trailingDup := n > 0 && msgs[n-1].Role == llm.RoleUser && msgs[n-1].Content == newMsg.Content
if !trailingDup { mem.Append(newMsg) }
```

A premature-exit duplicate leaves the session ending in a user turn → still skipped. A re-run of an answered request (session ends in an assistant turn) → appended, loop re-enters, tools re-attempted.

## Tests

- `VerbatimReRunIsAppended` — answered session (ends assistant) + identical incoming message → the message is the trailing turn the model sees (regression; fails on old code, which left the assistant refusal trailing).
- `TrailingUserDupSkipped` — session ending in an identical user turn → still deduped (no regression).

`go test ./runtime/...` green, gofmt + golangci-lint clean.

## Related

- Completes the delegated-MCP recovery story with #376/#377 (call-time auth-gate park): #377 stops a delegated call from *erroring into the transcript* in the first place; this fixes the plain "user re-sends the same text" recovery. Together the parked path auto-resumes and the re-send path re-attempts.
- Platform: initializ/console-next#67's auto-retry re-sends the last user message **verbatim**, so it hit this dedup and was swallowed — this is what makes that (and any manual re-type) actually work.