### PR TITLE
fix(channels): stop dumping raw tool JSON to Slack; keep chunks in-thread

### DIFF
--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -1078,15 +1078,35 @@ func isIntermediateOutputTool(toolName string) bool {
 // It attaches ONLY genuine prose deliverables (markdown). It never attaches:
 //   - intermediate-output tools (cli_execute, browser_*) — the model must
 //     analyze and summarize these, not forward them ("see attached");
+//   - MCP tool outputs (name contains "__") — these are structured API
+//     payloads (e.g. a Jira JQL search), not prose deliverables. The model
+//     must summarize them; forwarding the raw dump to a channel is exactly
+//     what a user never wants;
 //   - artifact-emitting tools — handled explicitly by fileArtifactFromToolResult;
 //   - output below the size threshold — the text answer carries it;
-//   - raw structured data (JSON/YAML, e.g. an MCP search result). Forwarded
-//     verbatim this dumps an unreadable blob to a channel, and once the ctxzip
-//     compression hook has run the blob still carries the "<<ctxzip:...>>"
-//     marker. Such outputs must be summarized by the model (which can expand
-//     offloaded rows if it needs them), never sent raw.
+//   - content the ctxzip compression hook already ran on. A compressed tool
+//     output carries "<<ctxzip:...>>" markers and is no longer valid JSON, so
+//     the detectFileType sniff below misclassifies it as markdown and would
+//     attach it — the exact bug that shipped a raw JSON blob as a `.md` file.
+//     A marker means "raw compressed tool dump", never a clean deliverable;
+//   - raw structured data (JSON/YAML) that is still uncompressed.
+//
+// The three suppression signals (MCP name, compression marker, detected
+// JSON/YAML) are deliberately redundant: content sniffing alone is defeated
+// once compression has mangled the bytes, so the tool-name and marker checks
+// are what actually hold for large real-world outputs.
 func largeOutputFilePart(toolName, result string) *a2a.Part {
 	if isIntermediateOutputTool(toolName) || artifactEmittingTools[toolName] || len(result) <= largeToolOutputThreshold {
+		return nil
+	}
+	// MCP tool → structured payload, summarize don't forward. The "__"
+	// namespace separator is reserved for MCP names (see MCPTool docs).
+	if strings.Contains(toolName, "__") {
+		return nil
+	}
+	// Compressed content is a raw tool dump, not a deliverable — and its
+	// markers defeat the content sniff below.
+	if strings.Contains(result, CompressionMarkerPrefix) {
 		return nil
 	}
 	name, mime := detectFileType(result, toolName)

--- a/forge-core/runtime/loop.go
+++ b/forge-core/runtime/loop.go
@@ -52,6 +52,11 @@ const (
 	toolResultCeilingAbsolute   = 4 << 20 // 4MB
 )
 
+// largeToolOutputThreshold is the size above which a non-artifact tool's
+// output is considered for auto-attachment as a channel file part (the LLM may
+// otherwise truncate it under output token limits). See largeOutputFilePart.
+const largeToolOutputThreshold = 8000
+
 // CompressionMarkerPrefix mirrors ctxzip's ccr.MarkerPrefix. The runtime
 // cannot import forge-core/compress (it imports runtime — cycle), so the
 // literal is pinned here and a guard test in the compress package asserts
@@ -340,7 +345,6 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 
 	// Track large tool outputs so they can be included as file parts
 	// in the response (the LLM may truncate them due to output token limits).
-	const largeToolOutputThreshold = 8000
 	var largeToolOutputs []a2a.Part
 
 	// stopNudgesSent tracks how many consecutive stop-nudges have been sent
@@ -813,16 +817,8 @@ func (e *LLMExecutor) Execute(ctx context.Context, task *a2a.Task, msg *a2a.Mess
 			// to say "see attached" instead of writing a report.
 			if part := fileArtifactFromToolResult(ctx, tc.Function.Name, result); part != nil {
 				largeToolOutputs = append(largeToolOutputs, *part)
-			} else if !isIntermediateOutputTool(tc.Function.Name) && !artifactEmittingTools[tc.Function.Name] && len(result) > largeToolOutputThreshold {
-				name, mime := detectFileType(result, tc.Function.Name)
-				largeToolOutputs = append(largeToolOutputs, a2a.Part{
-					Kind: a2a.PartKindFile,
-					File: &a2a.FileContent{
-						Name:     name,
-						MimeType: mime,
-						Bytes:    []byte(result),
-					},
-				})
+			} else if part := largeOutputFilePart(tc.Function.Name, result); part != nil {
+				largeToolOutputs = append(largeToolOutputs, *part)
 			}
 
 			// Append tool result to memory
@@ -1073,6 +1069,38 @@ func confinedFilesPath(ctx context.Context, p string) (string, bool) {
 // page digests/extracts.
 func isIntermediateOutputTool(toolName string) bool {
 	return toolName == "cli_execute" || browserToolNames[toolName]
+}
+
+// largeOutputFilePart decides whether a non-artifact tool's large output is
+// auto-attached to the channel response as a file part, returning the part or
+// nil.
+//
+// It attaches ONLY genuine prose deliverables (markdown). It never attaches:
+//   - intermediate-output tools (cli_execute, browser_*) — the model must
+//     analyze and summarize these, not forward them ("see attached");
+//   - artifact-emitting tools — handled explicitly by fileArtifactFromToolResult;
+//   - output below the size threshold — the text answer carries it;
+//   - raw structured data (JSON/YAML, e.g. an MCP search result). Forwarded
+//     verbatim this dumps an unreadable blob to a channel, and once the ctxzip
+//     compression hook has run the blob still carries the "<<ctxzip:...>>"
+//     marker. Such outputs must be summarized by the model (which can expand
+//     offloaded rows if it needs them), never sent raw.
+func largeOutputFilePart(toolName, result string) *a2a.Part {
+	if isIntermediateOutputTool(toolName) || artifactEmittingTools[toolName] || len(result) <= largeToolOutputThreshold {
+		return nil
+	}
+	name, mime := detectFileType(result, toolName)
+	if mime == "application/json" || mime == "text/yaml" {
+		return nil
+	}
+	return &a2a.Part{
+		Kind: a2a.PartKindFile,
+		File: &a2a.FileContent{
+			Name:     name,
+			MimeType: mime,
+			Bytes:    []byte(result),
+		},
+	}
 }
 
 // detectFileType inspects tool output content and returns an appropriate

--- a/forge-core/runtime/loop_artifact_test.go
+++ b/forge-core/runtime/loop_artifact_test.go
@@ -117,6 +117,41 @@ func TestFileArtifactFromToolResult_Negative(t *testing.T) {
 	}
 }
 
+// TestLargeOutputFilePart_NoRawJSON pins the channel-hygiene rule: large raw
+// structured data (JSON/YAML) from a normal tool is NEVER auto-attached — the
+// model must summarize it. Only large markdown/prose deliverables attach.
+func TestLargeOutputFilePart_NoRawJSON(t *testing.T) {
+	bigJSON := `{"issues":[` + strings.Repeat(`{"key":"INIT-1","x":"yyyyyyyyyy"},`, 400) + `{"key":"INIT-2"}]}`
+	if len(bigJSON) <= 8000 || !json.Valid([]byte(bigJSON)) {
+		t.Fatal("test premise broken: need a >8000-char valid JSON blob")
+	}
+	// An MCP tool (server__op) returning a large JSON search result.
+	if part := largeOutputFilePart("atlassian-write__searchJiraIssuesUsingJql", bigJSON); part != nil {
+		t.Errorf("large JSON was auto-attached as %q — must be summarized, not forwarded raw", part.File.Name)
+	}
+	// Same for a large YAML blob.
+	bigYAML := "---\n" + strings.Repeat("key: value\n", 1000)
+	if part := largeOutputFilePart("http_request", bigYAML); part != nil {
+		t.Errorf("large YAML was auto-attached as %q — must be summarized", part.File.Name)
+	}
+	// A large markdown/prose deliverable STILL attaches.
+	bigMD := "# Report\n\n" + strings.Repeat("Analysis paragraph. ", 500)
+	part := largeOutputFilePart("some_report_tool", bigMD)
+	if part == nil || part.File == nil {
+		t.Fatal("large markdown deliverable was not attached")
+	}
+	if part.File.MimeType != "text/markdown" {
+		t.Errorf("markdown deliverable mime = %q, want text/markdown", part.File.MimeType)
+	}
+	// Intermediate tools and sub-threshold output never attach.
+	if largeOutputFilePart("cli_execute", bigMD) != nil {
+		t.Error("cli_execute output must not be auto-attached")
+	}
+	if largeOutputFilePart("some_report_tool", "small") != nil {
+		t.Error("sub-threshold output must not be auto-attached")
+	}
+}
+
 func TestIsIntermediateOutputTool(t *testing.T) {
 	for tool, want := range map[string]bool{
 		"cli_execute":     true,

--- a/forge-core/runtime/loop_artifact_test.go
+++ b/forge-core/runtime/loop_artifact_test.go
@@ -152,6 +152,37 @@ func TestLargeOutputFilePart_NoRawJSON(t *testing.T) {
 	}
 }
 
+// TestLargeOutputFilePart_CompressedAndMCP is the regression for the live bug:
+// a large MCP JSON result that ctxzip has compressed is no longer valid JSON,
+// so detectFileType classifies the marker-laden bytes as markdown — the
+// content sniff alone would attach it as `<tool>-output.md`. The MCP-name and
+// compression-marker guards must suppress it regardless.
+func TestLargeOutputFilePart_CompressedAndMCP(t *testing.T) {
+	// Compressed JSON: starts with '{', carries a ctxzip marker, is NOT valid
+	// JSON — exactly what detectFileType would mislabel as markdown.
+	compressed := `{"issues":[` + strings.Repeat(`{"key":"INIT-1"},`, 500) +
+		"\n<<ctxzip:2cda42236849 55_lines_offloaded>>\n]}"
+	if json.Valid([]byte(compressed)) {
+		t.Fatal("test premise broken: compressed blob must be invalid JSON")
+	}
+	if _, mime := detectFileType(compressed, "x"); mime != "text/markdown" {
+		t.Fatalf("premise broken: compressed JSON should sniff as markdown, got %s", mime)
+	}
+
+	// The reported tool: MCP name (contains "__").
+	if part := largeOutputFilePart("atlassian-jira-mcp__searchJiraIssuesUsingJql", compressed); part != nil {
+		t.Errorf("compressed MCP JSON was attached as %q — the live bug is not fixed", part.File.Name)
+	}
+	// Even a non-MCP tool: the compression marker alone must suppress it.
+	if part := largeOutputFilePart("some_report_tool", compressed); part != nil {
+		t.Errorf("compressed output was attached as %q — marker guard failed", part.File.Name)
+	}
+	// Any MCP tool output is suppressed even when uncompressed and prose-like.
+	if largeOutputFilePart("atlassian-jira-mcp__searchJiraIssuesUsingJql", "# Heading\n\n"+strings.Repeat("prose ", 2000)) != nil {
+		t.Error("MCP tool output must never be auto-attached")
+	}
+}
+
 func TestIsIntermediateOutputTool(t *testing.T) {
 	for tool, want := range map[string]bool{
 		"cli_execute":     true,

--- a/forge-plugins/channels/markdown/compression.go
+++ b/forge-plugins/channels/markdown/compression.go
@@ -1,0 +1,26 @@
+package markdown
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ctxzipMarkerRe matches an internal context-compression pointer
+// ("<<ctxzip:HASH note>>") that ctxzip leaves in place of offloaded content.
+// Mirrors github.com/initializ/ctxzip/ccr's marker format. Kept in this shared
+// package so every channel plugin strips markers identically (the format is
+// also pinned as CompressionMarkerPrefix in forge-core/runtime, which cannot
+// import this package for import-cycle reasons).
+var ctxzipMarkerRe = regexp.MustCompile(`<<ctxzip:[0-9a-f]{12,64}(?:[ ,][^>]*)?>>`)
+
+// StripCompressionMarkers removes any ctxzip markers that leaked into
+// channel-bound text or file content. These are internal artifacts of context
+// compression; a user must never see them. The model is expected to expand
+// offloaded content it needs before answering, so a marker reaching a channel
+// is a leak — drop it rather than surface a dangling pointer.
+func StripCompressionMarkers(s string) string {
+	if !strings.Contains(s, "<<ctxzip:") {
+		return s
+	}
+	return strings.TrimSpace(ctxzipMarkerRe.ReplaceAllString(s, ""))
+}

--- a/forge-plugins/channels/markdown/compression_test.go
+++ b/forge-plugins/channels/markdown/compression_test.go
@@ -1,0 +1,41 @@
+package markdown
+
+import "testing"
+
+func TestStripCompressionMarkers(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"no marker", "plain text", "plain text"},
+		{
+			"trailing marker",
+			"Here are the issues.\n\n<<ctxzip:2cda42236849 55_lines_offloaded>>",
+			"Here are the issues.",
+		},
+		{
+			"inline marker",
+			"before <<ctxzip:abc123abc123 12_rows_offloaded>> after",
+			"before  after",
+		},
+		{
+			"multiple markers",
+			"<<ctxzip:aaaaaaaaaaaa 1_rows_offloaded>>x<<ctxzip:bbbbbbbbbbbb 2_rows_offloaded>>",
+			"x",
+		},
+		{
+			"bare marker no note",
+			"data<<ctxzip:0123456789ab>>",
+			"data",
+		},
+		// A "<<ctxzip:" that is not a well-formed marker is left alone rather
+		// than eating the rest of the string.
+		{"malformed left intact", "text <<ctxzip:not-hex blah", "text <<ctxzip:not-hex blah"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripCompressionMarkers(tt.in); got != tt.want {
+				t.Errorf("StripCompressionMarkers(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/forge-plugins/channels/msteams/msteams.go
+++ b/forge-plugins/channels/msteams/msteams.go
@@ -722,7 +722,7 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 	summary := ""
 	full := text
 	if response != nil {
-		summary = response.Summary
+		summary = markdown.StripCompressionMarkers(response.Summary)
 	}
 	if summary == "" {
 		summary, full = markdown.SplitSummaryAndReport(text)

--- a/forge-plugins/channels/msteams/msteams.go
+++ b/forge-plugins/channels/msteams/msteams.go
@@ -806,7 +806,7 @@ func extractText(msg *a2a.Message) string {
 	if len(parts) == 0 {
 		return "(no text response)"
 	}
-	return strings.Join(parts, "\n")
+	return markdown.StripCompressionMarkers(strings.Join(parts, "\n"))
 }
 
 // errIs is a small wrapper around errors.Is that tolerates wrapped sentinels

--- a/forge-plugins/channels/slack/longresponse_test.go
+++ b/forge-plugins/channels/slack/longresponse_test.go
@@ -24,6 +24,57 @@ func TestExtractText_StripsCompressionMarker(t *testing.T) {
 	}
 }
 
+// TestSendResponse_SummaryStripsCompressionMarker pins that a marker leaking
+// into the runtime-supplied response.Summary never reaches the channel. The
+// summary is composed over the possibly-compressed context, so it's a likely
+// leak site. Exercises the file-part branch (full upload flow → summary post).
+func TestSendResponse_SummaryStripsCompressionMarker(t *testing.T) {
+	var postedText string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/files.getUploadURLExternal":
+			_, _ = w.Write([]byte(`{"ok":true,"upload_url":"http://` + r.Host + `/upload","file_id":"F1"}`))
+		case "/upload":
+			w.WriteHeader(http.StatusOK)
+		case "/files.completeUploadExternal":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/chat.postMessage":
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]any
+			_ = json.Unmarshal(body, &payload)
+			postedText, _ = payload["text"].(string)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := New()
+	p.botToken = "xoxb-test-token"
+	p.apiBase = srv.URL
+
+	event := &channels.ChannelEvent{WorkspaceID: "C0123456", MessageID: "1699.0001"}
+	msg := &a2a.Message{
+		Role:    a2a.MessageRoleAgent,
+		Summary: "Found 3 issues. <<ctxzip:2cda42236849 55_lines_offloaded>>",
+		Parts: []a2a.Part{
+			a2a.NewTextPart("short text"),
+			a2a.NewFilePart(a2a.FileContent{Name: "report.md", Bytes: []byte(strings.Repeat("full report body\n", 200))}),
+		},
+	}
+
+	if err := p.SendResponse(event, msg); err != nil {
+		t.Fatalf("SendResponse error: %v", err)
+	}
+	if postedText == "" {
+		t.Fatal("no chat.postMessage captured")
+	}
+	if strings.Contains(postedText, "ctxzip") {
+		t.Errorf("summary leaked a compression marker to the channel: %q", postedText)
+	}
+}
+
 // recordingServer captures every chat.postMessage payload the plugin sends.
 func recordingServer(t *testing.T) (*httptest.Server, *[]map[string]any) {
 	t.Helper()

--- a/forge-plugins/channels/slack/longresponse_test.go
+++ b/forge-plugins/channels/slack/longresponse_test.go
@@ -1,0 +1,146 @@
+package slack
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+	"github.com/initializ/forge/forge-core/channels"
+)
+
+func TestStripCompressionMarkers(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"no marker", "plain text", "plain text"},
+		{
+			"trailing marker",
+			"Here are the issues.\n\n<<ctxzip:2cda42236849 55_lines_offloaded>>",
+			"Here are the issues.",
+		},
+		{
+			"inline marker",
+			"before <<ctxzip:abc123abc123 12_rows_offloaded>> after",
+			"before  after",
+		},
+		{
+			"multiple markers",
+			"<<ctxzip:aaaaaaaaaaaa 1_rows_offloaded>>x<<ctxzip:bbbbbbbbbbbb 2_rows_offloaded>>",
+			"x",
+		},
+		{
+			"bare marker no note",
+			"data<<ctxzip:0123456789ab>>",
+			"data",
+		},
+		// A "<<ctxzip:" that is not a well-formed marker is left alone rather
+		// than eating the rest of the string.
+		{"malformed left intact", "text <<ctxzip:not-hex blah", "text <<ctxzip:not-hex blah"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripCompressionMarkers(tt.in); got != tt.want {
+				t.Errorf("stripCompressionMarkers(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractText_StripsCompressionMarker pins that a leaked ctxzip marker
+// never reaches a Slack channel through the text path.
+func TestExtractText_StripsCompressionMarker(t *testing.T) {
+	msg := &a2a.Message{Parts: []a2a.Part{
+		a2a.NewTextPart("Summary of results. <<ctxzip:2cda42236849 55_lines_offloaded>>"),
+	}}
+	if got := extractText(msg); strings.Contains(got, "ctxzip") {
+		t.Errorf("extractText leaked a compression marker: %q", got)
+	}
+}
+
+// recordingServer captures every chat.postMessage payload the plugin sends.
+func recordingServer(t *testing.T) (*httptest.Server, *[]map[string]any) {
+	t.Helper()
+	var mu sync.Mutex
+	var calls []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/chat.postMessage") {
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]any
+			_ = json.Unmarshal(body, &payload)
+			mu.Lock()
+			calls = append(calls, payload)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	return srv, &calls
+}
+
+// TestSendChunked_AllChunksThreaded is the regression for the split bug: every
+// chunk of a multi-message fallback must carry thread_ts, so none leak to the
+// main channel.
+func TestSendChunked_AllChunksThreaded(t *testing.T) {
+	srv, calls := recordingServer(t)
+	defer srv.Close()
+
+	p := New()
+	p.botToken = "xoxb-test-token"
+	p.apiBase = srv.URL
+
+	event := &channels.ChannelEvent{
+		WorkspaceID: "C0123456",
+		ThreadID:    "1699.0001",
+	}
+
+	// Force multiple chunks: comfortably over the 4000-char split size.
+	big := strings.Repeat("line of report text\n", 800)
+	if err := p.sendChunked(event, big); err != nil {
+		t.Fatalf("sendChunked error: %v", err)
+	}
+
+	if len(*calls) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(*calls))
+	}
+	for i, c := range *calls {
+		if c["thread_ts"] != "1699.0001" {
+			t.Errorf("chunk %d thread_ts = %v, want 1699.0001 (chunk leaked to main channel)", i, c["thread_ts"])
+		}
+	}
+}
+
+// TestSendChunked_ThreadsUnderMessageID: when the event has no existing thread,
+// chunks reply under the originating message id so the whole reply stays in one
+// thread rather than splitting across the channel.
+func TestSendChunked_ThreadsUnderMessageID(t *testing.T) {
+	srv, calls := recordingServer(t)
+	defer srv.Close()
+
+	p := New()
+	p.botToken = "xoxb-test-token"
+	p.apiBase = srv.URL
+
+	event := &channels.ChannelEvent{
+		WorkspaceID: "C0123456",
+		MessageID:   "1699.9999",
+	}
+
+	big := strings.Repeat("line of report text\n", 800)
+	if err := p.sendChunked(event, big); err != nil {
+		t.Fatalf("sendChunked error: %v", err)
+	}
+
+	if len(*calls) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(*calls))
+	}
+	for i, c := range *calls {
+		if c["thread_ts"] != "1699.9999" {
+			t.Errorf("chunk %d thread_ts = %v, want 1699.9999", i, c["thread_ts"])
+		}
+	}
+}

--- a/forge-plugins/channels/slack/longresponse_test.go
+++ b/forge-plugins/channels/slack/longresponse_test.go
@@ -13,44 +13,6 @@ import (
 	"github.com/initializ/forge/forge-core/channels"
 )
 
-func TestStripCompressionMarkers(t *testing.T) {
-	tests := []struct {
-		name, in, want string
-	}{
-		{"no marker", "plain text", "plain text"},
-		{
-			"trailing marker",
-			"Here are the issues.\n\n<<ctxzip:2cda42236849 55_lines_offloaded>>",
-			"Here are the issues.",
-		},
-		{
-			"inline marker",
-			"before <<ctxzip:abc123abc123 12_rows_offloaded>> after",
-			"before  after",
-		},
-		{
-			"multiple markers",
-			"<<ctxzip:aaaaaaaaaaaa 1_rows_offloaded>>x<<ctxzip:bbbbbbbbbbbb 2_rows_offloaded>>",
-			"x",
-		},
-		{
-			"bare marker no note",
-			"data<<ctxzip:0123456789ab>>",
-			"data",
-		},
-		// A "<<ctxzip:" that is not a well-formed marker is left alone rather
-		// than eating the rest of the string.
-		{"malformed left intact", "text <<ctxzip:not-hex blah", "text <<ctxzip:not-hex blah"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := stripCompressionMarkers(tt.in); got != tt.want {
-				t.Errorf("stripCompressionMarkers(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestExtractText_StripsCompressionMarker pins that a leaked ctxzip marker
 // never reaches a Slack channel through the text path.
 func TestExtractText_StripsCompressionMarker(t *testing.T) {

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -1002,23 +1001,6 @@ func unwrapJSONContent(text string) string {
 	return text
 }
 
-// ctxzipMarkerRe matches an internal context-compression pointer
-// ("<<ctxzip:HASH note>>") that ctxzip leaves in place of offloaded content.
-// Mirrors github.com/initializ/ctxzip/ccr's marker format.
-var ctxzipMarkerRe = regexp.MustCompile(`<<ctxzip:[0-9a-f]{12,64}(?:[ ,][^>]*)?>>`)
-
-// stripCompressionMarkers removes any ctxzip markers that leaked into
-// channel-bound text. These are internal artifacts of context compression; a
-// user must never see them. The model is expected to expand offloaded content
-// it needs before answering, so a marker reaching a channel is a leak — drop
-// it rather than surface a dangling pointer.
-func stripCompressionMarkers(s string) string {
-	if !strings.Contains(s, "<<ctxzip:") {
-		return s
-	}
-	return strings.TrimSpace(ctxzipMarkerRe.ReplaceAllString(s, ""))
-}
-
 // extractText concatenates all text parts from an A2A message.
 func extractText(msg *a2a.Message) string {
 	if msg == nil {
@@ -1033,7 +1015,7 @@ func extractText(msg *a2a.Message) string {
 			text += unwrapJSONContent(p.Text)
 		}
 	}
-	text = stripCompressionMarkers(text)
+	text = markdown.StripCompressionMarkers(text)
 	if text == "" {
 		text = "(no text response)"
 	}
@@ -1057,7 +1039,7 @@ func extractLargestFile(msg *a2a.Message) (content, filename string) {
 			if strings.HasSuffix(p.File.Name, ".md") {
 				raw = unwrapJSONContent(raw)
 			}
-			content = stripCompressionMarkers(raw)
+			content = markdown.StripCompressionMarkers(raw)
 			filename = p.File.Name
 		}
 	}

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -695,18 +696,22 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 	mrkdwn := markdown.ToSlackMrkdwn(text)
 	chunks := markdown.SplitMessage(mrkdwn, 4000)
 
-	for i, chunk := range chunks {
+	// Thread EVERY chunk under the same parent. Threading only the first
+	// chunk (the old behavior) left continuation chunks with no thread_ts, so
+	// Slack posted them to the main channel — a reply split half in-thread,
+	// half in the channel.
+	threadTS := event.ThreadID
+	if threadTS == "" {
+		threadTS = event.MessageID
+	}
+	for _, chunk := range chunks {
 		payload := map[string]any{
 			"channel": event.WorkspaceID,
 			"text":    chunk,
 			"mrkdwn":  true,
 		}
-		if i == 0 {
-			if event.ThreadID != "" {
-				payload["thread_ts"] = event.ThreadID
-			} else if event.MessageID != "" {
-				payload["thread_ts"] = event.MessageID
-			}
+		if threadTS != "" {
+			payload["thread_ts"] = threadTS
 		}
 		if err := p.postMessage(payload); err != nil {
 			return err
@@ -719,18 +724,20 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 func (p *Plugin) sendChunked(event *channels.ChannelEvent, text string) error {
 	mrkdwn := markdown.ToSlackMrkdwn(text)
 	chunks := markdown.SplitMessage(mrkdwn, 4000)
-	for i, chunk := range chunks {
+	// Thread every chunk under the same parent (see SendResponse) so a
+	// multi-chunk fallback doesn't split across thread and main channel.
+	threadTS := event.ThreadID
+	if threadTS == "" {
+		threadTS = event.MessageID
+	}
+	for _, chunk := range chunks {
 		payload := map[string]any{
 			"channel": event.WorkspaceID,
 			"text":    chunk,
 			"mrkdwn":  true,
 		}
-		if i == 0 {
-			if event.ThreadID != "" {
-				payload["thread_ts"] = event.ThreadID
-			} else if event.MessageID != "" {
-				payload["thread_ts"] = event.MessageID
-			}
+		if threadTS != "" {
+			payload["thread_ts"] = threadTS
 		}
 		if err := p.postMessage(payload); err != nil {
 			return err
@@ -995,6 +1002,23 @@ func unwrapJSONContent(text string) string {
 	return text
 }
 
+// ctxzipMarkerRe matches an internal context-compression pointer
+// ("<<ctxzip:HASH note>>") that ctxzip leaves in place of offloaded content.
+// Mirrors github.com/initializ/ctxzip/ccr's marker format.
+var ctxzipMarkerRe = regexp.MustCompile(`<<ctxzip:[0-9a-f]{12,64}(?:[ ,][^>]*)?>>`)
+
+// stripCompressionMarkers removes any ctxzip markers that leaked into
+// channel-bound text. These are internal artifacts of context compression; a
+// user must never see them. The model is expected to expand offloaded content
+// it needs before answering, so a marker reaching a channel is a leak — drop
+// it rather than surface a dangling pointer.
+func stripCompressionMarkers(s string) string {
+	if !strings.Contains(s, "<<ctxzip:") {
+		return s
+	}
+	return strings.TrimSpace(ctxzipMarkerRe.ReplaceAllString(s, ""))
+}
+
 // extractText concatenates all text parts from an A2A message.
 func extractText(msg *a2a.Message) string {
 	if msg == nil {
@@ -1009,6 +1033,7 @@ func extractText(msg *a2a.Message) string {
 			text += unwrapJSONContent(p.Text)
 		}
 	}
+	text = stripCompressionMarkers(text)
 	if text == "" {
 		text = "(no text response)"
 	}
@@ -1032,7 +1057,7 @@ func extractLargestFile(msg *a2a.Message) (content, filename string) {
 			if strings.HasSuffix(p.File.Name, ".md") {
 				raw = unwrapJSONContent(raw)
 			}
-			content = raw
+			content = stripCompressionMarkers(raw)
 			filename = p.File.Name
 		}
 	}

--- a/forge-plugins/channels/slack/slack.go
+++ b/forge-plugins/channels/slack/slack.go
@@ -641,7 +641,7 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 
 		// File uploaded — prefer the runtime-generated summary when available,
 		// otherwise fall back to head-truncating the LLM text.
-		summary := response.Summary
+		summary := markdown.StripCompressionMarkers(response.Summary)
 		if summary == "" {
 			summary = text
 			if len(summary) > 600 {
@@ -663,7 +663,7 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 
 	// No file parts — use text-based logic.
 	if len(text) > 4096 {
-		summary := response.Summary
+		summary := markdown.StripCompressionMarkers(response.Summary)
 		report := text
 		if summary == "" {
 			summary, report = markdown.SplitSummaryAndReport(text)

--- a/forge-plugins/channels/telegram/marker_test.go
+++ b/forge-plugins/channels/telegram/marker_test.go
@@ -7,37 +7,6 @@ import (
 	"github.com/initializ/forge/forge-core/a2a"
 )
 
-func TestStripCompressionMarkers(t *testing.T) {
-	tests := []struct {
-		name, in, want string
-	}{
-		{"no marker", "plain text", "plain text"},
-		{
-			"trailing marker",
-			"Here are the issues.\n\n<<ctxzip:2cda42236849 55_lines_offloaded>>",
-			"Here are the issues.",
-		},
-		{
-			"inline marker",
-			"before <<ctxzip:abc123abc123 12_rows_offloaded>> after",
-			"before  after",
-		},
-		{
-			"bare marker no note",
-			"data<<ctxzip:0123456789ab>>",
-			"data",
-		},
-		{"malformed left intact", "text <<ctxzip:not-hex blah", "text <<ctxzip:not-hex blah"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := stripCompressionMarkers(tt.in); got != tt.want {
-				t.Errorf("stripCompressionMarkers(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestExtractText_StripsCompressionMarker pins that a leaked ctxzip marker
 // never reaches a Telegram chat through the text path.
 func TestExtractText_StripsCompressionMarker(t *testing.T) {

--- a/forge-plugins/channels/telegram/marker_test.go
+++ b/forge-plugins/channels/telegram/marker_test.go
@@ -1,0 +1,68 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/a2a"
+)
+
+func TestStripCompressionMarkers(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"no marker", "plain text", "plain text"},
+		{
+			"trailing marker",
+			"Here are the issues.\n\n<<ctxzip:2cda42236849 55_lines_offloaded>>",
+			"Here are the issues.",
+		},
+		{
+			"inline marker",
+			"before <<ctxzip:abc123abc123 12_rows_offloaded>> after",
+			"before  after",
+		},
+		{
+			"bare marker no note",
+			"data<<ctxzip:0123456789ab>>",
+			"data",
+		},
+		{"malformed left intact", "text <<ctxzip:not-hex blah", "text <<ctxzip:not-hex blah"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripCompressionMarkers(tt.in); got != tt.want {
+				t.Errorf("stripCompressionMarkers(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractText_StripsCompressionMarker pins that a leaked ctxzip marker
+// never reaches a Telegram chat through the text path.
+func TestExtractText_StripsCompressionMarker(t *testing.T) {
+	msg := &a2a.Message{Parts: []a2a.Part{
+		a2a.NewTextPart("Summary of results. <<ctxzip:2cda42236849 55_lines_offloaded>>"),
+	}}
+	if got := extractText(msg); strings.Contains(got, "ctxzip") {
+		t.Errorf("extractText leaked a compression marker: %q", got)
+	}
+}
+
+// TestExtractLargestFile_StripsCompressionMarker: a compressed markdown
+// deliverable carries no marker into the uploaded document either.
+func TestExtractLargestFile_StripsCompressionMarker(t *testing.T) {
+	msg := &a2a.Message{Parts: []a2a.Part{
+		a2a.NewFilePart(a2a.FileContent{
+			Name:  "report.md",
+			Bytes: []byte("# Report\n\nfindings <<ctxzip:abcabcabcabc 9_rows_offloaded>>"),
+		}),
+	}}
+	content, name := extractLargestFile(msg)
+	if name != "report.md" {
+		t.Fatalf("filename = %q, want report.md", name)
+	}
+	if strings.Contains(content, "ctxzip") {
+		t.Errorf("extractLargestFile leaked a compression marker: %q", content)
+	}
+}

--- a/forge-plugins/channels/telegram/telegram.go
+++ b/forge-plugins/channels/telegram/telegram.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -612,23 +611,6 @@ func (p *Plugin) sendMessage(payload map[string]any) error {
 	return nil
 }
 
-// ctxzipMarkerRe matches an internal context-compression pointer
-// ("<<ctxzip:HASH note>>") that ctxzip leaves in place of offloaded content.
-// Mirrors github.com/initializ/ctxzip/ccr's marker format.
-var ctxzipMarkerRe = regexp.MustCompile(`<<ctxzip:[0-9a-f]{12,64}(?:[ ,][^>]*)?>>`)
-
-// stripCompressionMarkers removes any ctxzip markers that leaked into
-// channel-bound text. These are internal artifacts of context compression; a
-// user must never see them. The model is expected to expand offloaded content
-// it needs before answering, so a marker reaching a channel is a leak — drop
-// it rather than surface a dangling pointer.
-func stripCompressionMarkers(s string) string {
-	if !strings.Contains(s, "<<ctxzip:") {
-		return s
-	}
-	return strings.TrimSpace(ctxzipMarkerRe.ReplaceAllString(s, ""))
-}
-
 // extractText concatenates all text parts from an A2A message.
 func extractText(msg *a2a.Message) string {
 	if msg == nil {
@@ -643,7 +625,7 @@ func extractText(msg *a2a.Message) string {
 			text += p.Text
 		}
 	}
-	text = stripCompressionMarkers(text)
+	text = markdown.StripCompressionMarkers(text)
 	if text == "" {
 		text = "(no text response)"
 	}
@@ -660,7 +642,7 @@ func extractLargestFile(msg *a2a.Message) (content, filename string) {
 	}
 	for _, p := range msg.Parts {
 		if p.Kind == a2a.PartKindFile && p.File != nil && len(p.File.Bytes) > len(content) {
-			content = stripCompressionMarkers(string(p.File.Bytes))
+			content = markdown.StripCompressionMarkers(string(p.File.Bytes))
 			filename = p.File.Name
 		}
 	}

--- a/forge-plugins/channels/telegram/telegram.go
+++ b/forge-plugins/channels/telegram/telegram.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -611,6 +612,23 @@ func (p *Plugin) sendMessage(payload map[string]any) error {
 	return nil
 }
 
+// ctxzipMarkerRe matches an internal context-compression pointer
+// ("<<ctxzip:HASH note>>") that ctxzip leaves in place of offloaded content.
+// Mirrors github.com/initializ/ctxzip/ccr's marker format.
+var ctxzipMarkerRe = regexp.MustCompile(`<<ctxzip:[0-9a-f]{12,64}(?:[ ,][^>]*)?>>`)
+
+// stripCompressionMarkers removes any ctxzip markers that leaked into
+// channel-bound text. These are internal artifacts of context compression; a
+// user must never see them. The model is expected to expand offloaded content
+// it needs before answering, so a marker reaching a channel is a leak — drop
+// it rather than surface a dangling pointer.
+func stripCompressionMarkers(s string) string {
+	if !strings.Contains(s, "<<ctxzip:") {
+		return s
+	}
+	return strings.TrimSpace(ctxzipMarkerRe.ReplaceAllString(s, ""))
+}
+
 // extractText concatenates all text parts from an A2A message.
 func extractText(msg *a2a.Message) string {
 	if msg == nil {
@@ -625,6 +643,7 @@ func extractText(msg *a2a.Message) string {
 			text += p.Text
 		}
 	}
+	text = stripCompressionMarkers(text)
 	if text == "" {
 		text = "(no text response)"
 	}
@@ -641,7 +660,7 @@ func extractLargestFile(msg *a2a.Message) (content, filename string) {
 	}
 	for _, p := range msg.Parts {
 		if p.Kind == a2a.PartKindFile && p.File != nil && len(p.File.Bytes) > len(content) {
-			content = string(p.File.Bytes)
+			content = stripCompressionMarkers(string(p.File.Bytes))
 			filename = p.File.Name
 		}
 	}

--- a/forge-plugins/channels/telegram/telegram.go
+++ b/forge-plugins/channels/telegram/telegram.go
@@ -358,7 +358,7 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 
 		// Document uploaded — prefer the runtime-generated summary when available,
 		// otherwise fall back to head-truncating the LLM text.
-		summary := response.Summary
+		summary := markdown.StripCompressionMarkers(response.Summary)
 		if summary == "" {
 			summary = text
 			if len(summary) > 600 {
@@ -385,7 +385,7 @@ func (p *Plugin) SendResponse(event *channels.ChannelEvent, response *a2a.Messag
 
 	// No file parts — use text-based logic.
 	if len(text) > 4096 {
-		summary := response.Summary
+		summary := markdown.StripCompressionMarkers(response.Summary)
 		report := text
 		if summary == "" {
 			summary, report = markdown.SplitSummaryAndReport(text)


### PR DESCRIPTION
## Problem

A long MCP/tool response (e.g. an Atlassian `searchJiraIssuesUsingJql` result) reached Slack as an **unreadable raw-JSON attachment**. When the bot lacked the `files:write` scope, the same raw JSON was chunked into chat messages — and the reply **split half in-thread, half in the main channel**. The internal `<<ctxzip:…>>` context-compression marker also leaked into the text.

### Root cause (one chain)
1. The `ctxzip` `AfterToolExec` hook compresses large tool output, leaving a `<<ctxzip:HASH …>>` marker.
2. `loop.go` then attaches that compressed blob as a `…-output.json` file part (MCP tools aren't classified as intermediate).
3. Slack's `extractLargestFile` only unwraps `.md`, so the `.json` is uploaded **verbatim** → raw-JSON attachment; on upload failure it's chunked into chat.
4. Only the **first** chunk carried `thread_ts`, so continuation chunks posted to the main channel.

## Fixes

**1. `forge-core/runtime/loop.go` — never auto-attach raw structured data (channel-agnostic)**
Extracted the attach decision into a testable `largeOutputFilePart()`. It attaches **only genuine prose deliverables (markdown)**; JSON/YAML tool output (incl. all MCP search results) is never forwarded — the model must summarize it (it can `expand` offloaded rows if needed). Promoted `largeToolOutputThreshold` to package scope.

**2. `forge-plugins/channels/slack/slack.go` — thread every chunk**
Both the primary chunk loop and the `sendChunked` fallback now compute `thread_ts` once and apply it to **every** chunk, so a multi-message reply can no longer split between thread and channel. (Slack-specific: Telegram/Teams post every message to the same chat regardless, so they have no equivalent split.)

**3. Strip leaked `<<ctxzip:…>>` markers across all channels**
A single shared `markdown.StripCompressionMarkers` helper (in the `channels/markdown` package both plugins already import) is applied in the `extractText` / `extractLargestFile` paths of **Slack, Telegram, and MS Teams**, so a compression pointer never reaches any channel. (The format is still pinned separately as `CompressionMarkerPrefix` in `forge-core/runtime` for a documented import-cycle reason.)

## Tests
- `largeOutputFilePart`: raw-JSON/YAML suppressed, markdown still attaches, intermediate + sub-threshold skipped.
- `markdown.StripCompressionMarkers`: full vector suite (trailing / inline / multiple / bare / malformed-left-intact).
- Per-plugin `extractText` / `extractLargestFile` marker leak guards (Slack + Telegram).
- `sendChunked`: all chunks threaded (under `ThreadID`, and under `MessageID` when no thread exists).

`gofmt`, `golangci-lint run` (0 issues), and full `go test ./...` pass for both `forge-core` and `forge-plugins`.

## Scope note
Fix #1 is channel-agnostic (stops raw-JSON attachment for every channel). Fix #3 covers Slack, Telegram, and MS Teams via one shared helper. Fix #2 (thread hygiene) is Slack-only by design — the other channels have no thread/main split to fix.
