### PR TITLE
feat(runtime): managed PDP decision resolver at BeforeToolExec

### DIFF
--- a/forge-cli/runtime/defer.go
+++ b/forge-cli/runtime/defer.go
@@ -57,8 +57,7 @@ func (r *Runner) registerDeferHook(hooks *coreruntime.HookRegistry, store TaskSt
 	if !cfg.Enabled || len(cfg.Tools) == 0 {
 		return
 	}
-	engine := r.deferEngine
-	if engine == nil {
+	if r.deferEngine == nil {
 		return
 	}
 	hooks.Register(coreruntime.BeforeToolExec, func(ctx context.Context, hctx *coreruntime.HookContext) error {
@@ -66,120 +65,134 @@ func (r *Runner) registerDeferHook(hooks *coreruntime.HookRegistry, store TaskSt
 		if !has {
 			return nil // fast path: tool has no defer requirement
 		}
-
 		spec := resolveDeferSpec(cfg, toolCfg, hctx)
-		handle, err := engine.Register(hctx.TaskID, hctx.ToolName, spec)
-		if err != nil {
-			// Only happens on duplicate register — a hook-level bug.
-			// Fail closed rather than silently dropping.
-			return fmt.Errorf("defer: %w", err)
-		}
+		return r.park(ctx, hctx, spec, store, auditLogger)
+	})
+}
 
-		// Flip task status → deferred while we wait so parallel
-		// GET /tasks/{id} readers see the deferred state.
-		originalStatus := store.SetStatus(hctx.TaskID, a2a.TaskStatus{
-			State: a2a.TaskStateDeferred,
-			Message: &a2a.Message{
-				Role: a2a.MessageRoleAgent,
-				Parts: []a2a.Part{
-					a2a.NewTextPart(fmt.Sprintf(
-						"Deferred: awaiting %s decision on %s",
-						spec.To, hctx.ToolName)),
-				},
+// park runs the DEFER parking machinery for an already-resolved Spec: register
+// the deferral, flip task status → deferred, emit task_deferred, deliver the
+// approval request, then block on the decision. approve → nil (the tool
+// proceeds); reject/timeout → error (the tool aborts). Shared verbatim by the
+// static defer hook (registerDeferHook) and a managed PDP `defer` verdict
+// (registerPDPDecisionHook) so both paths park identically.
+func (r *Runner) park(ctx context.Context, hctx *coreruntime.HookContext, spec deferengine.Spec, store TaskStatusStore, auditLogger *coreruntime.AuditLogger) error {
+	engine := r.deferEngine
+	if engine == nil {
+		// Fail closed: a defer verdict with no engine must not silently proceed.
+		return fmt.Errorf("defer: engine not wired")
+	}
+	handle, err := engine.Register(hctx.TaskID, hctx.ToolName, spec)
+	if err != nil {
+		// Only happens on duplicate register — a hook-level bug.
+		// Fail closed rather than silently dropping.
+		return fmt.Errorf("defer: %w", err)
+	}
+
+	// Flip task status → deferred while we wait so parallel
+	// GET /tasks/{id} readers see the deferred state.
+	originalStatus := store.SetStatus(hctx.TaskID, a2a.TaskStatus{
+		State: a2a.TaskStateDeferred,
+		Message: &a2a.Message{
+			Role: a2a.MessageRoleAgent,
+			Parts: []a2a.Part{
+				a2a.NewTextPart(fmt.Sprintf(
+					"Deferred: awaiting %s decision on %s",
+					spec.To, hctx.ToolName)),
+			},
+		},
+	})
+
+	auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+		Event:         coreruntime.AuditTaskDeferred,
+		CorrelationID: hctx.CorrelationID,
+		TaskID:        hctx.TaskID,
+		Fields: map[string]any{
+			"tool":       hctx.ToolName,
+			"to":         spec.To,
+			"timeout_ms": spec.Timeout.Milliseconds(),
+			"context":    truncateForAudit(spec.ContextForApprover, 512),
+		},
+	})
+
+	// #310 — deliver an interactive approval request to the channel named
+	// in `to:` (e.g. Slack Block Kit buttons). Best-effort: a delivery
+	// failure is logged, never fatal — the approver can still POST
+	// /tasks/{id}/decisions, and blocking/denying on a Slack outage would
+	// be worse than a missing button.
+	if r.deferralNotifier != nil {
+		if nErr := r.deferralNotifier(ctx, spec.To, hctx.TaskID, hctx.ToolName, spec.ContextForApprover, spec.Timeout); nErr != nil {
+			r.logger.Warn("defer: approval delivery failed", map[string]any{
+				"tool":  hctx.ToolName,
+				"to":    spec.To,
+				"error": nErr.Error(),
+			})
+		}
+	}
+
+	start := time.Now()
+	res, waitErr := handle.WaitCtx(ctx)
+	if waitErr != nil {
+		// ctx cancelled — the caller abandoned the request. Roll
+		// back task status and clean up the pending deferral.
+		// engine.Register left the timer running; resolve with
+		// timeout so the timer fires immediately if it hasn't
+		// already.
+		store.SetStatus(hctx.TaskID, originalStatus)
+		_ = engine.Resolve(hctx.TaskID, deferengine.Resolution{Decision: deferengine.DecisionTimeout})
+		return waitErr
+	}
+
+	waitMs := time.Since(start).Milliseconds()
+
+	switch res.Decision {
+	case deferengine.DecisionApprove:
+		// Approve: restore working state, let the tool proceed.
+		store.SetStatus(hctx.TaskID, originalStatus)
+		auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+			Event:         coreruntime.AuditTaskDeferredDecision,
+			CorrelationID: hctx.CorrelationID,
+			TaskID:        hctx.TaskID,
+			Fields: map[string]any{
+				"tool":           hctx.ToolName,
+				"decision":       string(res.Decision),
+				"approver":       res.Approver,
+				"approver_email": res.ApproverEmail,
+				"note":           res.Note,
+				"wait_ms":        waitMs,
 			},
 		})
-
+		return nil
+	case deferengine.DecisionReject:
 		auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
-			Event:         coreruntime.AuditTaskDeferred,
+			Event:         coreruntime.AuditTaskDeferredDecision,
+			CorrelationID: hctx.CorrelationID,
+			TaskID:        hctx.TaskID,
+			Fields: map[string]any{
+				"tool":           hctx.ToolName,
+				"decision":       string(res.Decision),
+				"approver":       res.Approver,
+				"approver_email": res.ApproverEmail,
+				"note":           res.Note,
+				"wait_ms":        waitMs,
+			},
+		})
+		return fmt.Errorf("defer: rejected by %s: %s", res.Approver, res.Note)
+	case deferengine.DecisionTimeout:
+		auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+			Event:         coreruntime.AuditTaskDeferredTimeout,
 			CorrelationID: hctx.CorrelationID,
 			TaskID:        hctx.TaskID,
 			Fields: map[string]any{
 				"tool":       hctx.ToolName,
-				"to":         spec.To,
 				"timeout_ms": spec.Timeout.Milliseconds(),
-				"context":    truncateForAudit(spec.ContextForApprover, 512),
+				"wait_ms":    waitMs,
 			},
 		})
-
-		// #310 — deliver an interactive approval request to the channel named
-		// in `to:` (e.g. Slack Block Kit buttons). Best-effort: a delivery
-		// failure is logged, never fatal — the approver can still POST
-		// /tasks/{id}/decisions, and blocking/denying on a Slack outage would
-		// be worse than a missing button.
-		if r.deferralNotifier != nil {
-			if nErr := r.deferralNotifier(ctx, spec.To, hctx.TaskID, hctx.ToolName, spec.ContextForApprover, spec.Timeout); nErr != nil {
-				r.logger.Warn("defer: approval delivery failed", map[string]any{
-					"tool":  hctx.ToolName,
-					"to":    spec.To,
-					"error": nErr.Error(),
-				})
-			}
-		}
-
-		start := time.Now()
-		res, waitErr := handle.WaitCtx(ctx)
-		if waitErr != nil {
-			// ctx cancelled — the caller abandoned the request. Roll
-			// back task status and clean up the pending deferral.
-			// engine.Register left the timer running; resolve with
-			// timeout so the timer fires immediately if it hasn't
-			// already.
-			store.SetStatus(hctx.TaskID, originalStatus)
-			_ = engine.Resolve(hctx.TaskID, deferengine.Resolution{Decision: deferengine.DecisionTimeout})
-			return waitErr
-		}
-
-		waitMs := time.Since(start).Milliseconds()
-
-		switch res.Decision {
-		case deferengine.DecisionApprove:
-			// Approve: restore working state, let the tool proceed.
-			store.SetStatus(hctx.TaskID, originalStatus)
-			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
-				Event:         coreruntime.AuditTaskDeferredDecision,
-				CorrelationID: hctx.CorrelationID,
-				TaskID:        hctx.TaskID,
-				Fields: map[string]any{
-					"tool":           hctx.ToolName,
-					"decision":       string(res.Decision),
-					"approver":       res.Approver,
-					"approver_email": res.ApproverEmail,
-					"note":           res.Note,
-					"wait_ms":        waitMs,
-				},
-			})
-			return nil
-		case deferengine.DecisionReject:
-			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
-				Event:         coreruntime.AuditTaskDeferredDecision,
-				CorrelationID: hctx.CorrelationID,
-				TaskID:        hctx.TaskID,
-				Fields: map[string]any{
-					"tool":           hctx.ToolName,
-					"decision":       string(res.Decision),
-					"approver":       res.Approver,
-					"approver_email": res.ApproverEmail,
-					"note":           res.Note,
-					"wait_ms":        waitMs,
-				},
-			})
-			return fmt.Errorf("defer: rejected by %s: %s", res.Approver, res.Note)
-		case deferengine.DecisionTimeout:
-			auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
-				Event:         coreruntime.AuditTaskDeferredTimeout,
-				CorrelationID: hctx.CorrelationID,
-				TaskID:        hctx.TaskID,
-				Fields: map[string]any{
-					"tool":       hctx.ToolName,
-					"timeout_ms": spec.Timeout.Milliseconds(),
-					"wait_ms":    waitMs,
-				},
-			})
-			return fmt.Errorf("defer: no decision within %s (auto-deny)", spec.Timeout)
-		default:
-			return fmt.Errorf("defer: unknown decision %q", res.Decision)
-		}
-	})
+		return fmt.Errorf("defer: no decision within %s (auto-deny)", spec.Timeout)
+	default:
+		return fmt.Errorf("defer: unknown decision %q", res.Decision)
+	}
 }
 
 // resolveDeferSpec composes a Spec from the tool-level + top-level

--- a/forge-cli/runtime/pdp_resolver.go
+++ b/forge-cli/runtime/pdp_resolver.go
@@ -1,0 +1,279 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+	deferengine "github.com/initializ/forge/forge-core/security/deferpolicy"
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// Managed PDP decision path (design-tool-registry §4.1). On every tool call a
+// BeforeToolExec hook POSTs the proposed call to a remote Policy Decision Point
+// and enforces the returned allow | defer | deny verdict, default-deny. This is
+// the managed counterpart to the standalone/OSS static `security.defer.tools`
+// path (registerDeferHook), which is retained UNCHANGED. Only one is active at
+// a time (config-selected in runner.go); enforcement is identical for both —
+// return nil to proceed, return an error to abort (loop.go), park a defer.
+//
+// FAIL-CLOSED (§14.5): the resolver NEVER returns allow on error — every
+// transport/timeout/malformed outcome becomes a Deny verdict. It never falls
+// back to the static defer map either; a silent downgrade from authorization to
+// opt-in approval would be a security regression.
+
+const defaultPDPTimeout = 3 * time.Second
+
+// Verdict is the resolver output at the CLI enforcement layer. It carries a full
+// deferengine.Spec (which includes Approvers) rather than runtime.DeferSpec
+// (which does not), so a PDP defer verdict feeds the parking machinery directly.
+type Verdict struct {
+	Decision coreruntime.PolicyDecision
+	Reason   string
+	Op       string
+	Defer    *deferengine.Spec // set only when Decision == DecisionDefer
+}
+
+// DecisionResolver reaches an authorization verdict for a proposed tool call.
+// It MUST NEVER fail open. A caching resolver can decorate an implementation
+// later without touching the hook or loop.go.
+type DecisionResolver interface {
+	Resolve(ctx context.Context, hctx *coreruntime.HookContext) Verdict
+}
+
+type pdpLogger interface {
+	Warn(msg string, fields map[string]any)
+}
+
+// ---- wire contract (mirrors security-next models/agent_policy_model.go) ------
+
+type pdpRequest struct {
+	Tool    string         `json:"tool"`
+	Op      string         `json:"op"`
+	Args    map[string]any `json:"args"`
+	Caller  pdpCaller      `json:"caller"`
+	Agent   string         `json:"agent"`
+	Session string         `json:"session,omitempty"`
+	Context map[string]any `json:"context,omitempty"`
+}
+
+type pdpCaller struct {
+	Subject string `json:"subject,omitempty"`
+	// EntitledAccounts is RESERVED for the relational rule (deferred): Forge has
+	// no end-user subject at BeforeToolExec, so it is always null in v0.0.1.
+	EntitledAccounts []string `json:"entitled_accounts,omitempty"`
+}
+
+type pdpResponse struct {
+	Decision      string          `json:"decision"` // allow | defer | deny
+	Reason        string          `json:"reason"`
+	PolicyVersion int             `json:"policy_version"`
+	DeferParams   *pdpDeferParams `json:"defer_params,omitempty"`
+}
+
+type pdpDeferParams struct {
+	To        string   `json:"to"`
+	Timeout   string   `json:"timeout"`
+	Approvers []string `json:"approvers,omitempty"`
+	Context   string   `json:"context"`
+}
+
+// pdpEnvelope unwraps security-next's ApplicationResponse{status,message,data}.
+type pdpEnvelope struct {
+	Data pdpResponse `json:"data"`
+}
+
+// pdpResolver POSTs each proposed tool call to the platform PDP.
+type pdpResolver struct {
+	endpoint    string
+	token       string
+	orgID       string
+	workspaceID string
+	agentID     string
+	timeout     time.Duration
+	client      *http.Client
+	logger      pdpLogger
+}
+
+// BuildPDPResolver constructs the managed resolver from config + the platform
+// identity env (reusing the admission env constants). The endpoint is
+// env-expanded so `endpoint: ${PDP_ENDPOINT}` in forge.yaml resolves.
+func BuildPDPResolver(cfg *types.ForgeConfig, logger pdpLogger) *pdpResolver {
+	pc := cfg.Security.Pdp
+	return &pdpResolver{
+		endpoint:    os.ExpandEnv(pc.Endpoint),
+		token:       os.Getenv(EnvPlatformToken),
+		orgID:       os.Getenv(EnvOrgID),
+		workspaceID: os.Getenv(EnvWorkspaceID),
+		agentID:     cfg.AgentID,
+		timeout:     pc.Timeout,
+		client:      &http.Client{},
+		logger:      logger,
+	}
+}
+
+func (p *pdpResolver) Resolve(ctx context.Context, hctx *coreruntime.HookContext) Verdict {
+	// op = the registry operation name the PDP keys rules on. For an MCP-style
+	// runtime name "<server>__<op>" it's the part after the first "__"; a
+	// builtin (no "__") IS the op.
+	op := hctx.ToolName
+	if _, after, found := strings.Cut(hctx.ToolName, "__"); found {
+		op = after
+	}
+
+	// Parsed args, never a rendered string. Empty args → {}.
+	args := map[string]any{}
+	if strings.TrimSpace(hctx.ToolInput) != "" {
+		if err := json.Unmarshal([]byte(hctx.ToolInput), &args); err != nil {
+			return p.deny(op, "unparsable tool arguments: "+err.Error())
+		}
+	}
+
+	reqBody := pdpRequest{
+		Tool:    hctx.ToolName,
+		Op:      op,
+		Args:    args,
+		Caller:  pdpCaller{Subject: "agent:" + p.agentID},
+		Agent:   p.agentID,
+		Session: hctx.TaskID,
+		Context: map[string]any{},
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return p.deny(op, "marshal pdp request: "+err.Error())
+	}
+
+	timeout := p.timeout
+	if timeout <= 0 {
+		timeout = defaultPDPTimeout
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(callCtx, http.MethodPost, p.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return p.deny(op, "build pdp request: "+err.Error())
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.token)
+	// Tenancy headers: the platform verifies a per-org HS256 token and needs
+	// Org-Id to select the signing secret before validating the bearer.
+	if p.orgID != "" {
+		req.Header.Set("Org-Id", p.orgID)
+	}
+	if p.workspaceID != "" {
+		req.Header.Set("Workspace-Id", p.workspaceID)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return p.deny(op, "pdp unreachable: "+err.Error())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return p.deny(op, fmt.Sprintf("pdp returned HTTP %d", resp.StatusCode))
+	}
+
+	var env pdpEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return p.deny(op, "parse pdp response: "+err.Error())
+	}
+	pr := env.Data
+
+	switch pr.Decision {
+	case "allow":
+		return Verdict{Decision: coreruntime.DecisionAllow, Reason: pr.Reason, Op: op}
+	case "deny":
+		reason := pr.Reason
+		if reason == "" {
+			reason = "denied by policy"
+		}
+		return Verdict{Decision: coreruntime.DecisionDeny, Reason: reason, Op: op}
+	case "defer":
+		if pr.DeferParams == nil {
+			return p.deny(op, "pdp returned defer with no defer_params")
+		}
+		spec := deferengine.Spec{
+			To:                 pr.DeferParams.To,
+			Timeout:            parsePDPTimeout(pr.DeferParams.Timeout),
+			ContextForApprover: pr.DeferParams.Context,
+			Approvers:          normalizeApprovers(pr.DeferParams.Approvers),
+		}
+		return Verdict{Decision: coreruntime.DecisionDefer, Reason: pr.Reason, Op: op, Defer: &spec}
+	default:
+		return p.deny(op, fmt.Sprintf("pdp returned unknown decision %q", pr.Decision))
+	}
+}
+
+// deny is the single fail-closed exit — every error path routes here.
+func (p *pdpResolver) deny(op, reason string) Verdict {
+	if p.logger != nil {
+		p.logger.Warn("pdp: failing closed to deny", map[string]any{"op": op, "reason": reason})
+	}
+	return Verdict{Decision: coreruntime.DecisionDeny, Reason: reason, Op: op}
+}
+
+func parsePDPTimeout(s string) time.Duration {
+	if s == "" {
+		return 0 // engine applies its 10m default
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 0
+	}
+	return d
+}
+
+// registerPDPDecisionHook wires the managed PDP path as a single BeforeToolExec
+// hook that fires on EVERY tool call. Allow → proceed; Deny → abort; Defer →
+// the existing parking machinery (shared park()).
+func (r *Runner) registerPDPDecisionHook(hooks *coreruntime.HookRegistry, resolver DecisionResolver, store TaskStatusStore, auditLogger *coreruntime.AuditLogger) {
+	hooks.Register(coreruntime.BeforeToolExec, func(ctx context.Context, hctx *coreruntime.HookContext) error {
+		v := resolver.Resolve(ctx, hctx)
+		emitPDPDecision(ctx, auditLogger, hctx, r.cfg.Config.AgentID, v)
+
+		switch v.Decision {
+		case coreruntime.DecisionAllow:
+			return nil
+		case coreruntime.DecisionDefer:
+			if v.Defer == nil {
+				return fmt.Errorf("pdp: defer verdict with no defer params (fail-closed)")
+			}
+			return r.park(ctx, hctx, *v.Defer, store, auditLogger)
+		case coreruntime.DecisionDeny:
+			return fmt.Errorf("denied by policy: %s", v.Reason)
+		default:
+			// Belt-and-suspenders: any unexpected decision fails closed.
+			return fmt.Errorf("pdp: unenforceable decision (fail-closed)")
+		}
+	})
+}
+
+// emitPDPDecision writes the agent-side pdp_decision audit record for every
+// verdict (a deny is a permanent-log deliverable). Defer RESOLUTION is
+// separately recorded by park()'s existing task_deferred* events.
+func emitPDPDecision(ctx context.Context, auditLogger *coreruntime.AuditLogger, hctx *coreruntime.HookContext, agentID string, v Verdict) {
+	if auditLogger == nil {
+		return
+	}
+	auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
+		Event:         coreruntime.AuditPDPDecision,
+		CorrelationID: hctx.CorrelationID,
+		TaskID:        hctx.TaskID,
+		Fields: map[string]any{
+			"tool":     hctx.ToolName,
+			"op":       v.Op,
+			"decision": v.Decision.String(),
+			"reason":   truncateForAudit(v.Reason, 512),
+			"caller":   "agent:" + agentID,
+			"agent":    agentID,
+		},
+	})
+}

--- a/forge-cli/runtime/pdp_resolver.go
+++ b/forge-cli/runtime/pdp_resolver.go
@@ -33,6 +33,13 @@ const defaultPDPTimeout = 3 * time.Second
 // Verdict is the resolver output at the CLI enforcement layer. It carries a full
 // deferengine.Spec (which includes Approvers) rather than runtime.DeferSpec
 // (which does not), so a PDP defer verdict feeds the parking machinery directly.
+//
+// CONTRACT: a zero-value Verdict is UNDEFINED and must never be treated as a
+// decision. Note DecisionAllow is the zero value of PolicyDecision, so an
+// accidentally-unconstructed Verdict{} would read as allow — every Verdict must
+// be constructed with an explicit Decision, and the enforcement hook's default
+// arm fails closed as a backstop. Do not add a code path that returns a
+// Verdict{} on an authorization boundary.
 type Verdict struct {
 	Decision coreruntime.PolicyDecision
 	Reason   string
@@ -41,8 +48,10 @@ type Verdict struct {
 }
 
 // DecisionResolver reaches an authorization verdict for a proposed tool call.
-// It MUST NEVER fail open. A caching resolver can decorate an implementation
-// later without touching the hook or loop.go.
+// It MUST NEVER fail open — every error is a Deny Verdict, never allow-on-error
+// and never a zero-value Verdict (see the contract note above). A caching
+// resolver can decorate an implementation later without touching the hook or
+// loop.go.
 type DecisionResolver interface {
 	Resolve(ctx context.Context, hctx *coreruntime.HookContext) Verdict
 }
@@ -102,12 +111,14 @@ type pdpResolver struct {
 }
 
 // BuildPDPResolver constructs the managed resolver from config + the platform
-// identity env (reusing the admission env constants). The endpoint is
-// env-expanded so `endpoint: ${PDP_ENDPOINT}` in forge.yaml resolves.
+// identity env (reusing the admission env constants). The endpoint is already
+// env-expanded at load (ParseForgeConfig), so startup validation saw the
+// resolved value and an unset ${PDP_ENDPOINT} failed loud rather than reaching
+// here empty.
 func BuildPDPResolver(cfg *types.ForgeConfig, logger pdpLogger) *pdpResolver {
 	pc := cfg.Security.Pdp
 	return &pdpResolver{
-		endpoint:    os.ExpandEnv(pc.Endpoint),
+		endpoint:    pc.Endpoint,
 		token:       os.Getenv(EnvPlatformToken),
 		orgID:       os.Getenv(EnvOrgID),
 		workspaceID: os.Getenv(EnvWorkspaceID),
@@ -156,25 +167,47 @@ func (p *pdpResolver) Resolve(ctx context.Context, hctx *coreruntime.HookContext
 	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(callCtx, http.MethodPost, p.endpoint, bytes.NewReader(body))
-	if err != nil {
-		return p.deny(op, "build pdp request: "+err.Error())
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+p.token)
-	// Tenancy headers: the platform verifies a per-org HS256 token and needs
-	// Org-Id to select the signing secret before validating the bearer.
-	if p.orgID != "" {
-		req.Header.Set("Org-Id", p.orgID)
-	}
-	if p.workspaceID != "" {
-		req.Header.Set("Workspace-Id", p.workspaceID)
-	}
+	// Send with a single retry on TRANSPORT error only — a dropped packet /
+	// reset shouldn't deny an otherwise-legitimate call. NOT retried: a 200
+	// deny (a real verdict), or a timeout — the shared callCtx bounds total
+	// time, so a retry after the deadline blows fails instantly and denies.
+	//
+	// NOTE (data flow): the PARSED tool arguments are sent to the PDP in full
+	// (it decides over argument values), so for tools whose args carry secrets
+	// or PII those values leave the pod. Keep the endpoint cluster-internal and
+	// TLS-terminated at any boundary it crosses; redact sensitive fields before
+	// they reach the decision point if needed.
+	var resp *http.Response
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(callCtx, http.MethodPost, p.endpoint, bytes.NewReader(body))
+		if err != nil {
+			return p.deny(op, "build pdp request: "+err.Error())
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "Bearer "+p.token)
+		// Tenancy headers: the platform verifies a per-org HS256 token and needs
+		// Org-Id to select the signing secret before validating the bearer.
+		if p.orgID != "" {
+			req.Header.Set("Org-Id", p.orgID)
+		}
+		if p.workspaceID != "" {
+			req.Header.Set("Workspace-Id", p.workspaceID)
+		}
 
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return p.deny(op, "pdp unreachable: "+err.Error())
+		var doErr error
+		resp, doErr = p.client.Do(req)
+		if doErr == nil {
+			break
+		}
+		// Out of attempts, or the deadline is blown (a retry would fail
+		// instantly) → fail closed.
+		if attempt == 1 || callCtx.Err() != nil {
+			return p.deny(op, "pdp unreachable: "+doErr.Error())
+		}
+	}
+	if resp == nil { // defensive — the loop always sets resp or denies
+		return p.deny(op, "pdp unreachable: no response")
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {

--- a/forge-cli/runtime/pdp_resolver_test.go
+++ b/forge-cli/runtime/pdp_resolver_test.go
@@ -1,0 +1,172 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	coreruntime "github.com/initializ/forge/forge-core/runtime"
+)
+
+func testResolver(endpoint string) *pdpResolver {
+	return &pdpResolver{
+		endpoint:    endpoint,
+		token:       "tok",
+		orgID:       "org_x",
+		workspaceID: "ws_1",
+		agentID:     "member-service",
+		timeout:     2 * time.Second,
+		client:      &http.Client{},
+	}
+}
+
+// writeEnvelope wraps a decision object in security-next's ApplicationResponse.
+func writeEnvelope(w http.ResponseWriter, decisionJSON string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":200,"message":"PDP decision","data":` + decisionJSON + `}`))
+}
+
+func hctx(tool, input string) *coreruntime.HookContext {
+	return &coreruntime.HookContext{ToolName: tool, ToolInput: input, TaskID: "task-1", CorrelationID: "corr-1"}
+}
+
+// S1 — allow, and verify the request shape + auth headers + parsed args + op split.
+func TestPDPResolver_Allow(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q, want Bearer tok", got)
+		}
+		if got := r.Header.Get("Org-Id"); got != "org_x" {
+			t.Errorf("Org-Id = %q, want org_x", got)
+		}
+		if got := r.Header.Get("Workspace-Id"); got != "ws_1" {
+			t.Errorf("Workspace-Id = %q, want ws_1", got)
+		}
+		var req pdpRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Tool != "memberservice__reverse_fee" || req.Op != "reverse_fee" {
+			t.Errorf("tool/op = %q/%q, want memberservice__reverse_fee/reverse_fee", req.Tool, req.Op)
+		}
+		if req.Args["amount"] != float64(25) { // parsed, not a string
+			t.Errorf("args.amount = %v (%T), want 25 (float64)", req.Args["amount"], req.Args["amount"])
+		}
+		if req.Caller.Subject != "agent:member-service" || req.Caller.EntitledAccounts != nil {
+			t.Errorf("caller = %+v, want subject agent:member-service, no entitled_accounts", req.Caller)
+		}
+		writeEnvelope(w, `{"decision":"allow","reason":"within policy","policy_version":7}`)
+	}))
+	defer srv.Close()
+
+	v := testResolver(srv.URL).Resolve(context.Background(), hctx("memberservice__reverse_fee", `{"amount":25,"fee_type":"overdraft"}`))
+	if v.Decision != coreruntime.DecisionAllow {
+		t.Fatalf("decision = %v, want allow", v.Decision)
+	}
+	if v.Op != "reverse_fee" {
+		t.Errorf("op = %q, want reverse_fee", v.Op)
+	}
+}
+
+// S2 — defer, with defer_params mapped into a full engine Spec (incl. approvers + parsed timeout).
+func TestPDPResolver_Defer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(w, `{"decision":"defer","reason":"approval required","defer_params":{"to":"platform","timeout":"10m","approvers":["Fee-Approvals@Initializ.ai"],"context":"reverse_fee amount=2500"}}`)
+	}))
+	defer srv.Close()
+
+	v := testResolver(srv.URL).Resolve(context.Background(), hctx("memberservice__reverse_fee", `{"amount":2500}`))
+	if v.Decision != coreruntime.DecisionDefer {
+		t.Fatalf("decision = %v, want defer", v.Decision)
+	}
+	if v.Defer == nil {
+		t.Fatal("defer spec is nil")
+	}
+	if v.Defer.To != "platform" {
+		t.Errorf("to = %q, want platform", v.Defer.To)
+	}
+	if v.Defer.Timeout != 10*time.Minute {
+		t.Errorf("timeout = %v, want 10m", v.Defer.Timeout)
+	}
+	if len(v.Defer.Approvers) != 1 || v.Defer.Approvers[0] != "fee-approvals@initializ.ai" {
+		t.Errorf("approvers = %v, want [fee-approvals@initializ.ai] (normalized)", v.Defer.Approvers)
+	}
+}
+
+// S3 — deny.
+func TestPDPResolver_Deny(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeEnvelope(w, `{"decision":"deny","reason":"off-allowlist destination"}`)
+	}))
+	defer srv.Close()
+
+	v := testResolver(srv.URL).Resolve(context.Background(), hctx("memberservice__get_account_history", `{"destination":"https://evil.example"}`))
+	if v.Decision != coreruntime.DecisionDeny {
+		t.Fatalf("decision = %v, want deny", v.Decision)
+	}
+	if v.Reason == "" {
+		t.Error("deny reason is empty")
+	}
+}
+
+// Fail-closed: every failure mode → deny, NEVER allow.
+func TestPDPResolver_FailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		// endpointOverride replaces the test server URL (for the unreachable case)
+		endpointOverride string
+	}{
+		{name: "non-200", handler: func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) }},
+		{name: "malformed body", handler: func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("not json")) }},
+		{name: "unknown decision", handler: func(w http.ResponseWriter, r *http.Request) { writeEnvelope(w, `{"decision":"maybe"}`) }},
+		{name: "defer without params", handler: func(w http.ResponseWriter, r *http.Request) { writeEnvelope(w, `{"decision":"defer"}`) }},
+		{name: "unreachable", endpointOverride: "http://127.0.0.1:1/nope"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint := tc.endpointOverride
+			if endpoint == "" {
+				srv := httptest.NewServer(tc.handler)
+				defer srv.Close()
+				endpoint = srv.URL
+			}
+			v := testResolver(endpoint).Resolve(context.Background(), hctx("some_tool", `{}`))
+			if v.Decision != coreruntime.DecisionDeny {
+				t.Fatalf("%s: decision = %v, want deny (fail-closed)", tc.name, v.Decision)
+			}
+		})
+	}
+}
+
+// A builtin tool (no "__") uses its whole name as the op; empty args → {}.
+func TestPDPResolver_BuiltinOpAndEmptyArgs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req pdpRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Tool != "http_request" || req.Op != "http_request" {
+			t.Errorf("tool/op = %q/%q, want http_request/http_request", req.Tool, req.Op)
+		}
+		if req.Args == nil || len(req.Args) != 0 {
+			t.Errorf("args = %v, want empty object", req.Args)
+		}
+		writeEnvelope(w, `{"decision":"allow"}`)
+	}))
+	defer srv.Close()
+
+	v := testResolver(srv.URL).Resolve(context.Background(), hctx("http_request", ""))
+	if v.Decision != coreruntime.DecisionAllow {
+		t.Fatalf("decision = %v, want allow", v.Decision)
+	}
+}
+
+// Unparsable tool args → deny (never sent as a string).
+func TestPDPResolver_UnparsableArgsDeny(t *testing.T) {
+	v := testResolver("http://unused").Resolve(context.Background(), hctx("t", `{not json`))
+	if v.Decision != coreruntime.DecisionDeny {
+		t.Fatalf("decision = %v, want deny", v.Decision)
+	}
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -486,9 +486,24 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err := r.cfg.Config.Security.Defer.Validate(); err != nil {
 		return fmt.Errorf("defer: %w", err)
 	}
-	if r.cfg.Config.Security.Defer.Enabled {
+	// Managed PDP path (design §4.1): validated fail-loud — `pdp.fail: open`
+	// aborts startup so no authz path fails open by accident (§14.5).
+	if err := r.cfg.Config.Security.Pdp.Validate(); err != nil {
+		return fmt.Errorf("pdp: %w", err)
+	}
+	pdpEnabled := r.cfg.Config.Security.Pdp.Enabled
+	deferEnabled := r.cfg.Config.Security.Defer.Enabled
+	if pdpEnabled && deferEnabled {
+		// One decision source at a time: PDP wins, the static map is ignored.
+		r.logger.Warn("both security.pdp and security.defer are enabled — PDP wins; the static security.defer.tools map is ignored", nil)
+	}
+	// The parking machinery is shared: wire the defer engine when EITHER path
+	// is active (a PDP `defer` verdict parks through the same engine).
+	if pdpEnabled || deferEnabled {
 		r.deferEngine = deferengine.New()
 		r.logger.Info("defer engine wired", map[string]any{
+			"pdp":   pdpEnabled,
+			"defer": deferEnabled,
 			"tools": len(r.cfg.Config.Security.Defer.Tools),
 		})
 	}
@@ -1206,13 +1221,20 @@ func (r *Runner) Run(ctx context.Context) error {
 					// No-op when the engine is disabled.
 					r.registerStepUpHook(hooks, auditLogger)
 
-					// R4c (#211) — defer hook. Pauses the executor
-					// when a listed tool is invoked, until a decision
-					// arrives (or the timeout auto-denies). The hook
-					// resolves r.taskStore lazily (populated after srv
-					// is built, below) so hook registration can happen
-					// before srv exists.
-					r.registerDeferHook(hooks, r, auditLogger)
+					// R4c (#211) — the authorization decision hook. One
+					// decision source at a time:
+					//   - MANAGED (security.pdp.enabled): POST every tool
+					//     call to the remote PDP, default-deny, fail-closed.
+					//   - STANDALONE (else): the static security.defer.tools
+					//     lookup, UNCHANGED (opt-in, approval-only).
+					// Both enforce identically and share the parking machinery
+					// (park); a PDP `defer` verdict routes through the same
+					// engine + POST /tasks/{id}/decisions flow.
+					if r.cfg.Config.Security.Pdp.Enabled {
+						r.registerPDPDecisionHook(hooks, BuildPDPResolver(r.cfg.Config, r.logger), r, auditLogger)
+					} else {
+						r.registerDeferHook(hooks, r, auditLogger)
+					}
 
 					// Register skill-level guardrails if present.
 					// Prefer build-time artifact; fall back to runtime-parsed guardrails.

--- a/forge-core/runtime/audit.go
+++ b/forge-core/runtime/audit.go
@@ -231,6 +231,15 @@ const (
 	// 429). See docs/security/admission.md.
 	AuditTaskAdmissionDenied = "task_admission_denied"
 
+	// AuditPDPDecision is emitted for EVERY managed PDP verdict at
+	// BeforeToolExec (the per-tool-call authorization altitude, over
+	// argument values — distinct from task_admission_denied's per-invocation
+	// quota gate). Carries in Fields: tool (runtime name), op (registry
+	// operation), decision (allow|defer|deny), reason, caller, agent. A deny
+	// is a permanent-log deliverable. The agent-side enforcement record; the
+	// platform separately records its own decision as tool_call_decided.
+	AuditPDPDecision = "pdp_decision"
+
 	// Deprecated: use EventAuthVerify. Kept as a string alias so any
 	// audit-log consumer that grep'd for "auth_success" can be migrated.
 	// Scheduled for removal in v0.11.0.

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -204,6 +204,15 @@ type SecurityConfig struct {
 	// Opt-in; requires a decision to arrive at
 	// `POST /tasks/{id}/decisions` before the tool call proceeds.
 	Defer DeferConfig `yaml:"defer,omitempty"`
+
+	// Pdp configures the MANAGED per-tool-call authorization decision:
+	// every tool call is POSTed to a remote Policy Decision Point that
+	// returns allow | defer | deny over the parsed arguments, default-deny
+	// (design-tool-registry §4.1). This is the managed counterpart to the
+	// standalone/OSS static `defer` above — when Pdp.Enabled the PDP is the
+	// single decision source and `defer.tools` is ignored (a startup warning
+	// is emitted). Fails CLOSED (§14.5). Opt-in; absent → today's behavior.
+	Pdp PdpConfig `yaml:"pdp,omitempty"`
 }
 
 // IntentDriftConfig is the forge.yaml-facing block for R7 drift
@@ -388,6 +397,49 @@ func (c DeferConfig) Validate() error {
 	}
 	if len(c.Tools) == 0 {
 		return fmt.Errorf("security.defer: enabled but no tools declared — either list tools under `defer.tools:` or set `defer.enabled: false`")
+	}
+	return nil
+}
+
+// PdpConfig is the forge.yaml-facing block for the managed PDP decision
+// path (`security.pdp`). When Enabled, a BeforeToolExec hook POSTs every
+// proposed tool call to Endpoint and enforces the returned verdict.
+type PdpConfig struct {
+	// Enabled turns the managed PDP path on. When true it is the single
+	// decision source (the static `defer.tools` map is ignored).
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Endpoint is the full PDP decide URL, POSTed verbatim (e.g.
+	// http://security-next.<ns>.svc:8080/security/v1/pdp/decide).
+	// `${VAR}` is env-expanded at load, so `endpoint: ${PDP_ENDPOINT}` works.
+	Endpoint string `yaml:"endpoint,omitempty"`
+
+	// Fail is the failure posture. Only "closed" (the default) is honored:
+	// an authorization decision must never fail open (§14.5). "open" and any
+	// other value are rejected at startup so nobody demos an authz path that
+	// fails open by accident.
+	Fail string `yaml:"fail,omitempty"`
+
+	// Timeout bounds each PDP call. Zero → a built-in default (3s).
+	Timeout time.Duration `yaml:"timeout,omitempty"`
+}
+
+// Validate rejects a misconfigured managed PDP at startup (fail-loud, like
+// DeferConfig.Validate). Critically it refuses `fail: open` — an authz path
+// that fails open is a security regression (§14.5).
+func (c PdpConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Endpoint == "" {
+		return fmt.Errorf("security.pdp: enabled but no endpoint — set `pdp.endpoint:` or `pdp.enabled: false`")
+	}
+	switch c.Fail {
+	case "", "closed":
+	case "open":
+		return fmt.Errorf("security.pdp.fail: 'open' is not permitted — an authorization decision must fail closed (design-tool-registry §14.5)")
+	default:
+		return fmt.Errorf("security.pdp.fail must be 'closed' (the only supported value), got %q", c.Fail)
 	}
 	return nil
 }

--- a/forge-core/types/config.go
+++ b/forge-core/types/config.go
@@ -1066,6 +1066,13 @@ func ParseForgeConfig(data []byte) (*ForgeConfig, error) {
 	// values, and the egress allowlist is computed from real hosts.
 	expandMCPEnv(&cfg)
 
+	// Expand ${VAR} in the managed PDP endpoint at load too, so
+	// PdpConfig.Validate() (run at startup) sees the RESOLVED value: an unset
+	// `endpoint: ${PDP_ENDPOINT}` expands to "" and fails loud ("enabled but no
+	// endpoint") instead of passing validation and silently degrading to a
+	// per-call deny-all when the resolver later expands it to "".
+	cfg.Security.Pdp.Endpoint = expandEnvRef(cfg.Security.Pdp.Endpoint)
+
 	if cfg.AgentID == "" {
 		return nil, fmt.Errorf("forge config: agent_id is required")
 	}

--- a/forge-core/types/pdp_config_test.go
+++ b/forge-core/types/pdp_config_test.go
@@ -6,6 +6,38 @@ import (
 	"time"
 )
 
+// The PDP endpoint must be env-expanded AT LOAD so startup validation sees the
+// resolved value — an unset ${PDP_ENDPOINT} must fail loud, not degrade to a
+// per-call deny-all when the resolver later expands it to "".
+func TestParseForgeConfig_PDPEndpointExpandedAtLoad(t *testing.T) {
+	doc := "agent_id: a\nversion: v1\nentrypoint: main\n" +
+		"security:\n  pdp:\n    enabled: true\n    endpoint: ${PDP_ENDPOINT}\n    fail: closed\n"
+
+	t.Setenv("PDP_ENDPOINT", "") // unset/empty
+	cfg, err := ParseForgeConfig([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Security.Pdp.Endpoint != "" {
+		t.Errorf("endpoint = %q, want empty after expanding an unset var at load", cfg.Security.Pdp.Endpoint)
+	}
+	if cfg.Security.Pdp.Validate() == nil {
+		t.Error("Validate must fail loud on the expanded-empty endpoint, not pass and deny-all at runtime")
+	}
+
+	t.Setenv("PDP_ENDPOINT", "http://security-next/security/v1/pdp/decide")
+	cfg2, err := ParseForgeConfig([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse (set): %v", err)
+	}
+	if cfg2.Security.Pdp.Endpoint != "http://security-next/security/v1/pdp/decide" {
+		t.Errorf("endpoint = %q, want the resolved URL", cfg2.Security.Pdp.Endpoint)
+	}
+	if err := cfg2.Security.Pdp.Validate(); err != nil {
+		t.Errorf("Validate should pass with a resolved endpoint: %v", err)
+	}
+}
+
 func TestPdpConfigValidate(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/forge-core/types/pdp_config_test.go
+++ b/forge-core/types/pdp_config_test.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPdpConfigValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     PdpConfig
+		wantErr string // substring; "" = expect valid
+	}{
+		{name: "disabled is always valid", cfg: PdpConfig{Enabled: false, Fail: "open"}},
+		{name: "enabled closed ok", cfg: PdpConfig{Enabled: true, Endpoint: "http://x/decide", Fail: "closed"}},
+		{name: "enabled default fail ok", cfg: PdpConfig{Enabled: true, Endpoint: "http://x/decide", Timeout: 3 * time.Second}},
+		{name: "enabled without endpoint", cfg: PdpConfig{Enabled: true, Fail: "closed"}, wantErr: "no endpoint"},
+		{name: "fail open rejected", cfg: PdpConfig{Enabled: true, Endpoint: "http://x", Fail: "open"}, wantErr: "must fail closed"},
+		{name: "fail garbage rejected", cfg: PdpConfig{Enabled: true, Endpoint: "http://x", Fail: "maybe"}, wantErr: "must be 'closed'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want valid, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Make the agent runtime ask a remote **Policy Decision Point** for a verdict on **every tool call** and enforce `allow | defer | deny`, **default-deny** (`design-tool-registry.md` §4.1). This is the managed counterpart to the standalone/OSS static `security.defer.tools` path, which is **retained unchanged**. Surgical: `loop.go`, `hooks.go`, and the `deferpolicy` engine are untouched.

## How

- **`security.pdp` config** `{enabled, endpoint, fail, timeout}` on `SecurityConfig`, with `PdpConfig.Validate()` that **rejects `fail: open`** fail-loud at startup — an authz decision must never fail open (§14.5).
- **`pdpResolver`** (new `forge-cli/runtime/pdp_resolver.go`): POSTs `{tool, op, args, caller, agent, session, context}` with the platform auth headers (`Bearer ${FORGE_PLATFORM_TOKEN}` + `Org-Id` + `Workspace-Id`), sends **parsed** args (never a rendered string), derives the bare `op` from the runtime tool name (`strings.Cut` on `__`), and maps the verdict. **Fail-closed**: any transport/timeout/non-200/malformed/unknown outcome → deny, never allow, never a fallback to the static map.
- **One decision source at a time** (config-selected in `runner.go`): `pdp.enabled` → the PDP hook; else the static defer hook, **byte-identical to today** (OSS backward-compat). Both enabled → PDP wins + a startup warning.
- The DEFER parking machinery is factored into a shared **`park()`** so a PDP `defer` verdict reuses it verbatim (registers the deferral → flips task status → delivers the approval → blocks on `POST /tasks/{id}/decisions`).
- Every verdict emits a hash-chained **`pdp_decision`** audit event `{tool, op, decision, reason, caller, agent}`; a deny is permanently logged.
- `DecisionResolver` interface leaves room for a local allow-cache decorator later without touching `loop.go`.

## Tests

`forge-cli` + `forge-core`: the three verdicts (with request-shape + auth-header assertions), all five **fail-closed** modes (unreachable/non-200/malformed/unknown/defer-without-params), builtin-op + empty-args, unparsable-args→deny, and config validation (`fail: open` rejected, endpoint required). Full `forge-core` (types/runtime/security incl. deferpolicy) + `forge-cli/runtime` suites pass — the `park()` refactor doesn't regress the existing DEFER tests. `make build`/`gofmt`/`vet`/`golangci-lint` clean.

## Contract

Matches security-next's `POST /security/v1/pdp/decide` (`PDPDecideRequest`/`Response`/`DeferParams`) by construction — `defer_params {to,timeout,approvers,context}` feed the existing DEFER flow with zero change.

## Deferred (out of scope, flagged)

- **API-tool materialization into forge.yaml** (agent-builder) — how an admitted API operation becomes a callable `reverse_fee` tool for the resolver to check.
- **Deploy injection** of `security.pdp.endpoint`/`PDP_ENDPOINT` into deployed agents (agent-builder), like `FORGE_ADMISSION_URL`.
- `pdp_decision` label registration in security-next + console-next (separate PRs).