### PR TITLE
pdp: govern only namespaced registry ops, skip builtins/scripts

### DIFF
--- a/forge-cli/runtime/env_passthrough_test.go
+++ b/forge-cli/runtime/env_passthrough_test.go
@@ -1,0 +1,45 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/initializ/forge/forge-core/types"
+)
+
+// Governed api/mcp bearer tokens must be collected so they can be withheld from
+// the script env passthrough (a script with the token could bypass the PDP).
+func TestGovernedToolTokenEnvs(t *testing.T) {
+	cfg := &types.ForgeConfig{
+		APIs: types.APIConfig{Servers: []types.APIServer{
+			{Name: "member-service", Auth: &types.APIAuth{TokenEnv: "API_MEMBER_SERVICE_TOKEN"}},
+			{Name: "noauth"}, // nil Auth → contributes nothing
+		}},
+		MCP: types.MCPConfig{Servers: []types.MCPServer{
+			{Name: "jira", Auth: &types.MCPAuth{Type: "bearer", TokenEnv: "MCP_JIRA_TOKEN"}},
+			{Name: "oauth-mcp", Auth: &types.MCPAuth{Type: "oauth"}}, // no static token env
+		}},
+	}
+	got := governedToolTokenEnvs(cfg)
+	if len(got) != 2 || !got["API_MEMBER_SERVICE_TOKEN"] || !got["MCP_JIRA_TOKEN"] {
+		t.Fatalf("governed token env set = %v, want exactly {API_MEMBER_SERVICE_TOKEN, MCP_JIRA_TOKEN}", got)
+	}
+	if governedToolTokenEnvs(nil) != nil {
+		t.Error("nil config should yield nil set")
+	}
+}
+
+func TestWithoutEnvNames(t *testing.T) {
+	in := []string{"HOME_LIKE", "API_MEMBER_SERVICE_TOKEN", "TAVILY_API_KEY"}
+	out := withoutEnvNames(in, map[string]bool{"API_MEMBER_SERVICE_TOKEN": true})
+	// Governed token removed; the skill's own script secret survives; order kept.
+	if len(out) != 2 || out[0] != "HOME_LIKE" || out[1] != "TAVILY_API_KEY" {
+		t.Fatalf("out = %v, want [HOME_LIKE TAVILY_API_KEY]", out)
+	}
+	// Empty/nil exclude → passthrough unchanged (and input not mutated).
+	if got := withoutEnvNames(in, nil); len(got) != 3 {
+		t.Errorf("nil exclude should pass all through, got %v", got)
+	}
+	if in[1] != "API_MEMBER_SERVICE_TOKEN" {
+		t.Errorf("input slice was mutated: %v", in)
+	}
+}

--- a/forge-cli/runtime/env_passthrough_test.go
+++ b/forge-cli/runtime/env_passthrough_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"testing"
 
+	clitools "github.com/initializ/forge/forge-cli/tools"
 	"github.com/initializ/forge/forge-core/types"
 )
 
@@ -41,5 +42,18 @@ func TestWithoutEnvNames(t *testing.T) {
 	}
 	if in[1] != "API_MEMBER_SERVICE_TOKEN" {
 		t.Errorf("input slice was mutated: %v", in)
+	}
+}
+
+// The EXPLICIT cli_execute path must also strip governed tokens from its
+// env_passthrough (mirrors the runner's explicit-cli_execute registration).
+func TestExplicitCLIExecuteStripsGovernedToken(t *testing.T) {
+	cfg := clitools.ParseCLIExecuteConfig(map[string]any{
+		"allowed_binaries": []any{"curl"},
+		"env_passthrough":  []any{"API_MEMBER_SERVICE_TOKEN", "MY_SCRIPT_KEY"},
+	})
+	cfg.EnvPassthrough = withoutEnvNames(cfg.EnvPassthrough, map[string]bool{"API_MEMBER_SERVICE_TOKEN": true})
+	if len(cfg.EnvPassthrough) != 1 || cfg.EnvPassthrough[0] != "MY_SCRIPT_KEY" {
+		t.Fatalf("env_passthrough = %v, want [MY_SCRIPT_KEY] (governed token stripped, script secret kept)", cfg.EnvPassthrough)
 	}
 }

--- a/forge-cli/runtime/pdp_resolver.go
+++ b/forge-cli/runtime/pdp_resolver.go
@@ -130,9 +130,10 @@ func BuildPDPResolver(cfg *types.ForgeConfig, logger pdpLogger) *pdpResolver {
 }
 
 func (p *pdpResolver) Resolve(ctx context.Context, hctx *coreruntime.HookContext) Verdict {
-	// op = the registry operation name the PDP keys rules on. For an MCP-style
-	// runtime name "<server>__<op>" it's the part after the first "__"; a
-	// builtin (no "__") IS the op.
+	// op = the registry operation name the PDP keys rules on: the part after the
+	// first "__" of the runtime name "<server>__<op>". The hook only reaches here
+	// for PDP-governed (namespaced) tools — see pdpGoverns; a name with no "__"
+	// would not be governed and is filtered before Resolve.
 	op := hctx.ToolName
 	if _, after, found := strings.Cut(hctx.ToolName, "__"); found {
 		op = after
@@ -267,8 +268,25 @@ func parsePDPTimeout(s string) time.Duration {
 // registerPDPDecisionHook wires the managed PDP path as a single BeforeToolExec
 // hook that fires on EVERY tool call. Allow → proceed; Deny → abort; Defer →
 // the existing parking machinery (shared park()).
+// pdpGoverns reports whether the PDP is in scope for a tool call. The PDP
+// governs only NAMESPACED registry operations — "<server>__<op>" materialized
+// from apis.servers / mcp.servers (forge's registry gate RESERVES "__" for that
+// namespacing, so a builtin or script tool never contains it). Built-ins
+// (read_skill, datetime_now, web_fetch, …) and skill script tools are NOT
+// registry-admitted and can't be expressed as a PDP rule, so they must bypass
+// the PDP: consulting it makes security-next default-deny ("op is not governed
+// by any admitted registry tool"), which would brick the agent (it couldn't
+// even read_skill to load its skill). Those tools stay governed by egress + the
+// platform deny-list policy, not the PDP.
+func pdpGoverns(toolName string) bool {
+	return strings.Contains(toolName, "__")
+}
+
 func (r *Runner) registerPDPDecisionHook(hooks *coreruntime.HookRegistry, resolver DecisionResolver, store TaskStatusStore, auditLogger *coreruntime.AuditLogger) {
 	hooks.Register(coreruntime.BeforeToolExec, func(ctx context.Context, hctx *coreruntime.HookContext) error {
+		if !pdpGoverns(hctx.ToolName) {
+			return nil // not a PDP-governed tool — no decision, no audit
+		}
 		v := resolver.Resolve(ctx, hctx)
 		emitPDPDecision(ctx, auditLogger, hctx, r.cfg.Config.AgentID, v)
 

--- a/forge-cli/runtime/pdp_resolver_test.go
+++ b/forge-cli/runtime/pdp_resolver_test.go
@@ -143,12 +143,12 @@ func TestPDPResolver_FailClosed(t *testing.T) {
 }
 
 // A builtin tool (no "__") uses its whole name as the op; empty args → {}.
-func TestPDPResolver_BuiltinOpAndEmptyArgs(t *testing.T) {
+func TestPDPResolver_NamespacedOpAndEmptyArgs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req pdpRequest
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if req.Tool != "http_request" || req.Op != "http_request" {
-			t.Errorf("tool/op = %q/%q, want http_request/http_request", req.Tool, req.Op)
+		if req.Tool != "member-service__reverse_fee" || req.Op != "reverse_fee" {
+			t.Errorf("tool/op = %q/%q, want member-service__reverse_fee/reverse_fee", req.Tool, req.Op)
 		}
 		if req.Args == nil || len(req.Args) != 0 {
 			t.Errorf("args = %v, want empty object", req.Args)
@@ -157,9 +157,25 @@ func TestPDPResolver_BuiltinOpAndEmptyArgs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := testResolver(srv.URL).Resolve(context.Background(), hctx("http_request", ""))
+	v := testResolver(srv.URL).Resolve(context.Background(), hctx("member-service__reverse_fee", ""))
 	if v.Decision != coreruntime.DecisionAllow {
 		t.Fatalf("decision = %v, want allow", v.Decision)
+	}
+}
+
+// pdpGoverns is the PDP scope gate: only NAMESPACED registry ops ("<server>__<op>")
+// are governed. Builtins/script tools (no "__") MUST be skipped — else the PDP
+// default-denies them and bricks the agent (it couldn't even call read_skill).
+func TestPDPGoverns(t *testing.T) {
+	for _, n := range []string{"member-service__reverse_fee", "jira__search", "linear-write__create_issue"} {
+		if !pdpGoverns(n) {
+			t.Errorf("pdpGoverns(%q) = false, want true (namespaced governed tool)", n)
+		}
+	}
+	for _, n := range []string{"read_skill", "datetime_now", "web_fetch", "http_request", "run_skill_script", "math_calculate"} {
+		if pdpGoverns(n) {
+			t.Errorf("pdpGoverns(%q) = true, want false (builtin/script — PDP must skip)", n)
+		}
 	}
 }
 

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -971,11 +971,17 @@ func (r *Runner) Run(ctx context.Context) error {
 					break
 				}
 			}
+			// Governed-tool bearer tokens are consumed in-process by the tool
+			// adapters — never by a script. Withhold them from every script
+			// env passthrough so a script can't read the token and call the
+			// governed host directly, bypassing the PDP (see governedToolTokenEnvs).
+			toolTokenEnvs := governedToolTokenEnvs(r.cfg.Config)
+
 			// Auto-register cli_execute from skill-derived config when not explicitly configured
 			if !hasExplicitCLI && r.derivedCLIConfig != nil && len(r.derivedCLIConfig.AllowedBinaries) > 0 {
 				cliCfg := clitools.CLIExecuteConfig{
 					AllowedBinaries: r.derivedCLIConfig.AllowedBinaries,
-					EnvPassthrough:  r.derivedCLIConfig.EnvPassthrough,
+					EnvPassthrough:  withoutEnvNames(r.derivedCLIConfig.EnvPassthrough, toolTokenEnvs),
 					TimeoutSeconds:  r.derivedCLIConfig.TimeoutHint,
 					WorkDir:         r.cfg.WorkDir,
 				}
@@ -1000,7 +1006,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			{
 				var envPass []string
 				if r.derivedCLIConfig != nil {
-					envPass = r.derivedCLIConfig.EnvPassthrough
+					envPass = withoutEnvNames(r.derivedCLIConfig.EnvPassthrough, toolTokenEnvs)
 				}
 				rss := clitools.NewRunSkillScriptTool(r.cfg.WorkDir, proxyURL, socksURL, envPass)
 				if regErr := reg.Register(rss); regErr != nil {
@@ -3598,6 +3604,10 @@ func (r *Runner) registerSkillTools(reg *tools.Registry, proxyURL string, socksU
 				envVars = append(envVars, entry.ForgeReqs.Env.OneOf...)
 				envVars = append(envVars, entry.ForgeReqs.Env.Optional...)
 			}
+			// Withhold governed-tool bearer tokens from the skill script env —
+			// they belong to the in-process tool adapter, not scripts (a script
+			// with the token could bypass the PDP; see governedToolTokenEnvs).
+			envVars = withoutEnvNames(envVars, governedToolTokenEnvs(r.cfg.Config))
 
 			var modelName string
 			if r.modelConfig != nil {
@@ -4001,6 +4011,48 @@ func convertSkillGuardrails(sg *contract.SkillGuardrailConfig) *agentspec.SkillG
 		return nil
 	}
 	return rules
+}
+
+// governedToolTokenEnvs returns the set of env-var NAMES that hold a governed
+// tool's bearer token (api + bearer/static mcp servers). These are read by the
+// IN-PROCESS tool adapters via os.Getenv and are the real governance boundary:
+// the LLM never sees them. They must therefore be WITHHELD from the skill-script
+// env passthrough — otherwise a bundled (or file_write-planted) skill script
+// could read the token (e.g. `echo $API_MEMBER_SERVICE_TOKEN`) and call the
+// governed host DIRECTLY, bypassing the PDP that governs "<server>__<op>" (the
+// network path becomes reachable once builtins are PDP-exempt). Scripts never
+// need these tokens; a skill's own script secrets (its requires.env) still pass.
+func governedToolTokenEnvs(cfg *types.ForgeConfig) map[string]bool {
+	if cfg == nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, s := range cfg.APIs.Servers {
+		if s.Auth != nil && s.Auth.TokenEnv != "" {
+			out[s.Auth.TokenEnv] = true
+		}
+	}
+	for _, s := range cfg.MCP.Servers {
+		if s.Auth != nil && s.Auth.TokenEnv != "" {
+			out[s.Auth.TokenEnv] = true
+		}
+	}
+	return out
+}
+
+// withoutEnvNames returns names with the excluded set removed, order-preserving,
+// without mutating the input.
+func withoutEnvNames(names []string, exclude map[string]bool) []string {
+	if len(exclude) == 0 {
+		return names
+	}
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if !exclude[n] {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 func envFromOS() map[string]string {

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -946,6 +946,13 @@ func (r *Runner) Run(ctx context.Context) error {
 				r.logger.Warn("failed to register read_skill", map[string]any{"error": regErr.Error()})
 			}
 
+			// Governed-tool bearer tokens are consumed in-process by the tool
+			// adapters — never by a script. Withhold them from EVERY script env
+			// passthrough (explicit + auto-derived cli_execute, run_skill_script,
+			// per-skill script tool) so a script can't read the token and call the
+			// governed host directly, bypassing the PDP (see governedToolTokenEnvs).
+			toolTokenEnvs := governedToolTokenEnvs(r.cfg.Config)
+
 			// Register cli_execute if configured explicitly or auto-derived from skills
 			hasExplicitCLI := false
 			for _, toolRef := range r.cfg.Config.Tools {
@@ -953,6 +960,7 @@ func (r *Runner) Run(ctx context.Context) error {
 					hasExplicitCLI = true
 					cliCfg := clitools.ParseCLIExecuteConfig(toolRef.Config)
 					cliCfg.WorkDir = r.cfg.WorkDir
+					cliCfg.EnvPassthrough = withoutEnvNames(cliCfg.EnvPassthrough, toolTokenEnvs)
 					// Apply timeout hint from skill requirements if larger than explicit config
 					if r.derivedCLIConfig != nil && r.derivedCLIConfig.TimeoutHint > cliCfg.TimeoutSeconds {
 						cliCfg.TimeoutSeconds = r.derivedCLIConfig.TimeoutHint
@@ -971,11 +979,6 @@ func (r *Runner) Run(ctx context.Context) error {
 					break
 				}
 			}
-			// Governed-tool bearer tokens are consumed in-process by the tool
-			// adapters — never by a script. Withhold them from every script
-			// env passthrough so a script can't read the token and call the
-			// governed host directly, bypassing the PDP (see governedToolTokenEnvs).
-			toolTokenEnvs := governedToolTokenEnvs(r.cfg.Config)
 
 			// Auto-register cli_execute from skill-derived config when not explicitly configured
 			if !hasExplicitCLI && r.derivedCLIConfig != nil && len(r.derivedCLIConfig.AllowedBinaries) > 0 {


### PR DESCRIPTION
## Symptom
A PDP-enabled agent (`security.pdp.enabled: true`) was **dead on arrival**:

```
pdp_decision: decision=deny op=read_skill reason="op is not governed by any admitted registry tool"
error: before tool exec hook: denied by policy
session_end: state=failed
```

## Root cause
The `BeforeToolExec` PDP hook fires for **every** tool call — including forge built-ins. The agent's first move is `read_skill` (to load its skill); forge sent it to `/pdp/decide` as `op="read_skill"`, security-next has no admitted registry entry for a builtin, so it **default-denied** and the task failed before doing anything. Every builtin (`read_skill`, `datetime_now`, `web_fetch`, …) hits this, so no PDP-on agent can function.

## Fix
The PDP governs only **namespaced registry operations** (`<server>__<op>`, materialized from `apis.servers` / `mcp.servers`). The registry gate reserves `__` for that namespacing, so a builtin or script tool never contains it — and a builtin can't even be expressed as a PDP rule (rules key on `<server>__<op>`). So the hook now **skips** any tool whose name has no `__`: returns early with allow, **no PDP call and no `pdp_decision` audit**. Built-ins/scripts stay governed by egress + the platform deny-list; governed api/mcp ops are gated exactly as today.

- `pdpGoverns(toolName)` gate + early return in `registerPDPDecisionHook`.
- Corrected `Resolve`'s op-extraction comment (only reached for governed tools now).
- `TestPDPGoverns` (builtins → false / namespaced → true); repurposed the old builtin-op test to a namespaced tool for empty-args coverage. `go build`/`vet`/`test ./runtime/...` green.

## Deploy note
Baked into the agent runtime — needs a forge build + `AGENT_FORGE_VERSION` bump (+ agent rebuild) to take effect on deployed agents.