### PR TITLE
runtime: detach task execution from the request so deferrals survive

### DIFF
--- a/forge-cli/runtime/defer_test.go
+++ b/forge-cli/runtime/defer_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -500,4 +501,33 @@ func TestResolveDeferSpec_Approvers(t *testing.T) {
 			t.Errorf("no approvers → nil, got %v", spec.Approvers)
 		}
 	})
+}
+
+// A parked deferral must survive the caller (request) disconnecting — the whole
+// point of a human-approval gate that can take minutes to hours. invocationContext
+// detaches the task from the request's cancellation while staying explicitly
+// cancellable via tasks/cancel and preserving request values.
+func TestInvocationContext_DetachesFromRequestCancel(t *testing.T) {
+	type ctxKey struct{}
+	reqCtx, cancelReq := context.WithCancel(context.WithValue(context.Background(), ctxKey{}, "corr-123"))
+	ctx, cancelInvocation := invocationContext(reqCtx)
+
+	// Caller disconnects → request ctx cancels → the invocation must NOT.
+	cancelReq()
+	select {
+	case <-ctx.Done():
+		t.Fatal("invocation ctx cancelled by request cancel — a deferral would die before approval")
+	default:
+	}
+	// Request values survive the detach.
+	if ctx.Value(ctxKey{}) != "corr-123" {
+		t.Errorf("request value not preserved: %v", ctx.Value(ctxKey{}))
+	}
+	// Explicit tasks/cancel still ends the task, with its cause.
+	cause := errors.New("operator stop")
+	cancelInvocation(cause)
+	<-ctx.Done()
+	if context.Cause(ctx) != cause {
+		t.Errorf("cause = %v, want %v", context.Cause(ctx), cause)
+	}
 }

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1956,7 +1956,10 @@ func (r *Runner) executeTask(
 	// invocation by task ID. The release closure pops the registry
 	// entry on return; cancel() at defer time is a no-op when the
 	// invocation completed cleanly.
-	ctx, cancelInvocation := context.WithCancelCause(ctx)
+	//
+	// Detaches from the HTTP request's cancellation so a parked deferral
+	// survives the caller disconnecting — see invocationContext.
+	ctx, cancelInvocation := invocationContext(ctx)
 	release := r.cancelRegistry.Register(params.ID, cancelInvocation)
 	defer release()
 	defer cancelInvocation(nil) // nil cause = clean completion; no-op when already cancelled
@@ -4056,6 +4059,21 @@ func withoutEnvNames(names []string, exclude map[string]bool) []string {
 		}
 	}
 	return out
+}
+
+// invocationContext derives the task-execution context from the request ctx.
+// It DETACHES from the request's cancellation (context.WithoutCancel) so a
+// caller disconnect can't cancel a task that legitimately outlives the request
+// — most importantly a parked DEFERRAL awaiting human approval for up to its
+// defer timeout (e.g. 1h), far longer than the synchronous caller holds the
+// connection. Before this, a caller that gave up after minutes cancelled the
+// request ctx, which resolved the parked deferral as a timeout and canceled the
+// task before anyone could approve it. The returned CancelCauseFunc keeps the
+// task explicitly cancellable (tasks/cancel via the cancellation registry) and
+// the deferral's own timeout still bounds it; request values (correlation id,
+// usage accumulator) are preserved by WithoutCancel.
+func invocationContext(reqCtx context.Context) (context.Context, context.CancelCauseFunc) {
+	return context.WithCancelCause(context.WithoutCancel(reqCtx))
 }
 
 func envFromOS() map[string]string {

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -1792,7 +1792,14 @@ func (r *Runner) registerHandlers(srv *server.Server, executor coreruntime.Agent
 			server.WriteSSEEvent(w, flusher, "progress", progressTask) //nolint:errcheck
 		})
 
-		// Stream from executor
+		// Stream from executor.
+		// NOTE: the streaming path intentionally runs with the REQUEST ctx
+		// (not invocationContext) — a client disconnect SHOULD stop a live SSE
+		// stream. The trade-off: a DEFER that parks here is cancelled on
+		// disconnect (park resolves as a timeout), so durable human-approval
+		// defers are NOT supported over streaming — only the synchronous
+		// tasks/send path detaches (see executeTask + invocationContext).
+		// Tracked as defer piece 1b: initializ/forge#404.
 		ch, err := executor.ExecuteStream(ctx, task, &params.Message)
 		if err != nil {
 			task.Status = a2a.TaskStatus{
@@ -2353,6 +2360,13 @@ func (r *Runner) registerRESTHandlers(srv *server.Server, executor coreruntime.A
 			server.WriteSSEEvent(w, flusher, "progress", progressTask) //nolint:errcheck
 		})
 
+		// NOTE: the streaming path intentionally runs with the REQUEST ctx
+		// (not invocationContext) — a client disconnect SHOULD stop a live SSE
+		// stream. The trade-off: a DEFER that parks here is cancelled on
+		// disconnect (park resolves as a timeout), so durable human-approval
+		// defers are NOT supported over streaming — only the synchronous
+		// tasks/send path detaches (see executeTask + invocationContext).
+		// Tracked as defer piece 1b: initializ/forge#404.
 		ch, err := executor.ExecuteStream(ctx, task, &params.Message)
 		if err != nil {
 			task.Status = a2a.TaskStatus{
@@ -4072,6 +4086,14 @@ func withoutEnvNames(names []string, exclude map[string]bool) []string {
 // task explicitly cancellable (tasks/cancel via the cancellation registry) and
 // the deferral's own timeout still bounds it; request values (correlation id,
 // usage accumulator) are preserved by WithoutCancel.
+//
+// RESIDUAL: WithoutCancel detaches from the WHOLE ctx chain, so an in-flight or
+// parked invocation also stops observing server graceful-shutdown signalling.
+// Teardown then falls to the agent loop cap (maxIter, default 50), the defer
+// timeout, or explicit tasks/cancel, and ultimately the shutdown hard-kill —
+// i.e. orphaned tasks compute to natural loop termination and don't drain
+// cleanly on shutdown. Accepted: the loop cap bounds runaway compute and task
+// state is persisted in the store, so a hard-killed task is recoverable.
 func invocationContext(reqCtx context.Context) (context.Context, context.CancelCauseFunc) {
 	return context.WithCancelCause(context.WithoutCancel(reqCtx))
 }


### PR DESCRIPTION
**Piece 1 of the defer-approval work** (the concrete "deferrals get cancelled in ~2 minutes" bug).

## Symptom
A PDP `defer` parks the task with a 1h window (`task_deferred timeout_ms:3600000 to:platform`), but ~2 min later:
```
task cancelled mid-execution  reason=external_signal
session_end  state=canceled
```

## Root cause
The execution context was `context.WithCancelCause(reqCtx)` (runner.go), i.e. tied to the synchronous `tasks/send` **HTTP request**. A deferral awaits a **human** far longer than the caller holds the connection — so when the caller gave up after minutes, the request ctx cancelled → `handle.WaitCtx(ctx)` in `park()` returned → the deferral resolved as a **timeout** and the task was canceled, long before anyone could approve. The 1h defer window was moot because the request can't stay open that long.

## Fix
`invocationContext` derives the execution ctx from **`context.WithoutCancel(reqCtx)`**: a caller disconnect no longer cancels the task. It stays:
- explicitly cancellable via **`tasks/cancel`** (the cancellation registry — cost/timeout/workflow cancels still work), and
- bounded by the **deferral's own timeout**;
- request values (correlation id, usage accumulator) are preserved.

Applied to the non-streaming `tasks/send` handler (the deferral path in the log). The task now stays `deferred` and is retrievable via `GET /tasks/{id}` until resolved.

Test: `TestInvocationContext_DetachesFromRequestCancel` — request cancel doesn't cancel the invocation, values survive, explicit cancel still ends it with its cause. `go build`/`vet`/`test ./runtime/...` green.

## Scope / follow-ups (this is piece 1 of 3)
- **Console approval UI** — a "Deferrals/Approvals" surface listing parked deferrals (from `task_deferred` minus resolved, like MCP pending-consents) with Approve/Deny → `POST /tasks/{id}/decisions`. This is the `to:platform` inbox.
- **Slack-channel route** — expose the defer route on the Compliance surface (like MCP delegated consent) → forge's existing Block-Kit delivery.
- Trade-off noted: a caller disconnect no longer implicitly cancels a task; explicit `tasks/cancel` and the defer timeout are the bounds. Streaming (`ExecuteStream`) SSE path unchanged (separate lifecycle) — out of scope here.

## Scope: streaming is intentionally excluded

The **non-streaming** `tasks/send` path (JSON-RPC + REST) is the only path detached here. The **streaming** `tasks/sendSubscribe` (SSE) path deliberately keeps the request-tied ctx — a client disconnect *should* stop a live stream. Consequence: a defer that parks on a streaming task is still cancelled on disconnect, so **durable human-approval defers are not supported over streaming**. Both `ExecuteStream` sites now document this. Tracked as **defer piece 1b: #404** (leaning toward making a streaming defer fail-fast rather than silently mis-resolve as a timeout).

## Residual: graceful shutdown

`WithoutCancel` detaches from the whole ctx chain, so a detached/parked invocation also stops observing server graceful-shutdown signalling; teardown falls to `maxIter` / the defer timeout / `tasks/cancel` / the shutdown hard-kill. Accepted — the loop cap bounds runaway compute and task state is persisted (a hard-killed task is recoverable). Documented on `invocationContext`.
