### PR TITLE
runtime: emit approver allowlist in task_deferred event

### DIFF
--- a/forge-cli/runtime/defer.go
+++ b/forge-cli/runtime/defer.go
@@ -103,16 +103,24 @@ func (r *Runner) park(ctx context.Context, hctx *coreruntime.HookContext, spec d
 		},
 	})
 
+	deferFields := map[string]any{
+		"tool":       hctx.ToolName,
+		"to":         spec.To,
+		"timeout_ms": spec.Timeout.Milliseconds(),
+		"context":    truncateForAudit(spec.ContextForApprover, 512),
+	}
+	// The approver allowlist rides on task_deferred so the platform can route
+	// the gate to the right person's approvals queue (a direct email matches a
+	// user; the #313 allowlist is what forge later enforces on the decision).
+	// Empty = no allowlist (anyone may approve).
+	if len(spec.Approvers) > 0 {
+		deferFields["approvers"] = spec.Approvers
+	}
 	auditLogger.EmitFromContext(ctx, coreruntime.AuditEvent{
 		Event:         coreruntime.AuditTaskDeferred,
 		CorrelationID: hctx.CorrelationID,
 		TaskID:        hctx.TaskID,
-		Fields: map[string]any{
-			"tool":       hctx.ToolName,
-			"to":         spec.To,
-			"timeout_ms": spec.Timeout.Milliseconds(),
-			"context":    truncateForAudit(spec.ContextForApprover, 512),
-		},
+		Fields:        deferFields,
 	})
 
 	// #310 — deliver an interactive approval request to the channel named

--- a/forge-cli/runtime/defer_test.go
+++ b/forge-cli/runtime/defer_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -529,5 +530,58 @@ func TestInvocationContext_DetachesFromRequestCancel(t *testing.T) {
 	<-ctx.Done()
 	if context.Cause(ctx) != cause {
 		t.Errorf("cause = %v, want %v", context.Cause(ctx), cause)
+	}
+}
+
+// TestDeferHook_EmitsApprovers asserts the task_deferred audit event
+// carries the configured approver allowlist, so the platform can route
+// the gate to the right approver's "My Approvals" queue.
+func TestDeferHook_EmitsApprovers(t *testing.T) {
+	var buf bytes.Buffer
+	logger := coreruntime.NewJSONLogger(discardWriter{}, false)
+	auditLogger := coreruntime.NewAuditLogger(&buf)
+	r := &Runner{
+		logger: logger,
+		cfg: RunnerConfig{Config: &types.ForgeConfig{Security: types.SecurityConfig{Defer: types.DeferConfig{
+			Enabled:        true,
+			DefaultTimeout: 500 * time.Millisecond,
+			Tools: map[string]types.DeferToolConfig{
+				"cli_execute": {To: "platform", Timeout: 500 * time.Millisecond, Approvers: []string{"Fee-Approvals@x.io"}},
+			},
+		}}}},
+		deferEngine: deferengine.New(),
+	}
+	hooks := coreruntime.NewHookRegistry()
+	store := newFakeStatusStore()
+	r.registerDeferHook(hooks, store, auditLogger)
+
+	hctx := &coreruntime.HookContext{
+		ToolName:      "cli_execute",
+		ToolInput:     `{}`,
+		TaskID:        "task-appr-emit",
+		CorrelationID: "corr-emit",
+	}
+	done := make(chan error, 1)
+	go func() { done <- hooks.Fire(context.Background(), coreruntime.BeforeToolExec, hctx) }()
+	time.Sleep(30 * time.Millisecond)
+	if err := r.deferEngine.Resolve("task-appr-emit", deferengine.Resolution{Decision: deferengine.DecisionApprove}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	<-done
+
+	events := captureAudit(t, &buf)
+	var found bool
+	for _, e := range events {
+		if e.Event != coreruntime.AuditTaskDeferred {
+			continue
+		}
+		found = true
+		appr, ok := e.Fields["approvers"].([]any)
+		if !ok || len(appr) != 1 || appr[0] != "fee-approvals@x.io" {
+			t.Errorf("task_deferred approvers = %#v, want [fee-approvals@x.io] (normalized)", e.Fields["approvers"])
+		}
+	}
+	if !found {
+		t.Fatal("no task_deferred event emitted")
 	}
 }


### PR DESCRIPTION
## What

The `task_deferred` audit event carried `tool`/`to`/`timeout_ms`/`context` but **not** the configured approver emails. Without that, the platform can't route a parked deferral to a specific approver's queue — every deferral looks identical downstream.

This adds an `approvers` field to the emitted `task_deferred` event (the normalized allowlist from `security.defer.tools.<tool>.approvers` / `default_approvers`, `#313`). Omitted when empty, so `to:platform`/no-allowlist deferrals are unchanged on the wire.

## Why

Backend prerequisite for the **DEFER approval flow** (async park → console approval → Slack route). Specifically the "My Approvals" scoping:

- **forge** (this PR) emits `approvers` in `task_deferred`.
- **security-next** projects per-approver pending-approval queues (`GET /security/v1/pending-approvals?approver=<email>` filters on array membership).
- **console-next** shows a personal *My Approvals* surface scoped by the signed-in user's email.

## Change

- `runtime/defer.go`: build `deferFields` and attach `approvers` only when `len(spec.Approvers) > 0`.
- `runtime/defer_test.go`: `TestDeferHook_EmitsApprovers` — a configured allowlist appears (normalized/lowercased) in the emitted `task_deferred` event; captured via an audit buffer.

No wire change for deferrals without an approver allowlist.