### PR TITLE
ci(release): don't run GoReleaser on the non-semver vnext tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Semver release tags only — "v" followed by a digit (v0.18.0,
+      # v1.2.3-rc1, …). Deliberately does NOT match the rolling `vnext`
+      # prerelease pointer (edge.yaml), which is not semver and made
+      # GoReleaser abort with "failed to parse tag 'vnext' as semver".
+      - "v[0-9]*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

The **Release** workflow triggered on `tags: "v*"`. That glob also matches the rolling **`vnext`** prerelease pointer that `edge.yaml` republishes on every merge to `main`. When the `vnext` tag moved, GoReleaser ran and aborted:

```
• getting and validating git state
  • using tags   previous=v0.17.1 current=vnext
⨯ release failed after 0s   error=failed to parse tag 'vnext' as semver: invalid semantic version
```

So every merge to main produced a red **Release** run (the `edge` snapshot prerelease it was meant to be handled by is a separate, working job).

## Fix

Narrow the tag trigger from `v*` to **`v[0-9]*`** — "v" followed by a digit. This matches real semver release tags (`v0.18.0`, `v1.2.3-rc1`, …) and deliberately excludes `vnext` (and any other non-numeric `v*` tag).

Verified glob behavior:

| tag | `v[0-9]*` |
|---|---|
| `v0.18.0` | ✅ runs |
| `v1.2.3-rc1` | ✅ runs |
| `vnext` | ⛔ skipped |

## Scope / safety
- The `edge.yaml` rolling prerelease is unaffected — it triggers on `push: branches: [main]` and builds via `goreleaser --snapshot` (no tag parse), not on the tag.
- The `library-tags` job shares this workflow's top-level `on:`, so it's correctly gated too.
- No change to what a real `vX.Y.Z` release does.