### PR TITLE
ci(release): pin GORELEASER_CURRENT_TAG (fixes v0.18.0 build picking vnext)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Pin GoReleaser to the tag that triggered this run. The rolling
+          # `vnext` prerelease (edge.yaml) points at the same commit as each
+          # real release tag, so GoReleaser's `git describe` could otherwise
+          # resolve `current=vnext` and abort ("failed to parse tag 'vnext' as
+          # semver") even on a real vX.Y.Z push. github.ref_name is the pushed
+          # tag (e.g. v0.18.1).
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   # Path-prefixed Git tags so external consumers (e.g. the Initializ
   # platform) can `go get github.com/initializ/forge/forge-{skills,core,


### PR DESCRIPTION
Follow-up to #413. The v0.18.0 release published but its GoReleaser build **failed**: even though the `v0.18.0` tag triggered the run, GoReleaser's git-state detection resolved `current=vnext` (the rolling prerelease pointer sits on the same commit) and aborted with `failed to parse tag 'vnext' as semver`.

#413 narrowed the *trigger* so vnext doesn't start the workflow, but it can't fix GoReleaser picking the wrong tag when a real release shares a commit with vnext. Pinning `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` forces GoReleaser to build the exact tag that triggered the run.

Needed on main before cutting **v0.18.1** (the tag-triggered run uses the workflow file at the tagged commit).