### PR TITLE
feat(skills): both name forms for tool→script binding + validate lint (#418)

### DIFF
--- a/docs/core-concepts/skill-md-format.md
+++ b/docs/core-concepts/skill-md-format.md
@@ -77,7 +77,7 @@ The `metadata.forge.runtime` field selects how the skill's tool is executed (iss
 
 | Value | Behavior |
 |---|---|
-| `script` (default; empty = `script`) | Skill body is materialized as a bash script at `skills/<dir>/scripts/<tool>.sh` and invoked as `bash <scriptPath> <jsonArgs>`. |
+| `script` (default; empty = `script`) | The `## Tool:` binds to a script at `skills/<dir>/scripts/<tool>.{sh,py,js}` (the tool name matches the file in either its underscore or hyphen form) and is invoked as `<interpreter> <scriptPath> <jsonArgs>`, interpreter chosen by extension. |
 | `binary` | The first `metadata.forge.requires.bins` entry IS the executable. The runtime resolves it via `exec.LookPath` and invokes `<binary> <jsonArgs>` directly — no bash fork, no script file required. Skill body is documentation only. |
 
 ```yaml

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -651,7 +651,7 @@ forge skills list --category sre
 forge skills list --tags kubernetes,incident-response
 
 # Validate skill requirements
-forge skills validate
+forge skills validate  # checks bins, env, invalid Input keys, missing/orphan scripts; non-zero exit on error
 
 # Audit skill security
 forge skills audit --embedded

--- a/docs/security/platform-policy.md
+++ b/docs/security/platform-policy.md
@@ -313,6 +313,45 @@ Semantics:
 
 Reach the PDP over the platform callout contract (bearer + `Org-Id`/`Workspace-Id`, see [Tenancy](tenancy.md)). Full field reference: [`security.pdp` schema](../reference/forge-yaml-schema.md#security--build-time--runtime-governance).
 
+### Default-deny: govern the tool the LLM picks, not just the ones you listed
+
+The PDP fires at the **execution** boundary, not the decision boundary — it does
+not matter *how* the model chose the call. A prose skill that vaguely says
+"use Linear to file a ticket" still ends up emitting a concrete `tool_use` for a
+registered, namespaced tool (`linear__create_issue`), and that invocation is
+intercepted at `BeforeToolExec` and sent to the PDP like any other. There is no
+runtime "discover-and-call" path that escapes the registry: MCP/API operations
+are enumerated at build/startup, filtered by `tools.allow`, and registered as
+fixed `<name>__<op>` tools — the model can only pick from that set, and every
+pick is governed.
+
+So the real control isn't *whether* the PDP is consulted (it always is) — it's
+what your policy decides for an operation you didn't anticipate the model
+reaching for. Write the policy **default-deny**: allow the operations the agent
+is meant to use, and deny everything else by default. Then an unexpected pick is
+denied even though the PDP fired.
+
+```jsonc
+// PDP decide response for an operation with no explicit allow rule.
+// With a default-deny policy the fallback is deny, not allow:
+{ "decision": "deny", "reason": "no matching allow rule (default-deny)", "policy_version": 7 }
+```
+
+This is the key contrast with the static [`security.defer.tools`](defer-decisions.md)
+map: a tool **absent** from that map has *no* requirement and simply **runs** —
+static defer is allow-by-default for anything you forgot to list. Managed PDP
+lets you invert that to deny-by-default. Two levers combine for defense in depth:
+
+1. **Narrow `tools.allow`** on each MCP/API server so operations you never intend
+   (e.g. `linear__delete_issue`) are not registered at all — the model cannot
+   select what isn't in the registry.
+2. **Default-deny in the PDP policy** so anything that *is* callable but lacks an
+   explicit allow rule is denied rather than silently permitted.
+
+Rely on `security.defer.tools` alone and vague prose becomes a real gap — not
+because the PDP is skipped, but because an unlisted tool is ungoverned. Move
+enforcement to a default-deny PDP and the looseness of the prompt stops mattering.
+
 ## Conflict semantics
 
 When `forge.yaml` declares an egress / tool / model / size value any layer forbids, the runner:

--- a/docs/skills/skills-cli.md
+++ b/docs/skills/skills-cli.md
@@ -88,6 +88,25 @@ Flags:
 > `metadata.forge.requires.bins` so the interpreter is still provisioned —
 > `forge skills import` warns if it's missing.
 
+## Validate
+
+`forge skills validate` checks that a project's skills will actually register at runtime, surfacing failures the runtime otherwise handles **silently** (an error log line at best). It scans the whole skill tree — the main `SKILL.md` **and** every `skills/*/SKILL.md` — and reports, per `## Tool:`:
+
+| Check | Level | Why it matters |
+|---|---|---|
+| **Invalid `**Input:**` property key** — a parameter name that yields a JSON-schema key outside `^[a-zA-Z0-9_.-]{1,64}$` (e.g. a space or backtick) | ERROR | The LLM provider rejects the *entire* request, so the runtime drops the whole tool at startup — the tool silently never appears. |
+| **No backing script** — a script-runtime `## Tool: foo_bar` with no `scripts/foo_bar.{sh,py,js}` or `scripts/foo-bar.{sh,py,js}` | ERROR | The tool never registers. |
+| **Orphan script** — a `scripts/*.{sh,py,js}` no `## Tool:` heading binds | WARN | Reachable only by path via `run_skill_script`; dead weight in the image if never referenced. |
+
+It also reports missing required binaries and unresolved required env vars. It exits **non-zero** when any ERROR is present, so CI can gate on it — making the parser itself the source of truth instead of an external lint you re-confirm each release.
+
+```bash
+# Validate the skills in the current project (run from a dir with forge.yaml).
+forge skills validate
+```
+
+> A `## Tool: foo_bar` binds to its script by **either** name form — `scripts/foo_bar.sh` or `scripts/foo-bar.sh` both work (hyphenated wins only if both exist). See [Writing Custom Skills](writing-custom-skills.md#skills-as-first-class-tools).
+
 ## Security Audit
 
 `forge skills audit` scores each skill in the project across four categories — egress, binary, env, script — and runs a `SecurityPolicy` check for hard violations. By default it uses the analyzer's `DefaultPolicy`. A custom policy YAML can be supplied with `--policy`.

--- a/docs/skills/writing-custom-skills.md
+++ b/docs/skills/writing-custom-skills.md
@@ -27,7 +27,9 @@ Script-backed skills are automatically registered as **first-class LLM tools** a
 
 1. Parses the skill's SKILL.md for tool definitions, descriptions, and input schemas
 2. Creates a named tool for each `## Tool:` entry (e.g., `tavily_research` becomes a tool the LLM can call directly)
-3. Executes the backing script with JSON input when the LLM invokes it, under the interpreter matching its extension — `scripts/<name>.sh` (bash), `.py` (python3), or `.js` (node). A `## Tool: foo_bar` binds to `scripts/foo-bar.<ext>` (underscores become hyphens); shell wins if several extensions exist. Ensure the interpreter is provisioned (`python3`/`node` in `requires.bins`; bash is built in).
+3. Executes the backing script with JSON input when the LLM invokes it, under the interpreter matching its extension — `scripts/<name>.sh` (bash), `.py` (python3), or `.js` (node). A `## Tool: foo_bar` binds to **either** `scripts/foo_bar.<ext>` **or** `scripts/foo-bar.<ext>` (the underscore and hyphen forms both work; the hyphenated form wins only if both files exist). Shell wins if several extensions exist. Ensure the interpreter is provisioned (`python3`/`node` in `requires.bins`; bash is built in).
+
+> **Silent-failure guard.** If the backing script is missing, or a `**Input:**` parameter yields a JSON-schema property key outside `^[a-zA-Z0-9_.-]{1,64}$`, the runtime drops that tool at startup with only a log line. Run [`forge skills validate`](skills-cli.md) to catch both — plus orphan scripts with no `## Tool:` heading — before you ship; it exits non-zero on any error, so you can gate CI on it.
 
 This means the LLM sees skill tools alongside builtins like `web_search` and `http_request` — no generic `cli_execute` indirection needed.
 

--- a/forge-cli/cmd/skills.go
+++ b/forge-cli/cmd/skills.go
@@ -390,13 +390,34 @@ func runSkillsValidate(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
+	// Tool → registry lint: surface the registration failures the runtime
+	// otherwise handles silently (invalid Input keys, missing/orphan scripts).
+	// Scans the whole skill tree, not just the main SKILL.md (#418).
+	toolFindings := lintSkillTools(filepath.Dir(skillsPath), skillsPath)
+	if len(toolFindings) > 0 {
+		fmt.Println("Tools:")
+		for _, f := range toolFindings {
+			prefix := "  WARN "
+			if f.Level == "error" {
+				prefix = "  ERROR"
+				hasErrors = true
+			}
+			where := f.Skill
+			if f.Tool != "" {
+				where = f.Skill + " / " + f.Tool
+			}
+			fmt.Printf("%s %s: %s\n", prefix, where, f.Msg)
+		}
+		fmt.Println()
+	}
+
 	// Summary
 	if !hasErrors {
 		fmt.Println("Validation passed.")
 		return nil
 	}
 
-	return fmt.Errorf("validation failed: missing required environment variables")
+	return fmt.Errorf("validation failed: see ERROR lines above")
 }
 
 func envFromOS() map[string]string {

--- a/forge-cli/cmd/skills_lint.go
+++ b/forge-cli/cmd/skills_lint.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/initializ/forge/forge-cli/runtime"
+	cliskills "github.com/initializ/forge/forge-cli/skills"
+	coretools "github.com/initializ/forge/forge-core/tools"
+	"github.com/initializ/forge/forge-skills/contract"
+)
+
+// skillToolFinding is one problem the tool→registry lint surfaces at author or
+// build time — a failure the runtime would otherwise handle silently at
+// startup (an error log line at best), which is exactly what customers had to
+// reimplement as external lints against Forge's parser (#418).
+type skillToolFinding struct {
+	Skill string // skill directory name, or the SKILL.md file's base name
+	Tool  string // `## Tool:` name ("" for orphan-script findings)
+	Level string // "error" | "warn"
+	Msg   string
+}
+
+// lintSkillTools scans the skill tree rooted at workDir and reports tool
+// registration problems that the runtime resolves silently:
+//
+//   - a `## Tool:` whose `**Input:**` yields a JSON-schema property key outside
+//     the provider pattern ^[a-zA-Z0-9_.-]{1,64}$ — the runtime DROPS the whole
+//     tool (registering it would 400 every LLM call). Reported as an error.
+//   - a script-runtime `## Tool:` with no backing scripts/<name>.{sh,py,js}
+//     (either name form) — the tool never registers. Reported as an error.
+//   - a scripts/*.{sh,py,js} with no `## Tool:` heading claiming it — reachable
+//     only by path via run_skill_script; dead weight if unreferenced. Warning.
+//
+// It uses runtime.SkillScriptCandidatePaths so the binding check matches the
+// runtime resolver exactly (the two cannot drift). mainSkillPath is the
+// resolved main SKILL.md (root or forge.yaml skills.path).
+func lintSkillTools(workDir, mainSkillPath string) []skillToolFinding {
+	var findings []skillToolFinding
+
+	// claimed collects every candidate script path (workDir-relative) that a
+	// script-runtime `## Tool:` could bind to, so the orphan pass can tell a
+	// backing script from dead weight regardless of which name form it uses.
+	claimed := map[string]bool{}
+	// scriptDirs collects the scripts/ directories to sweep for orphans.
+	scriptDirs := map[string]bool{}
+
+	for _, file := range discoverSkillFilesForLint(workDir, mainSkillPath) {
+		entries, meta, err := cliskills.ParseFileWithMetadata(file)
+		if err != nil {
+			continue
+		}
+
+		skillDirName := ""
+		if strings.HasSuffix(file, string(filepath.Separator)+"SKILL.md") || strings.HasSuffix(file, "/SKILL.md") {
+			skillDirName = filepath.Base(filepath.Dir(file))
+		}
+		label := skillDirName
+		if label == "" {
+			label = filepath.Base(file)
+		}
+
+		runtimeMode := skillRuntimeMode(meta)
+
+		// Register the scripts/ directories this skill could draw from.
+		if skillDirName != "" {
+			scriptDirs[filepath.Join("skills", skillDirName, "scripts")] = true
+		}
+		scriptDirs[filepath.Join("skills", "scripts")] = true
+
+		for _, entry := range entries {
+			// 1. Invalid **Input:** property key(s) — parsed exactly as the
+			// runtime does, so the rule can't drift from enforcement.
+			if bad := coretools.InvalidSchemaPropertyKeys(coretools.InputSpecToSchema(entry.InputSpec)); len(bad) > 0 {
+				findings = append(findings, skillToolFinding{
+					Skill: label, Tool: entry.Name, Level: "error",
+					Msg: "input property key(s) " + strings.Join(bad, ", ") +
+						" violate ^[a-zA-Z0-9_.-]{1,64}$ — the tool is DROPPED at runtime (it would fail every LLM call)",
+				})
+			}
+
+			// Binary-runtime tools bind to requires.bins, not a script — the
+			// binary/env checks above cover them.
+			if runtimeMode == contract.SkillRuntimeBinary {
+				continue
+			}
+
+			// 2. Tool→script binding — same candidate set the runtime resolves.
+			candidates := runtime.SkillScriptCandidatePaths(skillDirName, entry.Name)
+			backed := false
+			for _, cand := range candidates {
+				claimed[cand] = true
+				if _, err := os.Stat(filepath.Join(workDir, cand)); err == nil {
+					backed = true
+				}
+			}
+			if !backed {
+				findings = append(findings, skillToolFinding{
+					Skill: label, Tool: entry.Name, Level: "error",
+					Msg: "no backing script (scripts/" + entry.Name + ".{sh,py,js}) — the tool will not register",
+				})
+			}
+		}
+	}
+
+	// 3. Orphan scripts — a scripts/*.<ext> no `## Tool:` heading claims.
+	exts := map[string]bool{}
+	for _, e := range runtime.SkillScriptExtensions() {
+		exts[e] = true
+	}
+	for dir := range scriptDirs {
+		listed, err := os.ReadDir(filepath.Join(workDir, dir))
+		if err != nil {
+			continue
+		}
+		for _, de := range listed {
+			if de.IsDir() || !exts[strings.ToLower(filepath.Ext(de.Name()))] {
+				continue
+			}
+			rel := filepath.Join(dir, de.Name())
+			if claimed[rel] {
+				continue
+			}
+			findings = append(findings, skillToolFinding{
+				Skill: skillLabelForScriptDir(dir), Level: "warn",
+				Msg: "orphan script " + rel + " — no `## Tool:` heading binds it; reachable only via run_skill_script (dead weight if unreferenced)",
+			})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Skill != findings[j].Skill {
+			return findings[i].Skill < findings[j].Skill
+		}
+		if findings[i].Level != findings[j].Level {
+			return findings[i].Level < findings[j].Level // "error" before "warn"
+		}
+		return findings[i].Tool < findings[j].Tool
+	})
+	return findings
+}
+
+// discoverSkillFilesForLint mirrors Runner.discoverSkillFiles: flat skills/*.md,
+// subdir skills/*/SKILL.md, plus the main SKILL.md (root or forge.yaml path).
+func discoverSkillFilesForLint(workDir, mainSkillPath string) []string {
+	skillsDir := filepath.Join(workDir, "skills")
+	matches, _ := filepath.Glob(filepath.Join(skillsDir, "*.md"))
+	subDir, _ := filepath.Glob(filepath.Join(skillsDir, "*", "SKILL.md"))
+	matches = append(matches, subDir...)
+	if info, err := os.Stat(mainSkillPath); err == nil && !info.IsDir() {
+		matches = append(matches, mainSkillPath)
+	}
+	return matches
+}
+
+// skillRuntimeMode reads metadata.forge.runtime, defaulting to "script".
+func skillRuntimeMode(meta *contract.SkillMetadata) string {
+	mode := contract.SkillRuntimeScript
+	if meta != nil && meta.Metadata != nil {
+		if forgeMap, ok := meta.Metadata["forge"]; ok {
+			if raw, ok := forgeMap["runtime"]; ok {
+				if s, ok := raw.(string); ok && s != "" {
+					mode = s
+				}
+			}
+		}
+	}
+	return mode
+}
+
+// skillLabelForScriptDir turns "skills/foo/scripts" into "foo" and the shared
+// "skills/scripts" into "(shared)" for readable orphan-finding labels.
+func skillLabelForScriptDir(dir string) string {
+	parts := strings.Split(filepath.ToSlash(dir), "/")
+	if len(parts) == 3 && parts[0] == "skills" && parts[2] == "scripts" {
+		return parts[1]
+	}
+	return "(shared)"
+}

--- a/forge-cli/cmd/skills_lint_test.go
+++ b/forge-cli/cmd/skills_lint_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkill writes skills/<name>/SKILL.md and any scripts under
+// skills/<name>/scripts/ into root.
+func writeSkill(t *testing.T, root, name, body string, scripts map[string]string) {
+	t.Helper()
+	dir := filepath.Join(root, "skills", name)
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for fname, content := range scripts {
+		if err := os.WriteFile(filepath.Join(dir, "scripts", fname), []byte(content), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func findingFor(fs []skillToolFinding, skill, tool string) *skillToolFinding {
+	for i := range fs {
+		if fs[i].Skill == skill && fs[i].Tool == tool {
+			return &fs[i]
+		}
+	}
+	return nil
+}
+
+func TestLintSkillTools(t *testing.T) {
+	root := t.TempDir()
+
+	// hyphen-named script backs an underscore tool (historical convention).
+	writeSkill(t, root, "hyphen", "---\nname: hyphen\ndescription: d\n---\n## Tool: do_thing\nDoes it.\n**Input:** query (string)\n",
+		map[string]string{"do-thing.sh": "#!/bin/sh\n"})
+
+	// underscore-named script backs an underscore tool (NEW: #418).
+	writeSkill(t, root, "underscore", "---\nname: underscore\ndescription: d\n---\n## Tool: run_report\n**Input:** name (string)\n",
+		map[string]string{"run_report.sh": "#!/bin/sh\n"})
+
+	// invalid **Input:** property key ("pod name" has a space).
+	writeSkill(t, root, "badkey", "---\nname: badkey\ndescription: d\n---\n## Tool: scan\n**Input:** pod name (string)\n",
+		map[string]string{"scan.sh": "#!/bin/sh\n"})
+
+	// tool with no backing script at all.
+	writeSkill(t, root, "missing", "---\nname: missing\ndescription: d\n---\n## Tool: ghost\n**Input:** x (string)\n", nil)
+
+	// orphan script: a scripts file no `## Tool:` claims.
+	writeSkill(t, root, "orphan", "---\nname: orphan\ndescription: d\n---\n## Tool: real\n**Input:** x (string)\n",
+		map[string]string{"real.sh": "#!/bin/sh\n", "leftover.sh": "#!/bin/sh\n"})
+
+	findings := lintSkillTools(root, filepath.Join(root, "SKILL.md"))
+
+	// Both name forms resolve → no missing-script finding for these tools.
+	if f := findingFor(findings, "hyphen", "do_thing"); f != nil {
+		t.Errorf("hyphen/do_thing should be backed (hyphen script), got: %s", f.Msg)
+	}
+	if f := findingFor(findings, "underscore", "run_report"); f != nil {
+		t.Errorf("underscore/run_report should be backed (underscore script, #418), got: %s", f.Msg)
+	}
+
+	// Invalid key → error.
+	if f := findingFor(findings, "badkey", "scan"); f == nil || f.Level != "error" {
+		t.Errorf("expected error finding for badkey/scan invalid key, got: %+v", f)
+	}
+
+	// Missing script → error.
+	if f := findingFor(findings, "missing", "ghost"); f == nil || f.Level != "error" {
+		t.Errorf("expected error finding for missing/ghost, got: %+v", f)
+	}
+
+	// Orphan script → warn (Tool "" on the finding).
+	if f := findingFor(findings, "orphan", ""); f == nil || f.Level != "warn" {
+		t.Errorf("expected orphan-script warning for orphan skill, got: %+v", f)
+	}
+	// The claimed script (real.sh) must NOT be flagged orphan.
+	for _, f := range findings {
+		if f.Skill == "orphan" && f.Tool == "" && filepath.Base(pathFromMsg(f.Msg)) == "real.sh" {
+			t.Error("real.sh backs a tool and must not be an orphan finding")
+		}
+	}
+}
+
+// pathFromMsg extracts the "skills/.../x.sh" token from an orphan finding msg.
+func pathFromMsg(msg string) string {
+	for _, tok := range strings.Fields(msg) {
+		if filepath.Ext(tok) == ".sh" {
+			return tok
+		}
+	}
+	return ""
+}

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -3581,34 +3581,91 @@ var skillScriptExtensions = []struct{ ext, interpreter string }{
 	{".mjs", "node"},
 }
 
-// resolveSkillScript locates the script backing a `## Tool:` entry and returns
-// its container-relative path, the interpreter to run it under, and whether it
-// was found. It searches the skill's own scripts/ directory first, then the
-// shared skills/scripts/ directory; within each, shell before python before
-// node. Single source of truth shared by registerSkillTools (which registers
-// the tool) and skillEntryHasScript (which excludes it from the read_skill
-// catalog) so the two can never disagree about what's a first-class tool.
-func (r *Runner) resolveSkillScript(skillDirName, toolName string) (relPath, interpreter string, found bool) {
-	scriptName := strings.ReplaceAll(toolName, "_", "-")
+// SkillScriptExtensions returns the recognized skill-script file extensions
+// (each with a leading dot), for tooling that enumerates a scripts/ directory
+// — e.g. `forge skills validate`'s orphan-script check.
+func SkillScriptExtensions() []string {
+	out := make([]string, len(skillScriptExtensions))
+	for i, se := range skillScriptExtensions {
+		out[i] = se.ext
+	}
+	return out
+}
+
+// skillScriptNameVariants returns the distinct filename stems a `## Tool:`
+// name can bind to: the hyphenated form (historical convention) and, when it
+// differs, the underscore form. A tool `some_name` therefore matches both
+// scripts/some-name.<ext> and scripts/some_name.<ext> — authors no longer have
+// to remember the underscore→hyphen rewrite (#418). The hyphenated form is
+// listed first so it keeps priority for the (rare) skill that ships both.
+func skillScriptNameVariants(toolName string) []string {
+	hyphen := strings.ReplaceAll(toolName, "_", "-")
+	underscore := strings.ReplaceAll(toolName, "-", "_")
+	if hyphen == underscore {
+		return []string{hyphen}
+	}
+	return []string{hyphen, underscore}
+}
+
+// interpreterForSkillScript returns the interpreter for a resolved script path
+// by its extension, or "" if the extension is not a recognized skill script.
+func interpreterForSkillScript(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, se := range skillScriptExtensions {
+		if se.ext == ext {
+			return se.interpreter
+		}
+	}
+	return ""
+}
+
+// SkillScriptCandidatePaths returns the container-relative script paths a
+// `## Tool: toolName` in skill directory skillDirName can bind to, in
+// resolution priority order: skill-local scripts/ before the shared
+// skills/scripts/, shell before python before node, hyphenated name before
+// underscore. It returns nil when the tool name would escape the tree. Exported
+// so `forge skills validate` checks the tool→script binding against the exact
+// same candidate set the runtime resolves against — the two can never drift.
+func SkillScriptCandidatePaths(skillDirName, toolName string) []string {
+	names := skillScriptNameVariants(toolName)
 	// The `## Tool:` name is taken verbatim by the parser (no kebab/char
 	// check), so a crafted "## Tool: ../../../../x" would otherwise resolve to
-	// an out-of-tree script and register it as a callable tool. Require the
-	// derived script name to be a bare, non-escaping path segment before it
-	// touches the filesystem. Mirrors the import-path traversal hardening.
-	if !filepath.IsLocal(scriptName) || strings.ContainsRune(scriptName, filepath.Separator) || strings.ContainsRune(scriptName, '/') {
-		return "", "", false
+	// an out-of-tree script and register it as a callable tool. Require every
+	// derived stem to be a bare, non-escaping path segment before it touches
+	// the filesystem. Mirrors the import-path traversal hardening.
+	for _, n := range names {
+		if !filepath.IsLocal(n) || strings.ContainsRune(n, filepath.Separator) || strings.ContainsRune(n, '/') {
+			return nil
+		}
 	}
 	var dirs []string
 	if skillDirName != "" {
 		dirs = append(dirs, filepath.Join("skills", skillDirName, "scripts"))
 	}
 	dirs = append(dirs, filepath.Join("skills", "scripts"))
+	var out []string
 	for _, dir := range dirs {
 		for _, se := range skillScriptExtensions {
-			candidate := filepath.Join(dir, scriptName+se.ext)
-			if _, err := os.Stat(filepath.Join(r.cfg.WorkDir, candidate)); err == nil {
-				return candidate, se.interpreter, true
+			for _, name := range names {
+				out = append(out, filepath.Join(dir, name+se.ext))
 			}
+		}
+	}
+	return out
+}
+
+// resolveSkillScript locates the script backing a `## Tool:` entry and returns
+// its container-relative path, the interpreter to run it under, and whether it
+// was found. Candidate order comes from SkillScriptCandidatePaths (skill-local
+// before shared; shell before python before node; hyphenated name before
+// underscore). Single source of truth shared by registerSkillTools (which
+// registers the tool) and skillEntryHasScript (which excludes it from the
+// read_skill catalog) so the two can never disagree about what's a first-class
+// tool.
+func (r *Runner) resolveSkillScript(skillDirName, toolName string) (relPath, interpreter string, found bool) {
+	for _, candidate := range SkillScriptCandidatePaths(skillDirName, toolName) {
+		if _, err := os.Stat(filepath.Join(r.cfg.WorkDir, candidate)); err == nil {
+			return candidate, interpreterForSkillScript(candidate), true
 		}
 	}
 	return "", "", false

--- a/forge-cli/runtime/skill_script_binding_test.go
+++ b/forge-cli/runtime/skill_script_binding_test.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestSkillScriptNameVariants(t *testing.T) {
+	cases := []struct {
+		tool string
+		want []string
+	}{
+		{"some_name", []string{"some-name", "some_name"}}, // both forms, hyphen first
+		{"some-name", []string{"some-name", "some_name"}}, // symmetric
+		{"plain", []string{"plain"}},                      // no separator → single form
+		{"a_b-c", []string{"a-b-c", "a_b_c"}},             // mixed separators normalize both ways
+	}
+	for _, tc := range cases {
+		if got := skillScriptNameVariants(tc.tool); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("skillScriptNameVariants(%q) = %v, want %v", tc.tool, got, tc.want)
+		}
+	}
+}
+
+func TestSkillScriptCandidatePaths_bothForms(t *testing.T) {
+	got := SkillScriptCandidatePaths("myskill", "some_name")
+	// A `## Tool: some_name` must be bindable by both scripts/some_name.sh and
+	// scripts/some-name.sh (#418), skill-local before shared, shell before py.
+	want := []string{
+		"skills/myskill/scripts/some-name.sh",
+		"skills/myskill/scripts/some_name.sh",
+		"skills/myskill/scripts/some-name.bash",
+		"skills/myskill/scripts/some_name.bash",
+		"skills/myskill/scripts/some-name.py",
+		"skills/myskill/scripts/some_name.py",
+	}
+	for _, w := range want {
+		if !slices.Contains(got, w) {
+			t.Errorf("candidate %q missing from %v", w, got)
+		}
+	}
+	// Ordering: skill-local sh (either name) precedes any shared-dir candidate,
+	// and precedes skill-local python.
+	if idxOf(got, "skills/myskill/scripts/some_name.sh") > idxOf(got, "skills/myskill/scripts/some-name.py") {
+		t.Error("shell should rank before python within a directory")
+	}
+	if idxOf(got, "skills/myskill/scripts/some-name.sh") > idxOf(got, "skills/scripts/some-name.sh") {
+		t.Error("skill-local dir should rank before shared dir")
+	}
+	// Hyphen before underscore within the same ext.
+	if idxOf(got, "skills/myskill/scripts/some-name.sh") > idxOf(got, "skills/myskill/scripts/some_name.sh") {
+		t.Error("hyphenated name should rank before underscore for back-compat")
+	}
+}
+
+func TestSkillScriptCandidatePaths_traversalRejected(t *testing.T) {
+	for _, bad := range []string{"../../etc/passwd", "a/b", "..", "foo/../bar"} {
+		if got := SkillScriptCandidatePaths("s", bad); got != nil {
+			t.Errorf("SkillScriptCandidatePaths(%q) = %v, want nil (traversal must be rejected)", bad, got)
+		}
+	}
+}
+
+func idxOf(xs []string, s string) int {
+	for i, x := range xs {
+		if x == s {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Closes #418.

Two Forge skill-registration behaviors failed **silently** — a tool was discarded at runtime with (at best) one error-log line, and no author/build-time signal. Customers had to reimplement Forge's parser as external lints and re-confirm them against every `FORGE_VERSION`. This makes Forge the source of truth.

## 1. Tool→script binding accepts both name forms

A `## Tool: some_name` previously bound **only** to `scripts/some-name.{sh,py,js}` — underscores were forced to hyphens, so an author who named the file `scripts/some_name.sh` to match the tool got a silently-missing tool.

Now it binds to **either** `scripts/some_name.<ext>` **or** `scripts/some-name.<ext>` (and symmetrically for a hyphenated tool name). The hyphenated form keeps priority only if both files exist, so **existing skills resolve identically**. Priority order is otherwise unchanged: skill-local `scripts/` before shared `skills/scripts/`, shell → python → node.

Resolution is refactored around one exported generator, `runtime.SkillScriptCandidatePaths`, shared by the runtime resolver (`resolveSkillScript`), the read-skill catalog (`skillEntryHasScript`), and the new validator — so the "what's a first-class tool" decision can't drift between them. Traversal hardening (`..`, path separators) is preserved.

## 2. `forge skills validate` surfaces the silent failures

`validate` now scans the **whole** skill tree (main `SKILL.md` **and** every `skills/*/SKILL.md`, not just the root as before) and reports, per `## Tool:`:

| Check | Level | Why |
|---|---|---|
| **Invalid `**Input:**` property key** outside `^[a-zA-Z0-9_.-]{1,64}$` | ERROR | The provider rejects the *entire* request → the runtime drops the whole tool at startup (would 400 every LLM call). |
| **No backing script** (either name form) | ERROR | The tool never registers. |
| **Orphan script** with no `## Tool:` heading | WARN | Reachable only via `run_skill_script`; dead weight if unreferenced. |

The property-key check runs the **real** parser (`InputSpecToSchema` + `InvalidSchemaPropertyKeys`), so the lint can't approximate the rule wrong. `validate` exits **non-zero** on any ERROR, so CI can gate on it — replacing the external lints.

Sample output:
```
Tools:
  ERROR report / bad_scan: input property key(s) pod name violate ^[a-zA-Z0-9_.-]{1,64}$ — the tool is DROPPED at runtime (it would fail every LLM call)
  ERROR report / no_script: no backing script (scripts/no_script.{sh,py,js}) — the tool will not register
  WARN  report: orphan script skills/report/scripts/dead-helper.sh — no `## Tool:` heading binds it; reachable only via run_skill_script (dead weight if unreferenced)
```

## Tests
- `runtime`: `TestSkillScriptNameVariants`, `TestSkillScriptCandidatePaths_bothForms` (both name forms + priority order), `_traversalRejected`.
- `cmd`: `TestLintSkillTools` — a temp skill tree exercising hyphen-backed, underscore-backed (the #418 win), invalid-key, missing-script, and orphan-script cases.
- Manual end-to-end run of `forge skills validate` confirms wiring + exit code.

## Docs
`skills-cli.md` (new **Validate** section), `writing-custom-skills.md` (binding rule + silent-failure guard), `skill-md-format.md` (runtime table), `cli-reference.md`.

## Follow-up (noted in #418)
Wire the same lint into the `forge build` validate stage so an invalid property key **fails the build**, not just `validate`.
