### PR TITLE
fix(mcp): stamp per-invocation seq on MCP tool-call/result audit events

### DIFF
--- a/forge-core/tools/adapters/mcp_tool.go
+++ b/forge-core/tools/adapters/mcp_tool.go
@@ -195,9 +195,8 @@ func (m *MCPTool) InputSchema() json.RawMessage {
 // payload — only sizes, duration, and reason codes.
 func (m *MCPTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	start := time.Now()
-	correlationID := runtime.CorrelationIDFromContext(ctx)
 
-	m.emitCall(correlationID, len(args))
+	m.emitCall(ctx, len(args))
 	// resolveAndCall runs the whole resolve→call sequence for THIS request.
 	// ErrNoToken can surface from EITHER half: the per-subject connection
 	// establish (transports that authenticate at initialize) OR CallTool
@@ -233,7 +232,7 @@ func (m *MCPTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 	if err != nil {
 		reason := classifyToolErr(err)
-		m.emitResult(correlationID, durMs, 0, false, reason)
+		m.emitResult(ctx, durMs, 0, false, reason)
 		return "", fmt.Errorf("mcp %s/%s: %w", m.server, m.descriptor.Name, err)
 	}
 
@@ -254,9 +253,9 @@ func (m *MCPTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 
 	if res.IsError {
-		m.emitResult(correlationID, durMs, len(out), false, "tool_error")
+		m.emitResult(ctx, durMs, len(out), false, "tool_error")
 	} else {
-		m.emitResult(correlationID, durMs, len(out), true, "")
+		m.emitResult(ctx, durMs, len(out), true, "")
 	}
 	return out, nil
 }
@@ -321,13 +320,18 @@ func classifyToolErr(err error) string {
 	}
 }
 
-func (m *MCPTool) emitCall(correlationID string, argsSize int) {
+func (m *MCPTool) emitCall(ctx context.Context, argsSize int) {
 	if m.audit == nil {
 		return
 	}
-	m.audit.Emit(runtime.AuditEvent{
-		Event:         runtime.EventMCPToolCall,
-		CorrelationID: correlationID,
+	// EmitFromContext (not plain Emit) so the event carries the per-invocation
+	// `seq` from the counter the A2A handler put on ctx — same as every other
+	// per-call event (LLM call, tool exec). Without seq these events land
+	// unordered and, being second-precision on ts, collide in the console's
+	// same-second sort (a result renders before its own call). It also stamps
+	// correlation_id + tenancy from ctx, so we no longer pass them by hand.
+	m.audit.EmitFromContext(ctx, runtime.AuditEvent{
+		Event: runtime.EventMCPToolCall,
 		Fields: map[string]any{
 			"server":    m.server,
 			"tool":      m.descriptor.Name,
@@ -336,7 +340,7 @@ func (m *MCPTool) emitCall(correlationID string, argsSize int) {
 	})
 }
 
-func (m *MCPTool) emitResult(correlationID string, durMs int64, resultSize int, ok bool, reason string) {
+func (m *MCPTool) emitResult(ctx context.Context, durMs int64, resultSize int, ok bool, reason string) {
 	if m.audit == nil {
 		return
 	}
@@ -350,10 +354,9 @@ func (m *MCPTool) emitResult(correlationID string, durMs int64, resultSize int, 
 	if reason != "" {
 		fields["reason"] = reason
 	}
-	m.audit.Emit(runtime.AuditEvent{
-		Event:         runtime.EventMCPToolResult,
-		CorrelationID: correlationID,
-		Fields:        fields,
+	m.audit.EmitFromContext(ctx, runtime.AuditEvent{
+		Event:  runtime.EventMCPToolResult,
+		Fields: fields,
 	})
 }
 

--- a/forge-core/tools/adapters/mcp_tool_test.go
+++ b/forge-core/tools/adapters/mcp_tool_test.go
@@ -285,6 +285,55 @@ func TestMCPTool_Audit_NeverLogsBytes(t *testing.T) {
 	}
 }
 
+// TestMCPTool_Audit_StampsSequence guards the fix for MCP events landing
+// seq-less: Execute must emit via EmitFromContext so mcp_tool_call /
+// mcp_tool_result carry the per-invocation `seq` from the ctx counter. Without
+// it, same-second call/result pairs sort ambiguously in consumers (a result
+// renders before its own call).
+func TestMCPTool_Audit_StampsSequence(t *testing.T) {
+	t.Parallel()
+	c := &mockClient{res: &mcp.CallToolResult{
+		Content: []mcp.ToolContent{{Type: "text", Text: "ok"}},
+	}}
+	var buf safeBuf
+	a, err := NewMCPTool(MCPToolOpts{
+		Server:     "srv",
+		Descriptor: mcp.MCPToolDescriptor{Name: "echo", InputSchema: json.RawMessage(`{}`)},
+		Client:     c, Audit: runtime.NewAuditLogger(&buf),
+	})
+	if err != nil {
+		t.Fatalf("NewMCPTool: %v", err)
+	}
+	// The A2A handler installs this counter per request; simulate it.
+	ctx := runtime.EnsureSequenceCounter(context.Background())
+	if _, err := a.Execute(ctx, json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	var callSeq, resultSeq int
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var e struct {
+			Event string `json:"event"`
+			Seq   int    `json:"seq"`
+		}
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		switch e.Event {
+		case "mcp_tool_call":
+			callSeq = e.Seq
+		case "mcp_tool_result":
+			resultSeq = e.Seq
+		}
+	}
+	if callSeq == 0 || resultSeq == 0 {
+		t.Fatalf("expected non-zero seq on both events, got call=%d result=%d; log:\n%s", callSeq, resultSeq, buf.String())
+	}
+	if callSeq >= resultSeq {
+		t.Errorf("call seq (%d) must precede result seq (%d)", callSeq, resultSeq)
+	}
+}
+
 func TestMCPTool_Audit_OkFalseOnError(t *testing.T) {
 	t.Parallel()
 	c := &mockClient{err: errors.New("simulated network failure: " + mcp.ErrTransportUnavailable.Error())}


### PR DESCRIPTION
## Problem

In the agent Activity view, MCP events show up in the wrong order — a **result renders before its own call**, and a burst of MCP calls within one second is jumbled:

```
09:23:53  MCP result   datadog-read-only__get_datadog_metric_context   ok
09:23:53  MCP call     datadog-read-only__get_datadog_metric_context   info   ← after its result
```

## Root cause

`MCPTool.Execute` emits `mcp_tool_call` / `mcp_tool_result` through the plain `audit.Emit(...)`, which does **not** consult the per-invocation sequence counter. So these two events land with **no `seq`** — unlike every other per-call event (`llm_call`, tool exec), which goes through `EmitFromContext`. The audit envelope's `ts` is second-precision, so consumers ordering by `(ts, entity, seq)` (e.g. console `sortRuntimeEvents`) can't break same-second ties without `seq` → arbitrary order.

## Fix

Route both emits through `EmitFromContext(ctx, …)` so they carry the `seq` the A2A handler installed on `ctx` (`forge-core/tools/adapters/mcp_tool.go`). Side benefit: correlation_id + tenancy now come from `ctx` too (correlation_id was previously passed by hand; org/workspace were absent), aligning MCP events with the rest. **No payload bytes added** — the fields map is unchanged, so the "audit never logs bytes" invariant holds (existing `TestMCPTool_Audit_NeverLogsBytes` still passes).

## Test

`TestMCPTool_Audit_StampsSequence` — installs a ctx sequence counter, runs `Execute`, asserts both events carry a non-zero `seq` and that call-seq precedes result-seq. `go test ./forge-core/tools/adapters/ ./forge-core/runtime/` green; `go vet` clean.