### PR TITLE
fix(tracing): stop OTLP exporter egress from flooding the audit stream (#424)

### DIFF
--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -753,7 +753,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		// still can't exfiltrate span content) but has NO OnAttempt hook and is
 		// deliberately NOT otel-wrapped, so exporter traffic is neither audited
 		// nor self-traced.
-		tracingTransport = security.NewEgressEnforcer(nil, egressCfg.Mode, egressCfg.AllDomains, allowPrivateIPs, allowedPrivateCIDRs)
+		tracingTransport = newTracingExporterTransport(egressCfg.Mode, egressCfg.AllDomains, allowPrivateIPs, allowedPrivateCIDRs)
 		// Phase 3 (#104) — wrap the egress-enforced transport with
 		// otelhttp instrumentation so every outbound HTTP request the
 		// in-process clients (LLM providers, MCP, channels, OAuth)

--- a/forge-cli/runtime/runner.go
+++ b/forge-cli/runtime/runner.go
@@ -628,6 +628,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	var egressProxy *security.EgressProxy
 	var proxyURL string
 	var socksURL string
+	// Separate transport for the OTLP trace exporter — egress-enforced but
+	// NOT audited and NOT otel-wrapped (see the tracing enforcer built in the
+	// egress block below). Stays nil when egress resolution fails, matching
+	// the exporter's default-client fallback.
+	var tracingTransport http.RoundTripper
 	egressToolNames := make([]string, len(r.cfg.Config.Tools))
 	for i, t := range r.cfg.Config.Tools {
 		egressToolNames[i] = t.Name
@@ -736,6 +741,19 @@ func (r *Runner) Run(ctx context.Context) error {
 				Fields:        map[string]any{"domain": domain, "mode": string(egressCfg.Mode)},
 			})
 		}
+		// The OTLP trace exporter gets its OWN enforcer, distinct from the
+		// audited egressClient above. Routing the exporter through the audited
+		// client floods the audit stream: its OnAttempt emits an egress_allowed
+		// event on every request, and the batch exporter exports on a ~5s timer,
+		// so tracing alone produces one egress_allowed per 5s — indefinitely,
+		// because the otelhttp wrap below also traces the exporter's own POST,
+		// which enqueues a span that forces the next export (a self-sustaining
+		// loop that never quiesces even on an idle agent). This enforcer keeps
+		// the allowlist + post-DNS IP guard (so a misconfigured collector host
+		// still can't exfiltrate span content) but has NO OnAttempt hook and is
+		// deliberately NOT otel-wrapped, so exporter traffic is neither audited
+		// nor self-traced.
+		tracingTransport = security.NewEgressEnforcer(nil, egressCfg.Mode, egressCfg.AllDomains, allowPrivateIPs, allowedPrivateCIDRs)
 		// Phase 3 (#104) — wrap the egress-enforced transport with
 		// otelhttp instrumentation so every outbound HTTP request the
 		// in-process clients (LLM providers, MCP, channels, OAuth)
@@ -853,10 +871,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	// initiative ruling — a misconfigured exporter must never crash
 	// the agent.
 	tracingCfg := tracingCfgEarly
-	var tracingTransport http.RoundTripper
-	if egressClient != nil {
-		tracingTransport = egressClient.Transport
-	}
+	// tracingTransport was built alongside the egress enforcer above — an
+	// egress-enforced but unaudited, non-otel-wrapped RoundTripper (nil when
+	// egress resolution failed, which the exporter treats as "use default
+	// client"). Deliberately NOT egressClient.Transport: that path audits and
+	// self-traces every export, flooding the audit stream every ~5s.
 	tp, tpErr := observability.NewTracerProvider(ctx, tracingCfg, tracingTransport)
 	switch {
 	case errors.Is(tpErr, observability.ErrDisabled):

--- a/forge-cli/runtime/tracing_exporter_transport.go
+++ b/forge-cli/runtime/tracing_exporter_transport.go
@@ -1,0 +1,31 @@
+package runtime
+
+import (
+	"net"
+
+	"github.com/initializ/forge/forge-core/security"
+)
+
+// newTracingExporterTransport builds the egress-enforced RoundTripper handed to
+// the OTLP trace exporter (issue #424). It is deliberately DISTINCT from the
+// audited egress client the rest of the runtime uses:
+//
+//   - It sets NO OnAttempt hook. The audited client's OnAttempt emits an
+//     egress_allowed audit event on every request; because the batch exporter
+//     exports on a ~5s timer, reusing that path floods the audit stream with one
+//     egress_allowed per 5s — forever, even on an idle agent.
+//   - The concrete *security.EgressEnforcer return type (not http.RoundTripper)
+//     is a compile-time guard that this transport is never otelhttp-wrapped:
+//     observability.WrapHTTPTransport returns a different concrete type, so
+//     wrapping it here would not compile. Wrapping would make the exporter POST
+//     self-trace, enqueuing a span that forces the next export — the
+//     self-sustaining loop behind #424.
+//
+// It keeps the SAME allowlist + post-DNS IP guard as the audited client
+// (base=nil → SafeTransport), so a misconfigured collector host still cannot
+// exfiltrate span content. The caller must not set OnAttempt on the result.
+//
+// See TestNewTracingExporterTransport_Unaudited for the regression guard.
+func newTracingExporterTransport(mode security.EgressMode, domains []string, allowPrivateIPs bool, allowedPrivateCIDRs []*net.IPNet) *security.EgressEnforcer {
+	return security.NewEgressEnforcer(nil, mode, domains, allowPrivateIPs, allowedPrivateCIDRs)
+}

--- a/forge-cli/runtime/tracing_exporter_transport_test.go
+++ b/forge-cli/runtime/tracing_exporter_transport_test.go
@@ -1,0 +1,52 @@
+package runtime
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/initializ/forge/forge-core/security"
+)
+
+// TestNewTracingExporterTransport_Unaudited is the regression guard for #424:
+// the OTLP trace exporter must be handed an egress-enforced but UNAUDITED,
+// non-otel-wrapped transport. If a refactor re-wires the exporter onto the
+// audited egress client, tracing re-floods the audit stream with one
+// egress_allowed per ~5s batch export (and the exporter self-traces its own
+// POST). This pins the two properties that break that loop while proving the
+// security posture is preserved.
+func TestNewTracingExporterTransport_Unaudited(t *testing.T) {
+	tr := newTracingExporterTransport(security.ModeAllowlist, []string{"collector.example.com"}, false, nil)
+	if tr == nil {
+		t.Fatal("tracing exporter transport must not be nil for a resolved egress config")
+	}
+
+	// (1) No audit hook. The audited egress client sets OnAttempt (which emits
+	// egress_allowed); the exporter transport must never carry one.
+	if tr.OnAttempt != nil {
+		t.Error("tracing exporter transport must NOT set OnAttempt — it would re-emit egress_allowed on every export (#424)")
+	}
+
+	// (2) Raw enforcer, not otelhttp-wrapped. The concrete *EgressEnforcer type
+	// is the compile-time guarantee (observability.WrapHTTPTransport returns a
+	// different concrete type); this documents that a plain RoundTripper is what
+	// the exporter receives, so its POST never self-traces.
+	var _ http.RoundTripper = tr
+
+	// (3) Allowlist + IP guard preserved. A non-allowlisted host is rejected
+	// pre-dial (no network I/O), proving egress enforcement still applies so a
+	// misconfigured collector can't exfiltrate span content.
+	req, err := http.NewRequest(http.MethodPost, "https://not-allowed.example.net/v1/traces", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	if _, err := tr.RoundTrip(req); err == nil {
+		t.Error("tracing exporter transport must still enforce the allowlist — a non-allowlisted host should be blocked")
+	}
+
+	// And an allowlisted host is NOT rejected by the matcher (it proceeds to the
+	// dialer; we don't assert the dial itself to avoid network I/O).
+	allowed := security.NewDomainMatcher(security.ModeAllowlist, []string{"collector.example.com"})
+	if !allowed.IsAllowed("collector.example.com") {
+		t.Error("sanity: the allowlisted collector host should match the allowlist")
+	}
+}


### PR DESCRIPTION
Fixes #424.

## Problem
With `observability.tracing.enabled` and the HTTP OTLP exporter, forge emitted an `egress_allowed` audit event for the collector host **every ~5s, indefinitely — even on an idle agent**, flooding `audit_events`.

The exporter was handed `egressClient.Transport`: the **audited** (`OnAttempt` → `egress_allowed`) and **otelhttp-wrapped** egress transport. The batcher's default `ScheduleDelay` is 5s, so each export tripped `OnAttempt`; and because the export POST was itself otel-traced, it enqueued a span that forced the next export — a self-sustaining loop.

## Fix
Give the trace exporter its **own** `EgressEnforcer` — same allowlist + post-DNS IP guard (so a misconfigured collector host still can't exfiltrate span content), but:
- **no `OnAttempt` hook** → no `egress_allowed` events for telemetry, and
- **not otelhttp-wrapped** → the exporter no longer traces its own POST (breaks the self-loop).

Falls back to `nil` (exporter default client) when egress resolution fails, matching prior behavior. gRPC path is unchanged (it already bypasses the enforcer).

## Testing
- `go build ./forge-cli/runtime/` ✅
- `go test ./forge-cli/runtime/ -run 'Tracing|Egress|Tracer'` ✅
- `go test ./forge-core/observability/` ✅
- `gofmt` clean, `golangci-lint run ./forge-cli/runtime/` → 0 issues

## Note
This is behind `tracing.enabled` (off by default), so no impact on default deploys. Agents already flooded can also mitigate immediately by switching to `protocol: grpc` (workaround in #424) until this ships.