### PR TITLE
a2a: honor FORGE_A2A_PUBLIC_URL for the Agent Card url

### DIFF
--- a/forge-cli/runtime/agentcard.go
+++ b/forge-cli/runtime/agentcard.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/initializ/forge/forge-core/a2a"
 	"github.com/initializ/forge/forge-core/agentspec"
@@ -12,11 +13,23 @@ import (
 	"github.com/initializ/forge/forge-core/types"
 )
 
+// agentCardBaseURL is the URL the Agent Card advertises in its `url` field. When
+// the agent is fronted by an ingress/gateway, the operator sets FORGE_A2A_PUBLIC_URL
+// to the externally-reachable origin (e.g. https://agent.example.com) so A2A clients
+// that dial the card's `url` reach the agent — not the pod-local default. Unset (the
+// standalone / local-dev case) falls back to http://localhost:<port>.
+func agentCardBaseURL(port int) string {
+	if u := strings.TrimSpace(os.Getenv("FORGE_A2A_PUBLIC_URL")); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return fmt.Sprintf("http://localhost:%d", port)
+}
+
 // BuildAgentCard constructs an AgentCard from available sources.
 // It first tries .forge-output/agent.json; if that doesn't exist, it falls
 // back to the ForgeConfig.
 func BuildAgentCard(workDir string, cfg *types.ForgeConfig, port int) (*a2a.AgentCard, error) {
-	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	baseURL := agentCardBaseURL(port)
 
 	// Try loading from a prior build
 	card, err := agentCardFromDisk(workDir, baseURL)

--- a/forge-cli/runtime/agentcard.go
+++ b/forge-cli/runtime/agentcard.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,11 +19,21 @@ import (
 // to the externally-reachable origin (e.g. https://agent.example.com) so A2A clients
 // that dial the card's `url` reach the agent — not the pod-local default. Unset (the
 // standalone / local-dev case) falls back to http://localhost:<port>.
+//
+// A scheme-less or otherwise malformed override is rejected with a warning and the
+// local fallback, so a misconfiguration surfaces loudly at startup instead of
+// silently handing A2A clients an undialable card url.
 func agentCardBaseURL(port int) string {
-	if u := strings.TrimSpace(os.Getenv("FORGE_A2A_PUBLIC_URL")); u != "" {
-		return strings.TrimRight(u, "/")
+	fallback := fmt.Sprintf("http://localhost:%d", port)
+	u := strings.TrimRight(strings.TrimSpace(os.Getenv("FORGE_A2A_PUBLIC_URL")), "/")
+	if u == "" {
+		return fallback
 	}
-	return fmt.Sprintf("http://localhost:%d", port)
+	if pu, err := url.Parse(u); err != nil || pu.Scheme == "" || pu.Host == "" {
+		fmt.Fprintf(os.Stderr, "forge: FORGE_A2A_PUBLIC_URL=%q is not a valid absolute URL (want scheme://host); advertising %q in the Agent Card instead\n", u, fallback)
+		return fallback
+	}
+	return u
 }
 
 // BuildAgentCard constructs an AgentCard from available sources.

--- a/forge-cli/runtime/agentcard_baseurl_test.go
+++ b/forge-cli/runtime/agentcard_baseurl_test.go
@@ -1,0 +1,24 @@
+package runtime
+
+import "testing"
+
+func TestAgentCardBaseURL(t *testing.T) {
+	t.Run("defaults to pod-local localhost when unset", func(t *testing.T) {
+		t.Setenv("FORGE_A2A_PUBLIC_URL", "")
+		if got := agentCardBaseURL(8080); got != "http://localhost:8080" {
+			t.Errorf("got %q, want http://localhost:8080", got)
+		}
+	})
+	t.Run("honors FORGE_A2A_PUBLIC_URL for ingress-fronted agents", func(t *testing.T) {
+		t.Setenv("FORGE_A2A_PUBLIC_URL", "https://agent-ws.test.agents.initz.run")
+		if got := agentCardBaseURL(8080); got != "https://agent-ws.test.agents.initz.run" {
+			t.Errorf("got %q, want the public URL", got)
+		}
+	})
+	t.Run("trims a trailing slash so the card url is clean", func(t *testing.T) {
+		t.Setenv("FORGE_A2A_PUBLIC_URL", "https://agent-ws.test.agents.initz.run/")
+		if got := agentCardBaseURL(8080); got != "https://agent-ws.test.agents.initz.run" {
+			t.Errorf("got %q, want the trailing slash trimmed", got)
+		}
+	})
+}

--- a/forge-cli/runtime/agentcard_baseurl_test.go
+++ b/forge-cli/runtime/agentcard_baseurl_test.go
@@ -21,4 +21,12 @@ func TestAgentCardBaseURL(t *testing.T) {
 			t.Errorf("got %q, want the trailing slash trimmed", got)
 		}
 	})
+	t.Run("rejects a scheme-less / malformed override and falls back to localhost", func(t *testing.T) {
+		for _, bad := range []string{"agent.example.com", "://nope", "https://"} {
+			t.Setenv("FORGE_A2A_PUBLIC_URL", bad)
+			if got := agentCardBaseURL(8080); got != "http://localhost:8080" {
+				t.Errorf("override %q should fall back to localhost, got %q", bad, got)
+			}
+		}
+	})
 }


### PR DESCRIPTION
`BuildAgentCard` hardcoded the card's `url` to `http://localhost:<port>`, so an agent
fronted by an ingress/gateway advertised a pod-local address — A2A clients that read
the card to dial the agent couldn't reach it off-cluster.

New `agentCardBaseURL(port)`: when `FORGE_A2A_PUBLIC_URL` is set (the platform/operator
points it at the externally-reachable origin, e.g. `https://agent.example.com`), the
card advertises that; unset falls back to `http://localhost:<port>` for standalone /
local dev. Trailing slash trimmed. Unit-tested (`agentcard_baseurl_test.go`).

Platform companion: initializ/agent-builder#162 injects `FORGE_A2A_PUBLIC_URL`
(= `https://<agent>-<ws>.<domain>`) at deploy when a public endpoint is enabled. Since
agents bake the forge runtime via `AGENT_FORGE_VERSION=vnext` (rolling main), agents
rebuilt after this merges pick it up.
