### PR TITLE
docs: add OTel Collector → Datadog example (Helm daemonset + plain manifests)

### DIFF
--- a/docs/deployment/examples/otel-datadog/README.md
+++ b/docs/deployment/examples/otel-datadog/README.md
@@ -2,35 +2,62 @@
 
 ```
 Forge agent ──OTLP/http :4318──▶ otel-collector (contrib + datadog exporter) ──▶ Datadog US1
-   (collector host auto-allowlisted at `forge build`)      (DD_API_KEY from Secret)
+   (collector host auto-allowlisted at `forge build`)         (DD_API_KEY from Secret)
 ```
 
-Files:
-- `otel-collector-datadog.yaml` — namespace `monitoring`, collector ConfigMap, Deployment, Service.
-- `datadog-secret.yaml` — template only; prefer the imperative `kubectl create secret` below.
-- `forge-tracing.snippet.yaml` — the `observability.tracing` block for your agent's `forge.yaml`.
+Two ways to run the collector:
 
-## 1. Create the Datadog API-key Secret
+- **`helm/` — production daemonset (recommended).** One collector pod per node
+  via the official OpenTelemetry Collector Helm chart. Node-local routing,
+  k8sattributes enrichment + RBAC, `GOMEMLIMIT` tuning — all handled by the chart.
+- **`otel-collector-datadog.yaml` — plain manifests (no Helm).** A single
+  Deployment + Service. Simplest to read; not node-local, no autoscaling.
+
+Shared by both: `datadog-secret.yaml` (API-key Secret) and
+`forge-tracing.snippet.yaml` (the `forge.yaml` block). The Forge-side config is
+**identical** for both — the collector is reachable at the same stable DNS name.
+
+---
+
+## Recommended: Helm daemonset
 
 ```bash
-kubectl create secret generic datadog-secret \
-  --namespace monitoring \
+# One-shot: creates the namespace + Secret, adds the repo, installs the chart.
+DD_API_KEY=<your-datadog-api-key> ./helm/install.sh
+```
+
+Or step by step:
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+kubectl create namespace monitoring
+kubectl create secret generic datadog-secret -n monitoring \
   --from-literal=DD_API_KEY=<your-datadog-api-key>
-```
-(The `monitoring` namespace is created by the main manifest; if applying the
-Secret first, `kubectl create namespace monitoring` beforehand.)
-
-## 2. Deploy the collector
-
-```bash
-kubectl apply -f otel-collector-datadog.yaml
-kubectl -n monitoring rollout status deploy/otel-collector
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
+  --namespace monitoring --values helm/values.yaml
+kubectl -n monitoring rollout status daemonset/otel-collector
 ```
 
-The Service resolves to `otel-collector.monitoring.svc.cluster.local` — the
-hostname Forge's docs default to.
+Why these values (`helm/values.yaml`):
 
-## 3. Point Forge at it
+- **`image.repository: otel/opentelemetry-collector-contrib`** — the Datadog
+  exporter and `datadog` connector ship **only** in `-contrib`. The `-k8s` /
+  core images crashloop with `unknown type: datadog`. `command.name` is set to
+  `otelcol-contrib` to match the contrib binary.
+- **`mode: daemonset` + `service.internalTrafficPolicy: Local`** — each agent's
+  OTLP goes to the collector pod on its **own node**, while keeping a **stable
+  Service DNS name**. That stable name is what makes the daemonset work with
+  Forge: `forge build` allowlists the collector **host** for egress, and a
+  dynamic node IP (hostPort / `HOST_IP` downward-API) could not be allowlisted
+  at build time — it would be blocked by the egress enforcer.
+- **`presets.kubernetesAttributes.enabled: true`** — adds the `k8sattributes`
+  processor (with a node-local pod filter) plus the ServiceAccount + ClusterRole
+  it needs, so every span is tagged with pod / namespace / deployment / node.
+- **`datadog/connector`** — computes APM trace stats (hits/errors/latency) so
+  the APM UI shows service/resource stats for the gen_ai spans.
+
+## Point Forge at it
 
 Merge `forge-tracing.snippet.yaml` into your agent's `forge.yaml`, then:
 
@@ -38,50 +65,57 @@ Merge `forge-tracing.snippet.yaml` into your agent's `forge.yaml`, then:
 forge build && forge package   # collector host auto-added to egress allowlist + NetworkPolicy
 ```
 
-Forge wraps the OTLP exporter in its egress enforcer, so the collector host is
-allowlisted automatically — no manual egress edit. `service.name` in Datadog =
+Endpoint is `http://otel-collector.monitoring.svc.cluster.local:4318/v1/traces`
+for **both** the Helm and plain-manifest paths. `service.name` in Datadog =
 your `agent_id`.
 
-## 4. Verify
+## Verify
 
 ```bash
-# Collector healthy + datadog exporter started
-kubectl -n monitoring logs deploy/otel-collector | grep -iE 'datadog|everything is ready'
-
-# See spans flow (temporary): set exporters.debug verbosity: detailed and add
-# `debug` to the traces/export pipeline, re-apply, then:
-kubectl -n monitoring logs -f deploy/otel-collector | grep -iE 'gen_ai|llm.completion|tool\.'
+kubectl -n monitoring rollout status daemonset/otel-collector
+kubectl -n monitoring logs -l app.kubernetes.io/name=opentelemetry-collector | grep -iE 'datadog|Everything is ready'
 ```
 
-In Datadog: **APM → Traces**, filter `service:<agent_id>`. You should see traces
-whose spans include `agent.execute`, `llm.completion`, and `tool.<name>`, with
-`gen_ai.*` attributes as span tags (`gen_ai.provider.name`, `gen_ai.request.model`,
-`gen_ai.usage.input_tokens`, `gen_ai.tool.name`, `gen_ai.tool.type`, …).
+In Datadog: **APM → Traces**, filter `service:<agent_id>`. Spans include
+`agent.execute`, `llm.completion`, `tool.<name>`, with `gen_ai.*` tags
+(`gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`,
+`gen_ai.tool.name`, `gen_ai.tool.type`, …).
 
-## Notes / gotchas
+---
 
-- **TLS.** The in-cluster hop is plaintext OTLP (`http://…:4318`). Forge's docs
-  show an `https://` example — that requires terminating TLS on the collector
-  receiver (`tls:` under `otlp.protocols.http`) and switching the forge.yaml
-  endpoint to `https://`. Plaintext in-cluster is fine and is the default here;
-  bound it with a NetworkPolicy / service mesh if your posture needs it.
-- **Collector → Datadog egress.** The collector pod needs outbound 443 to
-  Datadog's intake (`*.datadoghq.com`). This is OUTSIDE Forge's egress control
-  (separate deployment). If your cluster has default-deny egress NetworkPolicies,
-  add one allowing the collector egress to 443 (DNS + `api.datadoghq.com`).
-- **Cross-namespace reachability.** The agent (its namespace) must be able to
-  reach the `monitoring` namespace on 4318. Forge's generated NetworkPolicy
-  allows the agent's egress; make sure no ingress NetworkPolicy on `monitoring`
-  blocks it.
-- **Image version.** `otel/opentelemetry-collector-contrib:0.119.0` is a
-  placeholder — pin to the latest contrib release you've validated.
-- **APM stats / connector.** The `datadog/connector` produces APM trace metrics
-  (hits/errors/latency). Remove it and simplify to `otlp → batch → datadog` if
-  you only want raw traces without APM service stats.
+## Alternative: plain manifests (no Helm)
+
+```bash
+kubectl create secret generic datadog-secret -n monitoring \
+  --from-literal=DD_API_KEY=<your-datadog-api-key>   # create ns first if needed
+kubectl apply -f otel-collector-datadog.yaml
+```
+
+Single Deployment + Service, same collector pipeline. Use this if you don't run
+Helm; prefer the daemonset for production.
+
+---
+
+## Production notes / gotchas
+
+- **Tail-based sampling needs a gateway, not a daemonset.** A daemonset pod sees
+  only the spans from apps on its node, so it cannot make a whole-trace sampling
+  decision. Forge's default is **head** sampling at the source
+  (`sampler: parentbased_always_on`), which is correct for a daemonset. If you
+  want tail sampling (e.g. keep-on-error), run a **second** collector as a
+  `mode: deployment` gateway with the `tail_sampling` processor and point the
+  daemonset's exporter at it instead of Datadog.
+- **Collector → Datadog egress.** The collector needs outbound 443 to
+  `*.datadoghq.com`. This is OUTSIDE Forge's egress control (separate workload).
+  On a default-deny-egress cluster, add a NetworkPolicy for the collector.
+- **Cross-namespace reachability.** The agent's namespace must reach `monitoring`
+  on 4318. Forge's generated NetworkPolicy allows the agent's egress; ensure no
+  ingress NetworkPolicy on `monitoring` blocks it.
+- **TLS.** The in-cluster hop is plaintext OTLP (`http://…:4318`). For `https://`
+  you must terminate TLS on the collector's OTLP receiver and switch the
+  forge.yaml endpoint accordingly.
+- **Image version.** `helm/values.yaml` pins a placeholder contrib tag — bump it
+  to the latest contrib release you have validated.
 - **LLM Observability.** These land in Datadog **APM** with `gen_ai.*` as span
-  tags. Datadog's LLM Observability product ingests via its own SDK/OTel mapping
-  that is still evolving — APM span search on `gen_ai.*` works today; native
-  LLM-Obs surfacing may need additional Datadog-side config.
-- **k8sattributes (optional).** To tag spans with pod/deployment/namespace, add
-  the `k8sattributes` processor — it needs a ServiceAccount + ClusterRole/Binding
-  (get/list/watch on pods, replicasets). Left out here to keep the deploy RBAC-free.
+  tags. Datadog's native OTel-GenAI → LLM-Observability mapping is still
+  evolving; APM span search on `gen_ai.*` works today.

--- a/docs/deployment/examples/otel-datadog/README.md
+++ b/docs/deployment/examples/otel-datadog/README.md
@@ -1,0 +1,87 @@
+# Forge GenAI traces → OpenTelemetry Collector → Datadog (US1)
+
+```
+Forge agent ──OTLP/http :4318──▶ otel-collector (contrib + datadog exporter) ──▶ Datadog US1
+   (collector host auto-allowlisted at `forge build`)      (DD_API_KEY from Secret)
+```
+
+Files:
+- `otel-collector-datadog.yaml` — namespace `monitoring`, collector ConfigMap, Deployment, Service.
+- `datadog-secret.yaml` — template only; prefer the imperative `kubectl create secret` below.
+- `forge-tracing.snippet.yaml` — the `observability.tracing` block for your agent's `forge.yaml`.
+
+## 1. Create the Datadog API-key Secret
+
+```bash
+kubectl create secret generic datadog-secret \
+  --namespace monitoring \
+  --from-literal=DD_API_KEY=<your-datadog-api-key>
+```
+(The `monitoring` namespace is created by the main manifest; if applying the
+Secret first, `kubectl create namespace monitoring` beforehand.)
+
+## 2. Deploy the collector
+
+```bash
+kubectl apply -f otel-collector-datadog.yaml
+kubectl -n monitoring rollout status deploy/otel-collector
+```
+
+The Service resolves to `otel-collector.monitoring.svc.cluster.local` — the
+hostname Forge's docs default to.
+
+## 3. Point Forge at it
+
+Merge `forge-tracing.snippet.yaml` into your agent's `forge.yaml`, then:
+
+```bash
+forge build && forge package   # collector host auto-added to egress allowlist + NetworkPolicy
+```
+
+Forge wraps the OTLP exporter in its egress enforcer, so the collector host is
+allowlisted automatically — no manual egress edit. `service.name` in Datadog =
+your `agent_id`.
+
+## 4. Verify
+
+```bash
+# Collector healthy + datadog exporter started
+kubectl -n monitoring logs deploy/otel-collector | grep -iE 'datadog|everything is ready'
+
+# See spans flow (temporary): set exporters.debug verbosity: detailed and add
+# `debug` to the traces/export pipeline, re-apply, then:
+kubectl -n monitoring logs -f deploy/otel-collector | grep -iE 'gen_ai|llm.completion|tool\.'
+```
+
+In Datadog: **APM → Traces**, filter `service:<agent_id>`. You should see traces
+whose spans include `agent.execute`, `llm.completion`, and `tool.<name>`, with
+`gen_ai.*` attributes as span tags (`gen_ai.provider.name`, `gen_ai.request.model`,
+`gen_ai.usage.input_tokens`, `gen_ai.tool.name`, `gen_ai.tool.type`, …).
+
+## Notes / gotchas
+
+- **TLS.** The in-cluster hop is plaintext OTLP (`http://…:4318`). Forge's docs
+  show an `https://` example — that requires terminating TLS on the collector
+  receiver (`tls:` under `otlp.protocols.http`) and switching the forge.yaml
+  endpoint to `https://`. Plaintext in-cluster is fine and is the default here;
+  bound it with a NetworkPolicy / service mesh if your posture needs it.
+- **Collector → Datadog egress.** The collector pod needs outbound 443 to
+  Datadog's intake (`*.datadoghq.com`). This is OUTSIDE Forge's egress control
+  (separate deployment). If your cluster has default-deny egress NetworkPolicies,
+  add one allowing the collector egress to 443 (DNS + `api.datadoghq.com`).
+- **Cross-namespace reachability.** The agent (its namespace) must be able to
+  reach the `monitoring` namespace on 4318. Forge's generated NetworkPolicy
+  allows the agent's egress; make sure no ingress NetworkPolicy on `monitoring`
+  blocks it.
+- **Image version.** `otel/opentelemetry-collector-contrib:0.119.0` is a
+  placeholder — pin to the latest contrib release you've validated.
+- **APM stats / connector.** The `datadog/connector` produces APM trace metrics
+  (hits/errors/latency). Remove it and simplify to `otlp → batch → datadog` if
+  you only want raw traces without APM service stats.
+- **LLM Observability.** These land in Datadog **APM** with `gen_ai.*` as span
+  tags. Datadog's LLM Observability product ingests via its own SDK/OTel mapping
+  that is still evolving — APM span search on `gen_ai.*` works today; native
+  LLM-Obs surfacing may need additional Datadog-side config.
+- **k8sattributes (optional).** To tag spans with pod/deployment/namespace, add
+  the `k8sattributes` processor — it needs a ServiceAccount + ClusterRole/Binding
+  (get/list/watch on pods, replicasets). Left out here to keep the deploy RBAC-free.

--- a/docs/deployment/examples/otel-datadog/README.md
+++ b/docs/deployment/examples/otel-datadog/README.md
@@ -36,8 +36,15 @@ kubectl create secret generic datadog-secret -n monitoring \
   --from-literal=DD_API_KEY=<your-datadog-api-key>
 helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
   --namespace monitoring --values helm/values.yaml
-kubectl -n monitoring rollout status daemonset/otel-collector
+# In daemonset mode the chart names the workload "<release>-agent":
+kubectl -n monitoring rollout status daemonset/otel-collector-agent --timeout=300s
 ```
+
+> First-boot note: the Datadog exporter probes host metadata at startup, which
+> is slow on non-cloud clusters, so the pod can take ~20–30s to become ready.
+> `helm/values.yaml` sets `livenessProbe.initialDelaySeconds` and
+> `host_metadata.hostname_source: first_resource` to prevent the kubelet from
+> liveness-killing the pod mid-start (which otherwise CrashLoops the daemonset).
 
 Why these values (`helm/values.yaml`):
 
@@ -72,8 +79,16 @@ your `agent_id`.
 ## Verify
 
 ```bash
-kubectl -n monitoring rollout status daemonset/otel-collector
-kubectl -n monitoring logs -l app.kubernetes.io/name=opentelemetry-collector | grep -iE 'datadog|Everything is ready'
+kubectl -n monitoring rollout status daemonset/otel-collector-agent --timeout=300s
+kubectl -n monitoring logs -l app.kubernetes.io/instance=otel-collector | grep -iE 'datadog|Everything is ready'
+
+# Optional end-to-end smoke test (expect HTTP 200), then confirm the span in
+# Datadog APM under service:forge-otel-smoketest:
+NOW=$(date +%s)
+kubectl -n monitoring run otel-smoketest --rm -i --restart=Never \
+  --image=curlimages/curl:8.10.1 -- -sS -o /dev/null -w 'HTTP %{http_code}\n' \
+  -X POST http://otel-collector.monitoring.svc.cluster.local:4318/v1/traces \
+  -H 'Content-Type: application/json' -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"forge-otel-smoketest"}}]},"scopeSpans":[{"spans":[{"traceId":"5b8efff798038103d269b633813fc60c","spanId":"eee19b7ec3c1b174","name":"llm.completion","kind":2,"startTimeUnixNano":"'${NOW}'000000000","endTimeUnixNano":"'$((NOW+1))'000000000","attributes":[{"key":"gen_ai.provider.name","value":{"stringValue":"anthropic"}}]}]}]}]}'
 ```
 
 In Datadog: **APM → Traces**, filter `service:<agent_id>`. Spans include

--- a/docs/deployment/examples/otel-datadog/datadog-secret.yaml
+++ b/docs/deployment/examples/otel-datadog/datadog-secret.yaml
@@ -1,0 +1,17 @@
+# PREFERRED: create the Secret imperatively so the key never lands in git:
+#
+#   kubectl create secret generic datadog-secret \
+#     --namespace monitoring \
+#     --from-literal=DD_API_KEY=<your-datadog-api-key>
+#
+# This manifest is only a template for GitOps setups that seal/encrypt secrets
+# (SealedSecrets, SOPS, External Secrets). DO NOT commit a real key in plaintext.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-secret
+  namespace: monitoring
+type: Opaque
+stringData:
+  DD_API_KEY: "REPLACE_WITH_DATADOG_API_KEY"

--- a/docs/deployment/examples/otel-datadog/forge-tracing.snippet.yaml
+++ b/docs/deployment/examples/otel-datadog/forge-tracing.snippet.yaml
@@ -1,0 +1,18 @@
+# Add to your agent's forge.yaml. `forge build && forge package` auto-adds the
+# collector host to the egress allowlist + NetworkPolicy — no second egress edit.
+observability:
+  tracing:
+    enabled: true
+    # In-cluster hop is plaintext OTLP over http (see README on TLS). Include
+    # the /v1/traces path — Forge posts to this exact URL.
+    endpoint: http://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
+    protocol: http/protobuf
+    sampler: parentbased_always_on   # honor upstream sampling; sample roots
+    # service_name: ""               # defaults to agent_id (your DD service)
+
+    # Prompt / completion / tool-arg / tool-result CONTENT is OFF by default.
+    # Enabling ships gen_ai.input.messages / .output.messages /
+    # gen_ai.tool.call.arguments / .result to Datadog. Turn on only if you want
+    # that content in DD; redact stays on unless you disable it.
+    # capture_content: true
+    # redact: true

--- a/docs/deployment/examples/otel-datadog/helm/install.sh
+++ b/docs/deployment/examples/otel-datadog/helm/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Install the OpenTelemetry Collector (daemonset) → Datadog for Forge traces.
+# Idempotent: safe to re-run (helm upgrade --install, kubectl apply-style guards).
+#
+# Usage:
+#   DD_API_KEY=<your-datadog-api-key> ./install.sh
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-monitoring}"
+RELEASE="${RELEASE:-otel-collector}"
+VALUES="${VALUES:-$(dirname "$0")/values.yaml}"
+
+if [[ -z "${DD_API_KEY:-}" ]]; then
+  echo "ERROR: set DD_API_KEY in the environment (Datadog US1 API key)." >&2
+  exit 1
+fi
+
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update open-telemetry
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# Create/refresh the API-key Secret without echoing it into shell history/logs.
+kubectl create secret generic datadog-secret \
+  --namespace "$NAMESPACE" \
+  --from-literal=DD_API_KEY="$DD_API_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install "$RELEASE" open-telemetry/opentelemetry-collector \
+  --namespace "$NAMESPACE" \
+  --values "$VALUES"
+
+kubectl -n "$NAMESPACE" rollout status daemonset/"$RELEASE" --timeout=120s
+echo "Collector ready. Point Forge at http://otel-collector.${NAMESPACE}.svc.cluster.local:4318/v1/traces"

--- a/docs/deployment/examples/otel-datadog/helm/install.sh
+++ b/docs/deployment/examples/otel-datadog/helm/install.sh
@@ -30,5 +30,8 @@ helm upgrade --install "$RELEASE" open-telemetry/opentelemetry-collector \
   --namespace "$NAMESPACE" \
   --values "$VALUES"
 
-kubectl -n "$NAMESPACE" rollout status daemonset/"$RELEASE" --timeout=120s
-echo "Collector ready. Point Forge at http://otel-collector.${NAMESPACE}.svc.cluster.local:4318/v1/traces"
+# In daemonset mode the chart suffixes the workload name with "-agent".
+# Each pod waits out livenessProbe.initialDelaySeconds, and the daemonset rolls
+# one pod at a time, so allow generous time on multi-node clusters.
+kubectl -n "$NAMESPACE" rollout status daemonset/"$RELEASE"-agent --timeout=300s
+echo "Collector ready. Point Forge at http://${RELEASE}.${NAMESPACE}.svc.cluster.local:4318/v1/traces"

--- a/docs/deployment/examples/otel-datadog/helm/values.yaml
+++ b/docs/deployment/examples/otel-datadog/helm/values.yaml
@@ -1,0 +1,136 @@
+# Helm values for open-telemetry/opentelemetry-collector — PRODUCTION daemonset
+# shipping Forge GenAI traces to Datadog (US1).
+#
+#   helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+#   helm repo update
+#   kubectl create namespace monitoring
+#   kubectl create secret generic datadog-secret -n monitoring --from-literal=DD_API_KEY=<key>
+#   helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
+#     --namespace monitoring --values values.yaml
+#
+# One collector pod per node (agent pattern). Forge sends OTLP to the collector
+# on its OWN node via a stable Service (see `service` below).
+
+mode: daemonset
+
+# Stable name -> Service DNS otel-collector.monitoring.svc.cluster.local, the
+# host Forge points at (and allowlists for egress at `forge build`).
+fullnameOverride: otel-collector
+
+image:
+  # MUST be -contrib. The Datadog exporter and the `datadog` connector are NOT
+  # in the -k8s / core distributions — using those crashloops with
+  # "unknown type: datadog". Pin to a contrib release you have validated:
+  # https://github.com/open-telemetry/opentelemetry-collector-releases/releases
+  repository: otel/opentelemetry-collector-contrib
+  tag: "0.119.0"
+
+# The contrib image's binary is `otelcol-contrib`; the chart's command name
+# must match or the pod fails to start.
+command:
+  name: otelcol-contrib
+
+# Node-local routing WITHOUT hostPort. A ClusterIP Service with
+# internalTrafficPolicy: Local delivers each agent's OTLP to the daemonset pod
+# on the SAME node, while keeping a STABLE DNS name. The stable name is what
+# makes this work with Forge: `forge build` allowlists the collector HOST for
+# egress; a dynamic node IP (hostPort / HOST_IP downward-API) can't be
+# allowlisted at build time and would be blocked by the egress enforcer.
+service:
+  enabled: true
+  internalTrafficPolicy: Local
+
+# Adds the k8sattributes processor + the RBAC it needs (ServiceAccount +
+# ClusterRole/Binding) and, in daemonset mode, the node-local pod filter.
+# Enriches every span with pod / namespace / deployment / node tags.
+presets:
+  kubernetesAttributes:
+    enabled: true
+
+extraEnvs:
+  - name: DD_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: datadog-secret
+        key: DD_API_KEY
+
+resources:
+  requests: { cpu: 200m, memory: 400Mi }
+  limits:   { cpu: "1",  memory: 1Gi }
+
+# Uncomment to also collect traces from workloads on control-plane nodes.
+# tolerations:
+#   - key: node-role.kubernetes.io/control-plane
+#     operator: Exists
+#     effect: NoSchedule
+
+# Only OTLP is needed for Forge. Turn the chart's other receiver ports off.
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+  jaeger-compact: { enabled: false }
+  jaeger-thrift:  { enabled: false }
+  jaeger-grpc:    { enabled: false }
+  zipkin:         { enabled: false }
+
+# Merged over the chart defaults. The kubernetesAttributes preset injects its
+# `k8s_attributes` processor into every pipeline automatically — do NOT list it
+# in the pipelines below, or the injected + explicit entries clash.
+config:
+  # Drop the chart's default non-OTLP receivers; Forge speaks OTLP only.
+  receivers:
+    jaeger: null
+    zipkin: null
+    prometheus: null
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 100
+      send_batch_max_size: 1000
+      timeout: 10s
+    resourcedetection:
+      detectors: [env, system]
+      timeout: 5s
+      override: false
+
+  connectors:
+    # Computes APM trace stats (hits/errors/latency) from the spans and
+    # forwards them onward.
+    datadog/connector: {}
+
+  exporters:
+    datadog:
+      api:
+        site: datadoghq.com          # US1
+        key: ${env:DD_API_KEY}
+
+  service:
+    pipelines:
+      # 1) OTLP in → connector (which computes APM stats + forwards spans).
+      #    (k8s_attributes is prepended here by the preset.)
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, resourcedetection, batch]
+        exporters: [datadog/connector]
+      # 2) Connector → Datadog APM.
+      traces/export:
+        receivers: [datadog/connector]
+        processors: [memory_limiter, batch]
+        exporters: [datadog]
+      # 3) APM trace metrics the connector produced.
+      metrics:
+        receivers: [datadog/connector]
+        processors: [memory_limiter, batch]
+        exporters: [datadog]

--- a/docs/deployment/examples/otel-datadog/helm/values.yaml
+++ b/docs/deployment/examples/otel-datadog/helm/values.yaml
@@ -58,6 +58,21 @@ resources:
   requests: { cpu: 200m, memory: 400Mi }
   limits:   { cpu: "1",  memory: 1Gi }
 
+# The Datadog exporter's host-metadata step probes cloud-metadata endpoints at
+# startup; on bare-metal / non-cloud clusters those calls hang to timeout and
+# push first-boot past 20s. Give the probes headroom so the kubelet doesn't
+# liveness-kill the pod mid-start (which otherwise CrashLoops the daemonset).
+# host_metadata.hostname_source: first_resource (below) also cuts that time by
+# taking the node name from resource attributes instead of cloud probing.
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 5
+readinessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  failureThreshold: 5
+
 # Uncomment to also collect traces from workloads on control-plane nodes.
 # tolerations:
 #   - key: node-role.kubernetes.io/control-plane
@@ -115,6 +130,11 @@ config:
       api:
         site: datadoghq.com          # US1
         key: ${env:DD_API_KEY}
+      host_metadata:
+        # Derive the DD host from resource attributes (k8s.node.name, set by the
+        # kubernetesAttributes preset + resourcedetection) instead of probing
+        # cloud-metadata endpoints — avoids multi-second startup hangs off-cloud.
+        hostname_source: first_resource
 
   service:
     pipelines:

--- a/docs/deployment/examples/otel-datadog/otel-collector-datadog.yaml
+++ b/docs/deployment/examples/otel-datadog/otel-collector-datadog.yaml
@@ -1,5 +1,8 @@
 # OpenTelemetry Collector → Datadog (US1) for Forge GenAI traces.
 #
+# PLAIN-MANIFEST ALTERNATIVE (single Deployment). For production, prefer the
+# Helm daemonset in ./helm/ — see README.md.
+#
 # Pipeline: Forge --OTLP--> this collector --datadog exporter--> Datadog APM.
 # The `datadog/connector` computes APM trace stats (hits/errors/latency) from
 # the incoming spans, so the APM UI shows service/resource stats for the

--- a/docs/deployment/examples/otel-datadog/otel-collector-datadog.yaml
+++ b/docs/deployment/examples/otel-datadog/otel-collector-datadog.yaml
@@ -1,0 +1,155 @@
+# OpenTelemetry Collector → Datadog (US1) for Forge GenAI traces.
+#
+# Pipeline: Forge --OTLP--> this collector --datadog exporter--> Datadog APM.
+# The `datadog/connector` computes APM trace stats (hits/errors/latency) from
+# the incoming spans, so the APM UI shows service/resource stats for the
+# gen_ai spans (llm.completion, tool.<name>, agent.execute).
+#
+# Prereq: create the API-key Secret first (see datadog-secret.yaml or the
+# kubectl command in README.md).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318   # Forge default (http/protobuf, /v1/traces)
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      # Guardrail against OOM; keep the % below the container memory limit.
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch:
+        send_batch_size: 100
+        send_batch_max_size: 1000
+        timeout: 10s
+      # Cheap host/env enrichment (no RBAC). For pod/deployment tags add the
+      # k8sattributes processor — needs a ServiceAccount + ClusterRole (see README).
+      resourcedetection:
+        detectors: [env, system]
+        timeout: 5s
+        override: false
+
+    connectors:
+      # Computes APM trace metrics from spans AND forwards the spans onward.
+      datadog/connector:
+
+    exporters:
+      datadog:
+        api:
+          site: datadoghq.com          # US1
+          key: ${env:DD_API_KEY}
+      # Flip verbosity to `detailed` during bring-up to eyeball spans in the
+      # collector logs, then remove `debug` from the pipeline.
+      debug:
+        verbosity: normal
+
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    service:
+      extensions: [health_check]
+      telemetry:
+        logs:
+          level: info
+      pipelines:
+        # 1) Ingest OTLP spans, hand them to the connector.
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, resourcedetection, batch]
+          exporters: [datadog/connector]
+        # 2) Connector forwards the spans to Datadog APM.
+        traces/export:
+          receivers: [datadog/connector]
+          processors: [memory_limiter, batch]
+          exporters: [datadog]   # add `debug` here during bring-up
+        # 3) APM trace metrics the connector computed.
+        metrics:
+          receivers: [datadog/connector]
+          processors: [memory_limiter, batch]
+          exporters: [datadog]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: monitoring
+  labels: { app: otel-collector }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: otel-collector }
+  template:
+    metadata:
+      labels: { app: otel-collector }
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: otel-collector
+          # Datadog exporter ships only in the -contrib distribution.
+          # Pin to the latest contrib tag you have validated:
+          # https://github.com/open-telemetry/opentelemetry-collector-releases/releases
+          image: otel/opentelemetry-collector-contrib:0.119.0
+          args: ["--config=/etc/otelcol-contrib/config.yaml"]
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: datadog-secret
+                  key: DD_API_KEY
+          ports:
+            - { name: otlp-http, containerPort: 4318 }
+            - { name: otlp-grpc, containerPort: 4317 }
+            - { name: health,    containerPort: 13133 }
+          livenessProbe:
+            httpGet: { path: /, port: 13133 }
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet: { path: /, port: 13133 }
+            initialDelaySeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests: { cpu: "200m", memory: "400Mi" }
+            limits:   { cpu: "1",    memory: "1Gi" }
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol-contrib
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: monitoring
+  labels: { app: otel-collector }
+spec:
+  selector: { app: otel-collector }
+  ports:
+    - { name: otlp-http, port: 4318, targetPort: 4318 }
+    - { name: otlp-grpc, port: 4317, targetPort: 4317 }
+  # DNS: otel-collector.monitoring.svc.cluster.local


### PR DESCRIPTION
Adds a **production Kubernetes example** for shipping Forge's GenAI traces to **Datadog (US1)** through an OpenTelemetry Collector.

```
Forge agent ──OTLP/http :4318──▶ otel-collector (contrib + datadog exporter) ──▶ Datadog US1
   (collector host auto-allowlisted at `forge build`)      (DD_API_KEY from Secret)
```

## `docs/deployment/examples/otel-datadog/`
- **`helm/` — production daemonset (recommended).** `values.yaml` + `install.sh` for the official `open-telemetry/opentelemetry-collector` chart, `mode: daemonset`.
- **`otel-collector-datadog.yaml` — plain manifests (no-Helm alternative).** Single Deployment + Service.
- **`datadog-secret.yaml`**, **`forge-tracing.snippet.yaml`** — shared (API-key Secret; the `forge.yaml` block). Forge-side config is identical for both paths.
- **`README.md`** — deploy/verify + production gotchas.

## Production choices (why, not just what)
- **`-contrib` image, not `-k8s`.** The `datadog` exporter and `datadog` connector ship only in contrib; the `-k8s`/core images crashloop with `unknown type: datadog`. `command.name: otelcol-contrib` matches the binary.
- **`mode: daemonset` + `service.internalTrafficPolicy: Local`.** Each agent's OTLP goes to the collector on its **own node**, while keeping a **stable Service DNS name**. That stable name is required for Forge: `forge build` allowlists the collector **host** for egress; a dynamic node IP (hostPort/`HOST_IP`) can't be allowlisted at build time and would be blocked by the egress enforcer.
- **`presets.kubernetesAttributes`** — k8sattributes enrichment + RBAC + node-local pod filter, all wired by the chart.
- **`datadog/connector`** — APM trace stats (hits/errors/latency) for the gen_ai spans.

## Documented caveats
- **Tail sampling needs a gateway, not a daemonset** (a daemonset sees only its node's spans). Forge's default head sampling (`parentbased_always_on`) is correct for a daemonset; the README shows the gateway pattern if you need tail sampling.
- Collector → Datadog egress (outside Forge's egress control), cross-namespace reachability, TLS, image pinning, and the LLM-Observability caveat.

## Validation
Docs only, no code changes. The Helm values were rendered with **`helm template`** against the real chart and the output inspected: DaemonSet on the contrib image with `/otelcol-contrib`, Service `internalTrafficPolicy: Local` on 4317/4318, k8sattributes with a `node_from_env_var: K8S_NODE_NAME` filter + ServiceAccount/ClusterRole, `DD_API_KEY` wired from the Secret, and every pipeline component reference resolved. The plain manifest passes `kubectl apply --dry-run=client`.

Relates to the GenAI OTel work in #422.
